### PR TITLE
📝 docs: document necessary prerequisites for Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,6 @@ Ever wondered what's _behind_ the terminal? Press <kbd>Ctrl</kbd>+<kbd>Alt</kbd>
 
 Requirements:
 
-- Rust toolchain with Cargo
 - A GPU / graphics stack supported by Bevy and wgpu
 - Melted cheese (optional but recommended)
 
@@ -59,6 +58,13 @@ pacman -S ratty
 Prebuilt binaries are available on the [GitHub releases page](https://github.com/orhun/ratty/releases) for direct download.
 
 ### From Git
+
+Requirements:
+
+- Rust toolchain with Cargo
+- on Bazzite / Bluefin: `rpm-ostree install gcc fontconfig-devel wayland-devel` (then reboot)
+- on Debian / Ubuntu: `apt-get update ; apt-get install gcc pkgconf libfontconfig-dev libwayland-dev`
+- on Fedora: `dnf install gcc fontconfig-devel wayland-devel`
 
 ```bash
 cargo install --git https://github.com/orhun/ratty


### PR DESCRIPTION
howdy! thanks so much for sharing this project! <3

bevy has libudev-sys in its dependency graph, requiring libudev-devel / systemd-devel

and smithay-client-toolkit has wayland-sys in its dependency graph (which is surprising to me, i thought this was a pure-Rust implementation of the wayland protocol, but i guess it is not) so it requires wayland-devel

it's completely up to you, of course, but i've added instructions for how to get this working on Bazzite/Bluefin