### PR TITLE
feat: add Nix packaging, devshell, and modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 assets/img
+result

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,77 @@
+{
+  "nodes": {
+    "crane": {
+      "locked": {
+        "lastModified": 1778106249,
+        "narHash": "sha256-cM/AuKy5tMhwOOQIbha8ZRRMHVfNf7cv2aljIw+qoCg=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "6d015ea29630b7ad2402841386da2cb617a470a7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1777988971,
+        "narHash": "sha256-qIoWPDs+0/8JecyYgE3gpKQxW/4bLW/gp45vow9ioCQ=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "0678d8986be1661af6bb555f3489f2fdfc31f6ff",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1777954456,
+        "narHash": "sha256-hGdgeU2Nk87RAuZyYjyDjFL6LK7dAZN5RE9+hrDTkDU=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "549bd84d6279f9852cae6225e372cc67fb91a4c1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib": {
+      "locked": {
+        "lastModified": 1777168982,
+        "narHash": "sha256-GOkGPcboWE9BmGCRMLX3worL4EMnsnG8MyKmXNeYuhQ=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "f5901329dade4a6ea039af1433fb087bd9c1fe14",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "crane": "crane",
+        "flake-parts": "flake-parts",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,238 @@
+{
+  description = "A GPU-rendered terminal emulator that supports inline 3D graphics";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-parts.url = "github:hercules-ci/flake-parts";
+    crane.url = "github:ipetkov/crane";
+  };
+
+  outputs =
+    inputs@{
+      self,
+      nixpkgs,
+      flake-parts,
+      crane,
+      ...
+    }:
+    flake-parts.lib.mkFlake { inherit inputs; } {
+      systems = [
+        "x86_64-linux"
+        "aarch64-linux"
+        "x86_64-darwin"
+        "aarch64-darwin"
+      ];
+
+      perSystem =
+        {
+          config,
+          self',
+          inputs',
+          pkgs,
+          system,
+          lib,
+          ...
+        }:
+        let
+          craneLib = crane.mkLib pkgs;
+
+          buildInputs =
+            with pkgs;
+            [
+              vulkan-loader
+              libx11
+              libxcursor
+              libxi
+              libxrandr
+              wayland
+              libxkbcommon
+              fontconfig
+            ]
+            ++ lib.optionals stdenv.isDarwin [
+              darwin.apple_sdk.frameworks.Cocoa
+              darwin.apple_sdk.frameworks.AppKit
+              darwin.apple_sdk.frameworks.CoreGraphics
+              rustPlatform.bindgenHook
+            ];
+
+          nativeBuildInputs = with pkgs; [
+            pkg-config
+            makeWrapper
+            copyDesktopItems
+          ];
+
+          LD_LIBRARY_PATH = pkgs.lib.makeLibraryPath buildInputs;
+
+          src = craneLib.cleanCargoSource ./.;
+
+          cargoArtifacts = craneLib.buildDepsOnly {
+            inherit src buildInputs nativeBuildInputs;
+          };
+
+          ratty = craneLib.buildPackage {
+            inherit
+              src
+              cargoArtifacts
+              buildInputs
+              nativeBuildInputs
+              ;
+
+            desktopItems = [
+              (pkgs.makeDesktopItem {
+                name = "ratty";
+                desktopName = "Ratty";
+                comment = "A GPU-rendered terminal emulator with inline 3D graphics";
+                exec = "ratty";
+                terminal = false;
+                categories = [ "System" "TerminalEmulator" "Utility" ];
+                icon = "ratty";
+              })
+            ];
+
+            doCheck = false;
+            postInstall = pkgs.lib.optionalString pkgs.stdenv.isLinux ''
+              install -Dm644 ${./website/assets/images/ratty-logo.png} $out/share/icons/hicolor/512x512/apps/ratty.png
+
+              wrapProgram $out/bin/ratty \
+                --prefix LD_LIBRARY_PATH : ${LD_LIBRARY_PATH}
+            '';
+          };
+        in
+        {
+          packages = {
+            default = ratty;
+            ratty = ratty;
+          };
+
+          devShells.default = craneLib.devShell {
+            inputsFrom = [ ratty ];
+
+            inherit LD_LIBRARY_PATH;
+
+            packages = with pkgs; [
+              rust-analyzer
+            ];
+          };
+        };
+
+      flake = {
+        homeManagerModules.default =
+          {
+            config,
+            lib,
+            pkgs,
+            ...
+          }:
+          let
+            cfg = config.programs.ratty;
+            tomlFormat = pkgs.formats.toml { };
+          in
+          {
+            options.programs.ratty = {
+              enable = lib.mkEnableOption "Ratty, a GPU-rendered terminal emulator";
+
+              package = lib.mkOption {
+                type = lib.types.package;
+                default = self.packages.${pkgs.stdenv.hostPlatform.system}.ratty;
+                defaultText = lib.literalExpression "self.packages.\${pkgs.stdenv.hostPlatform.system}.ratty";
+                description = "The ratty package to install.";
+              };
+
+              settings = lib.mkOption {
+                type = tomlFormat.type;
+                default = { };
+                description = ''
+                  Configuration written to $XDG_CONFIG_HOME/ratty/ratty.toml.
+                  See the ratty repository for the default configuration options.
+                '';
+                example = lib.literalExpression ''
+                  {
+                    window = {
+                      opacity = 0.8;
+                    };
+                    shell = {
+                      program = "bash";
+                    };
+                  }
+                '';
+              };
+            };
+
+            config = lib.mkIf cfg.enable {
+              home.packages = [ cfg.package ];
+
+              xdg.configFile."ratty/ratty.toml" = lib.mkIf (cfg.settings != { }) {
+                source = tomlFormat.generate "ratty.toml" cfg.settings;
+              };
+            };
+          };
+
+        nixosModules.default =
+          {
+            config,
+            lib,
+            pkgs,
+            ...
+          }:
+          let
+            cfg = config.programs.ratty;
+            tomlFormat = pkgs.formats.toml { };
+          in
+          {
+            options.programs.ratty = {
+              enable = lib.mkEnableOption "Ratty, a GPU-rendered terminal emulator";
+
+              package = lib.mkOption {
+                type = lib.types.package;
+                default = self.packages.${pkgs.stdenv.hostPlatform.system}.ratty;
+                defaultText = lib.literalExpression "self.packages.\${pkgs.stdenv.hostPlatform.system}.ratty";
+                description = "The ratty package to install in the system environment.";
+              };
+
+              settings = lib.mkOption {
+                type = tomlFormat.type;
+                default = { };
+                description = ''
+                  Configuration written to /etc/ratty/ratty.toml.
+                  Note: Defining settings here will wrap the ratty binary to use the system configuration by default.
+                '';
+                example = lib.literalExpression ''
+                  {
+                    window = {
+                      opacity = 0.8;
+                    };
+                    shell = {
+                      program = "bash";
+                    };
+                  }
+                '';
+              };
+            };
+
+            config = lib.mkIf cfg.enable {
+              environment.systemPackages = [
+                (
+                  if cfg.settings == { } then
+                    cfg.package
+                  else
+                    pkgs.symlinkJoin {
+                      name = "ratty-system-wrapped";
+                      paths = [ cfg.package ];
+                      nativeBuildInputs = [ pkgs.makeWrapper ];
+                      postBuild = ''
+                        rm $out/bin/ratty
+                        makeWrapper ${cfg.package}/bin/ratty $out/bin/ratty \
+                          --add-flags "--config-file /etc/ratty/ratty.toml"
+                      '';
+                    }
+                )
+              ];
+
+              environment.etc."ratty/ratty.toml" = lib.mkIf (cfg.settings != { }) {
+                source = tomlFormat.generate "ratty.toml" cfg.settings;
+              };
+            };
+          };
+      };
+    };
+}


### PR DESCRIPTION
- Adds a flake.nix using crane and flake-parts for fast caching
- Provides a development shell with necessary dependencies
- Exports a Home Manager module to manage ratty.toml
- Exports a NixOS module to enforce system-wide config
- Patches hardcoded shell paths for NixOS compatibility

<!-- Please read CONTRIBUTING.md before submitting any pull request 🐀 -->
