### PR TITLE
feat: support inline payloads

### DIFF
--- a/protocols/graphics.md
+++ b/protocols/graphics.md
@@ -65,7 +65,7 @@ ESC _ ratty;g;s ESC \
 Ratty replies:
 
 ```text
-ESC _ ratty;g;s;v=1;fmt=obj|glb;path=1;anim=1;depth=1;color=1;brightness=1;transform=1;update=1 ESC \
+ESC _ ratty;g;s;v=1;fmt=obj|glb;path=1;payload=1;chunk=1;anim=1;depth=1;color=1;brightness=1;transform=1;update=1 ESC \
 ```
 
 Fields:
@@ -73,6 +73,8 @@ Fields:
 - `v=1`: protocol version
 - `fmt=glb`: `obj` and `glb` are supported
 - `path=1`: path-based object registration is supported
+- `payload=1`: payload-based asset registration is supported
+- `chunk=1`: chunked payload-based registration is supported
 - `anim=1`: `animate=1` placement is supported
 - `depth=1`: `depth=<f32>` placement is supported
 - `color=1`: `color=<RRGGBB>` placement is supported
@@ -94,11 +96,53 @@ ESC _ ratty;g;r;id=42;fmt=obj;path=CairoSpinyMouse.obj ESC \
 
 This registers object `42` using an object asset.
 
-#### Required fields
+The required fields are:
 
 - `id`: object id chosen by the application
 - `fmt`: payload format, `obj` or `glb` in v1
 - `path`: object path known to Ratty
+
+#### Payload-based registration
+
+RGP can also register an object by embedding the asset data directly into the
+register command as a payload. This is intended for cases such as SSH, where
+the sending application cannot rely on a shared filesystem path on the terminal
+side.
+
+The payload is base64-encoded and appended after the semicolon-separated
+header fields.
+
+Client sends:
+
+```text
+ESC _ ratty;g;r;id=42;fmt=obj;source=payload;more=0;name=rat.obj;<base64 payload> ESC \
+```
+
+For larger assets, the payload can be split across multiple register chunks:
+
+```text
+ESC _ ratty;g;r;id=42;fmt=glb;source=payload;more=1;<chunk-1> ESC \
+ESC _ ratty;g;r;id=42;fmt=glb;source=payload;more=1;<chunk-2> ESC \
+ESC _ ratty;g;r;id=42;fmt=glb;source=payload;more=0;<chunk-n> ESC \
+```
+
+Fields:
+
+- `id`: object id chosen by the application
+- `fmt`: payload format, `obj` or `glb`
+- `source`: registration source
+  - `payload`: asset bytes are carried in this command
+- `more`: continuation flag
+  - `1`: more register chunks follow for this object id
+  - `0`: this is the final chunk and registration can be finalized
+- `name`: optional source name for diagnostics and temporary asset naming
+
+The terminal accumulates chunks for the same `id` until it receives the final
+`more=0` chunk. At that point, the object becomes registered and can be placed
+normally.
+
+Path-based and payload-based registration are additive modes of the same `r` verb.
+Clients may continue using `path=...` exactly as before.
 
 ### 3. Place Object
 

--- a/src/inline.rs
+++ b/src/inline.rs
@@ -396,9 +396,7 @@ impl TerminalInlineObjects {
             return None;
         }
 
-        let Some(pending) = self.pending_rgp_payloads.remove(&object_id) else {
-            return None;
-        };
+        let pending = self.pending_rgp_payloads.remove(&object_id)?;
         info!(
             "finalizing RGP payload for object {} (format={}, total={} bytes)",
             object_id,

--- a/src/inline.rs
+++ b/src/inline.rs
@@ -8,10 +8,10 @@ use bevy::prelude::*;
 use vt100::Callbacks;
 
 use crate::kitty::{KittyOperation, KittyParserState, refresh_kitty_placeholder_anchors};
-use crate::model::{ObjectSource, load_object_source};
+use crate::model::{ObjectSource, load_object_source, load_object_source_from_bytes};
 use crate::rgp::{
-    RgpOperation, RgpPlacementStyle, RgpPlacementUpdate, consume_sequence as consume_rgp_sequence,
-    support_reply,
+    RgpOperation, RgpPlacementStyle, RgpPlacementUpdate, RgpRegisterSource,
+    consume_sequence as consume_rgp_sequence, support_reply,
 };
 const APC_START: &[u8] = b"\x1b_";
 const ST: &[u8] = b"\x1b\\";
@@ -36,6 +36,7 @@ pub struct TerminalRgpObject {
 #[derive(Resource, Default)]
 pub struct TerminalInlineObjects {
     pending_bytes: Vec<u8>,
+    pending_rgp_payloads: HashMap<u32, PendingRgpPayload>,
     kitty: KittyParserState,
     dirty: bool,
     last_viewport_size: Vec2,
@@ -154,12 +155,14 @@ impl TerminalInlineObjects {
     fn remove_object(&mut self, object_id: u32) {
         self.objects.remove(&object_id);
         self.anchors.remove(&object_id);
+        self.pending_rgp_payloads.remove(&object_id);
         self.dirty = true;
     }
 
     fn clear_objects(&mut self) {
         self.objects.clear();
         self.anchors.clear();
+        self.pending_rgp_payloads.clear();
         self.dirty = true;
     }
 
@@ -243,34 +246,44 @@ impl TerminalInlineObjects {
             RgpOperation::Register {
                 object_id,
                 format,
-                path,
+                source,
             } => {
                 if format != "obj" && format != "glb" {
                     warn!("unsupported RGP object format `{format}` for object {object_id}");
                     None
                 } else {
-                    match load_object_source(Path::new(&path)) {
-                        Ok((source, source_data)) => {
-                            info!("registered RGP object {} from {}", object_id, source,);
-                            self.objects.insert(
-                                object_id,
-                                InlineObject::RgpObject(match source_data {
-                                    ObjectSource::Obj(meshes) => RgpInlineObject::Obj {
-                                        meshes,
-                                        handles: None,
-                                    },
-                                    ObjectSource::Gltf(asset_path) => RgpInlineObject::Gltf {
-                                        asset_path,
-                                        handle: None,
-                                    },
-                                }),
-                            );
-                            self.dirty = true;
-                            None
+                    match source {
+                        RgpRegisterSource::Path { path } => {
+                            self.pending_rgp_payloads.remove(&object_id);
+                            match load_object_source(Path::new(&path)) {
+                                Ok((source, source_data)) => {
+                                    info!("registered RGP object {} from {}", object_id, source);
+                                    self.objects.insert(
+                                        object_id,
+                                        InlineObject::RgpObject(match source_data {
+                                            ObjectSource::Obj(meshes) => RgpInlineObject::Obj {
+                                                meshes,
+                                                handles: None,
+                                            },
+                                            ObjectSource::Gltf(asset_path) => {
+                                                RgpInlineObject::Gltf {
+                                                    asset_path,
+                                                    handle: None,
+                                                }
+                                            }
+                                        }),
+                                    );
+                                    self.dirty = true;
+                                    None
+                                }
+                                Err(error) => {
+                                    warn!("failed to load RGP object {object_id}: {error:#}");
+                                    None
+                                }
+                            }
                         }
-                        Err(error) => {
-                            warn!("failed to load RGP object {object_id}: {error:#}");
-                            None
+                        RgpRegisterSource::Payload { name, more, data } => {
+                            self.handle_rgp_payload_chunk(object_id, &format, name, more, data)
                         }
                     }
                 }
@@ -343,6 +356,87 @@ impl TerminalInlineObjects {
             self.anchors.remove(&object_id);
         }
     }
+
+    // Buffers chunked payload registrations until the final chunk arrives, then loads and registers the object.
+    fn handle_rgp_payload_chunk(
+        &mut self,
+        object_id: u32,
+        format: &str,
+        name: Option<String>,
+        more: bool,
+        data: Vec<u8>,
+    ) -> Option<Vec<u8>> {
+        let pending = self
+            .pending_rgp_payloads
+            .entry(object_id)
+            .or_insert_with(|| PendingRgpPayload {
+                format: format.to_string(),
+                name: name.clone(),
+                data: Vec::new(),
+            });
+        if pending.format != format {
+            warn!(
+                "ignoring RGP payload chunk for object {} due to format mismatch ({} vs {})",
+                object_id, pending.format, format
+            );
+            return None;
+        }
+        if pending.name.is_none() {
+            pending.name = name;
+        }
+        pending.data.extend_from_slice(&data);
+        info!(
+            "received RGP payload chunk for object {} (format={}, accumulated={} bytes, more={})",
+            object_id,
+            pending.format,
+            pending.data.len(),
+            more
+        );
+        if more {
+            return None;
+        }
+
+        let Some(pending) = self.pending_rgp_payloads.remove(&object_id) else {
+            return None;
+        };
+        info!(
+            "finalizing RGP payload for object {} (format={}, total={} bytes)",
+            object_id,
+            pending.format,
+            pending.data.len()
+        );
+        match load_object_source_from_bytes(&pending.format, pending.name.as_deref(), &pending.data)
+        {
+            Ok((source, source_data)) => {
+                info!("registered RGP object {} from {}", object_id, source);
+                self.objects.insert(
+                    object_id,
+                    InlineObject::RgpObject(match source_data {
+                        ObjectSource::Obj(meshes) => RgpInlineObject::Obj {
+                            meshes,
+                            handles: None,
+                        },
+                        ObjectSource::Gltf(asset_path) => RgpInlineObject::Gltf {
+                            asset_path,
+                            handle: None,
+                        },
+                    }),
+                );
+                self.dirty = true;
+                None
+            }
+            Err(error) => {
+                warn!("failed to load RGP object {object_id}: {error:#}");
+                None
+            }
+        }
+    }
+}
+
+struct PendingRgpPayload {
+    format: String,
+    name: Option<String>,
+    data: Vec<u8>,
 }
 
 fn normalize_hvp_sequences(bytes: &[u8]) -> Cow<'_, [u8]> {

--- a/src/model.rs
+++ b/src/model.rs
@@ -146,6 +146,50 @@ pub fn load_object_source(path: &Path) -> anyhow::Result<(String, ObjectSource)>
     }
 }
 
+/// Loads an object source from inline bytes.
+///
+/// # Errors
+///
+/// Returns an error if the payload cannot be parsed or materialized.
+pub fn load_object_source_from_bytes(
+    format: &str,
+    name: Option<&str>,
+    bytes: &[u8],
+) -> anyhow::Result<(String, ObjectSource)> {
+    let display_name = name.unwrap_or(match format {
+        "obj" => "payload.obj",
+        "glb" | "gltf" => "payload.glb",
+        _ => "payload",
+    });
+
+    match format {
+        "obj" => load_obj_meshes_from_bytes(display_name, bytes)
+            .map(|meshes| (format!("payload:{display_name}"), ObjectSource::Obj(meshes))),
+        "glb" | "gltf" => {
+            let extension = if format == "gltf" { "gltf" } else { "glb" };
+            let stem = Path::new(display_name)
+                .file_stem()
+                .and_then(|stem| stem.to_str())
+                .filter(|stem| !stem.is_empty())
+                .unwrap_or("payload");
+            let sanitized = stem
+                .chars()
+                .map(|c| match c {
+                    'a'..='z' | 'A'..='Z' | '0'..='9' | '-' | '_' => c,
+                    _ => '_',
+                })
+                .collect::<String>();
+            let candidate = format!("objects/rgp/{sanitized}.{extension}");
+            let asset_path = ensure_scene_asset_path(&candidate, Some((display_name, bytes)))?;
+            Ok((
+                format!("payload:{display_name}"),
+                ObjectSource::Gltf(asset_path),
+            ))
+        }
+        _ => bail!("unsupported object format for {}", display_name),
+    }
+}
+
 fn ensure_scene_asset_path(
     candidate: &str,
     embedded: Option<(&str, &[u8])>,

--- a/src/model.rs
+++ b/src/model.rs
@@ -166,6 +166,8 @@ pub fn load_object_source_from_bytes(
         "obj" => load_obj_meshes_from_bytes(display_name, bytes)
             .map(|meshes| (format!("payload:{display_name}"), ObjectSource::Obj(meshes))),
         "glb" | "gltf" => {
+            // Bevy scene loading still goes through the asset server, so payload-backed GLB/GLTF
+            // assets need to be materialized under the asset root before they can be instantiated.
             let extension = if format == "gltf" { "gltf" } else { "glb" };
             let stem = Path::new(display_name)
                 .file_stem()

--- a/src/rgp.rs
+++ b/src/rgp.rs
@@ -1,5 +1,7 @@
 //! Ratty Graphics Protocol parsing.
 
+use base64::Engine as _;
+
 /// Ratty Graphics Protocol APC prefix.
 pub const RGP_APC_START: &[u8] = b"\x1b_ratty;g;";
 const ST: &[u8] = b"\x1b\\";
@@ -47,6 +49,24 @@ pub struct RgpPlacementUpdate {
     pub scale3: [Option<f32>; 3],
 }
 
+/// Register source for an RGP object.
+pub enum RgpRegisterSource {
+    /// Path-based object registration.
+    Path {
+        /// Asset path known to Ratty.
+        path: String,
+    },
+    /// Payload-based object registration.
+    Payload {
+        /// Optional payload name.
+        name: Option<String>,
+        /// Whether more chunks follow.
+        more: bool,
+        /// Decoded payload bytes.
+        data: Vec<u8>,
+    },
+}
+
 /// Consumes an RGP APC sequence.
 pub fn consume_sequence(sequence: &[u8]) -> Option<RgpOperation> {
     if !sequence.starts_with(RGP_APC_START) {
@@ -66,6 +86,9 @@ pub fn consume_sequence(sequence: &[u8]) -> Option<RgpOperation> {
     let mut id = None;
     let mut format = None;
     let mut path = None;
+    let mut source = None;
+    let mut more = None;
+    let mut name = None;
     let mut row = None;
     let mut col = None;
     let mut width = None;
@@ -84,14 +107,22 @@ pub fn consume_sequence(sequence: &[u8]) -> Option<RgpOperation> {
     let mut sx = None;
     let mut sy = None;
     let mut sz = None;
+    let mut payload = None;
     for part in parts.filter(|part| !part.is_empty()) {
         let Some((key, value)) = part.split_once('=') else {
+            if verb == "r" && source.as_deref() == Some("payload") {
+                payload = Some(part.to_string());
+                break;
+            }
             continue;
         };
         match key {
             "id" => id = value.parse().ok(),
             "fmt" => format = Some(value.to_string()),
             "path" => path = Some(value.to_string()),
+            "source" => source = Some(value.to_string()),
+            "more" => more = parse_bool(value),
+            "name" => name = Some(value.to_string()),
             "row" => row = value.parse().ok(),
             "col" => col = value.parse().ok(),
             "w" => width = value.parse().ok(),
@@ -110,6 +141,10 @@ pub fn consume_sequence(sequence: &[u8]) -> Option<RgpOperation> {
             "sx" => sx = value.parse().ok(),
             "sy" => sy = value.parse().ok(),
             "sz" => sz = value.parse().ok(),
+            _ if verb == "r" && source.as_deref() == Some("payload") => {
+                payload = Some(part.to_string());
+                break;
+            }
             _ => {}
         }
     }
@@ -119,7 +154,21 @@ pub fn consume_sequence(sequence: &[u8]) -> Option<RgpOperation> {
         "r" => Some(RgpOperation::Register {
             object_id: id?,
             format: format?,
-            path: path?,
+            source: if let Some(path) = path {
+                RgpRegisterSource::Path { path }
+            } else {
+                if source.as_deref() != Some("payload") {
+                    return None;
+                }
+                let data = base64::engine::general_purpose::STANDARD
+                    .decode(payload.unwrap_or_default())
+                    .ok()?;
+                RgpRegisterSource::Payload {
+                    name,
+                    more: more.unwrap_or(false),
+                    data,
+                }
+            },
         }),
         "p" => Some(RgpOperation::Place {
             object_id: id?,
@@ -183,8 +232,8 @@ pub enum RgpOperation {
         object_id: u32,
         /// Declared object format.
         format: String,
-        /// Asset path.
-        path: String,
+        /// Register source.
+        source: RgpRegisterSource,
     },
     /// Object placement.
     Place {
@@ -211,7 +260,7 @@ pub enum RgpOperation {
 
 /// Returns the RGP support reply sequence.
 pub fn support_reply() -> Vec<u8> {
-    b"\x1b_ratty;g;s;v=1;fmt=obj|glb;path=1;anim=1;depth=1;color=1;brightness=1;transform=1;update=1\x1b\\".to_vec()
+    b"\x1b_ratty;g;s;v=1;fmt=obj|glb;path=1;payload=1;chunk=1;anim=1;depth=1;color=1;brightness=1;transform=1;update=1\x1b\\".to_vec()
 }
 
 fn parse_color(value: &str) -> Option<[u8; 3]> {

--- a/widget/Cargo.lock
+++ b/widget/Cargo.lock
@@ -1699,6 +1699,7 @@ dependencies = [
 name = "ratatui-ratty"
 version = "0.1.0"
 dependencies = [
+ "base64",
  "crossterm",
  "image",
  "ratatui",

--- a/widget/Cargo.toml
+++ b/widget/Cargo.toml
@@ -12,6 +12,7 @@ categories = ["command-line-interface", "graphics"]
 edition = "2024"
 
 [dependencies]
+base64 = "0.22"
 ratatui-core = "0.1.0"
 
 [dev-dependencies]

--- a/widget/examples/draw.rs
+++ b/widget/examples/draw.rs
@@ -1,8 +1,4 @@
-use std::{
-    collections::BTreeSet,
-    env, fs, io,
-    path::{Path, PathBuf},
-};
+use std::{collections::BTreeSet, io};
 
 use crossterm::{
     event::{
@@ -52,24 +48,12 @@ struct DrawingApp<'a> {
     last_rotate_position: Option<Position>,
     points: BTreeSet<(u16, u16)>,
     preview: RattyGraphic<'a>,
-    preview_obj_path: PathBuf,
 }
 
 impl<'a> DrawingApp<'a> {
     fn new() -> io::Result<Self> {
-        let cwd = env::current_dir()?;
-        let relative_path = if cwd.file_name().and_then(|name| name.to_str()) == Some("widget") {
-            "../target/live_draw.obj"
-        } else {
-            "target/live_draw.obj"
-        };
-        let preview_obj_path = cwd.join(relative_path);
-        if let Some(parent) = preview_obj_path.parent() {
-            fs::create_dir_all(parent)?;
-        }
-
         let preview = RattyGraphic::new(
-            RattyGraphicSettings::new(relative_path)
+            RattyGraphicSettings::new("live_draw.obj")
                 .id(700)
                 .format(ObjectFormat::Obj)
                 .animate(true)
@@ -87,7 +71,6 @@ impl<'a> DrawingApp<'a> {
             last_rotate_position: None,
             points: BTreeSet::new(),
             preview,
-            preview_obj_path,
         })
     }
 
@@ -271,8 +254,8 @@ impl<'a> DrawingApp<'a> {
             return self.preview.clear();
         }
 
-        write_obj(&self.preview_obj_path, &self.points)?;
-        self.preview.register()
+        let obj = write_obj(&self.points);
+        self.preview.register_payload(obj.as_bytes())
     }
 
     fn render(&mut self, frame: &mut Frame<'_>) {
@@ -411,7 +394,7 @@ impl<'a> DrawingApp<'a> {
     }
 }
 
-fn write_obj(path: &Path, points: &BTreeSet<(u16, u16)>) -> io::Result<()> {
+fn write_obj(points: &BTreeSet<(u16, u16)>) -> String {
     let mut out = String::new();
     let mut vertex = 1u32;
 
@@ -430,5 +413,5 @@ fn write_obj(path: &Path, points: &BTreeSet<(u16, u16)>) -> io::Result<()> {
         vertex += 4;
     }
 
-    fs::write(path, out)
+    out
 }

--- a/widget/src/lib.rs
+++ b/widget/src/lib.rs
@@ -1,9 +1,12 @@
 #![doc = include_str!("../README.md")]
 
+use base64::Engine as _;
 use ratatui_core::{buffer::Buffer, layout::Rect, widgets::Widget};
 use std::borrow::Cow;
 use std::io::{self, Write};
 use std::path::Path;
+
+const PAYLOAD_CHUNK_SIZE: usize = 3072;
 
 /// Object asset format.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -31,6 +34,13 @@ impl ObjectFormat {
         {
             Some("obj") => Self::Obj,
             _ => Self::Glb,
+        }
+    }
+
+    fn payload_name(self) -> &'static str {
+        match self {
+            Self::Obj => "payload.obj",
+            Self::Glb => "payload.glb",
         }
     }
 }
@@ -173,6 +183,62 @@ impl<'a> RattyGraphic<'a> {
         )
     }
 
+    /// Returns the RGP register sequences for a payload-backed asset.
+    pub fn register_payload_sequences(&self, bytes: &[u8]) -> Vec<String> {
+        self.register_payload_sequences_with_name(bytes, None)
+    }
+
+    /// Returns the RGP register sequences for a payload-backed asset with an explicit source name.
+    pub fn register_payload_sequences_with_name(
+        &self,
+        bytes: &[u8],
+        name: Option<&str>,
+    ) -> Vec<String> {
+        let encoded = base64::engine::general_purpose::STANDARD.encode(bytes);
+        let default_name = Path::new(self.settings.path.as_ref())
+            .file_name()
+            .and_then(|name| name.to_str())
+            .filter(|name| !name.is_empty())
+            .unwrap_or_else(|| self.settings.format.payload_name());
+        let name = name.unwrap_or(default_name);
+        let mut sequences = Vec::new();
+
+        for (index, chunk_start) in (0..encoded.len()).step_by(PAYLOAD_CHUNK_SIZE).enumerate() {
+            let chunk_end = (chunk_start + PAYLOAD_CHUNK_SIZE).min(encoded.len());
+            let more = u8::from(chunk_end < encoded.len());
+            let chunk = &encoded[chunk_start..chunk_end];
+            sequences.push(if index == 0 {
+                format!(
+                    "\x1b_ratty;g;r;id={};fmt={};source=payload;more={};name={};{}\x1b\\",
+                    self.settings.id,
+                    self.settings.format.as_str(),
+                    more,
+                    name,
+                    chunk
+                )
+            } else {
+                format!(
+                    "\x1b_ratty;g;r;id={};fmt={};source=payload;more={};{}\x1b\\",
+                    self.settings.id,
+                    self.settings.format.as_str(),
+                    more,
+                    chunk
+                )
+            });
+        }
+
+        if sequences.is_empty() {
+            sequences.push(format!(
+                "\x1b_ratty;g;r;id={};fmt={};source=payload;more=0;name={};\x1b\\",
+                self.settings.id,
+                self.settings.format.as_str(),
+                name,
+            ));
+        }
+
+        sequences
+    }
+
     /// Writes the RGP register sequence to stdout.
     ///
     /// # Errors
@@ -181,6 +247,28 @@ impl<'a> RattyGraphic<'a> {
     pub fn register(&self) -> io::Result<()> {
         io::stdout().write_all(self.register_sequence().as_bytes())?;
         io::stdout().flush()
+    }
+
+    /// Writes the RGP register sequences for a payload-backed asset to stdout.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if stdout cannot be written or flushed.
+    pub fn register_payload(&self, bytes: &[u8]) -> io::Result<()> {
+        self.register_payload_with_name(bytes, None)
+    }
+
+    /// Writes the RGP register sequences for a payload-backed asset to stdout with an explicit source name.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if stdout cannot be written or flushed.
+    pub fn register_payload_with_name(&self, bytes: &[u8], name: Option<&str>) -> io::Result<()> {
+        let mut stdout = io::stdout();
+        for sequence in self.register_payload_sequences_with_name(bytes, name) {
+            stdout.write_all(sequence.as_bytes())?;
+        }
+        stdout.flush()
     }
 
     /// Returns the RGP place sequence for an area.


### PR DESCRIPTION
closes #37

This PR extends the Ratty Graphics Protocol with payload-based object registration.

This is useful if you want to load objects from base64-encoded strings instead of files.

Example registration pipeline:

```text
ESC _ ratty;g;r;id=42;fmt=obj;source=payload;more=1;name=rat.obj;<base64 chunk 1> ESC \
ESC _ ratty;g;r;id=42;fmt=obj;source=payload;more=1;<base64 chunk 2> ESC \
ESC _ ratty;g;r;id=42;fmt=obj;source=payload;more=0;<base64 chunk N> ESC \
ESC _ ratty;g;p;id=42;row=12;col=8;w=4;h=2 ESC \
```

Example usage in Rust:

```rust
use ratatui_ratty::{ObjectFormat, RattyGraphic, RattyGraphicSettings};

let graphic = RattyGraphic::new(
    RattyGraphicSettings::new("live_draw.obj")
        .id(42)
        .format(ObjectFormat::Obj),
);

let obj_bytes = std::fs::read("live_draw.obj")?;
graphic.register_payload(&obj_bytes)?;
```
