### PR TITLE
feat: enable arboard wayland-data-control by default

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -231,6 +231,7 @@ dependencies = [
  "parking_lot",
  "percent-encoding",
  "windows-sys 0.59.0",
+ "wl-clipboard-rs",
  "x11rb",
 ]
 
@@ -3559,6 +3560,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "nonmax"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3959,6 +3969,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7bb71e1b3fa6ca1c61f383464aaf2bb0e2f8e772a1f01d486832464de363b951"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "os_pipe"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5260,7 +5280,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4ea810f0692f9f51b382fff5893887bb4580f5fa246fde546e0b13e7fcee662"
 dependencies = [
  "fnv",
- "nom",
+ "nom 7.1.3",
  "phf",
  "phf_codegen",
 ]
@@ -5643,6 +5663,17 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "tree_magic_mini"
+version = "3.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8765b90061cba6c22b5831f675da109ae5561588290f9fa2317adab2714d5a6"
+dependencies = [
+ "memchr",
+ "nom 8.0.0",
+ "petgraph",
 ]
 
 [[package]]
@@ -6998,6 +7029,24 @@ dependencies = [
  "serde_json",
  "unicode-xid",
  "wasmparser",
+]
+
+[[package]]
+name = "wl-clipboard-rs"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9651471a32e87d96ef3a127715382b2d11cc7c8bb9822ded8a7cc94072eb0a3"
+dependencies = [
+ "libc",
+ "log",
+ "os_pipe",
+ "rustix 1.1.4",
+ "thiserror 2.0.18",
+ "tree_magic_mini",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-protocols-wlr",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ exclude = ["website/**", ".github/**", "widget/**"]
 
 [dependencies]
 anyhow = "1.0"
-arboard = "3.6"
+arboard = { version = "3.6", features = ["wayland-data-control"] }
 base64 = "0.22"
 bevy = { version = "0.18.1", default-features = false, features = [
     "std",


### PR DESCRIPTION
  ---
  # Title: feat: enable arboard wayland-data-control by default

  Closes #30.

  ## Summary
Enables the wayland-data-control feature on arboard so the system clipboard bridge works out of the box under Wayland compositors (Hyprland, Sway, etc.) — no rebuild required.

bevy/wayland is already on by default, so this fills in the other half of what users currently have to compile in manually.

  ## Change

  - Cargo.toml: arboard = "3.6" → arboard = { version = "3.6", features = ["wayland-data-control"] }

  ## Notes

  - Copy/paste keybindings (Ctrl+Alt+C / Ctrl+Alt+V) and scrollback (Alt+PageUp/Down, Alt+↑/↓) already exist — the reported issue was purely the missing Wayland clipboard backend.
  - X11 path is unaffected.
  - WINIT_UNIX_BACKEND=wayland remains a user-side env var; not in scope here.

  ## Test plan

  - cargo build --release on Wayland (Hyprland)
  - Copy from a Wayland app → paste into ratty with Ctrl+Alt+V
  - Select in ratty → Ctrl+Alt+C → paste into a Wayland app
  - Verify X11 session still copies/pastes