### PR TITLE
fix: defer terminal redraw during resize

### DIFF
--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -7,9 +7,10 @@ use crate::keyboard::{TerminalClipboard, TerminalKeyBindings, handle_keyboard_in
 use crate::mouse::{TerminalSelection, handle_mouse_input};
 use crate::scene::{apply_terminal_presentation, setup_scene};
 use crate::systems::{
-    animate_mobius_transition, animate_terminal_plane_warp, apply_inline_objects,
-    apply_instance_brightness, handle_window_resize, pump_pty_output, redraw_soft_terminal,
-    sync_asset_to_terminal_cursor, sync_inline_objects, sync_rgp_objects,
+    PendingTerminalResize, animate_mobius_transition, animate_terminal_plane_warp,
+    apply_inline_objects, apply_instance_brightness, apply_pending_terminal_resize,
+    handle_window_resize, pump_pty_output, redraw_soft_terminal, sync_asset_to_terminal_cursor,
+    sync_inline_objects, sync_rgp_objects,
 };
 use crate::terminal::TerminalRedrawState;
 
@@ -20,6 +21,7 @@ impl Plugin for TerminalPlugin {
     fn build(&self, app: &mut App) {
         app.init_resource::<TerminalSelection>()
             .init_resource::<TerminalInlineObjects>()
+            .init_resource::<PendingTerminalResize>()
             .init_resource::<TerminalRedrawState>()
             .init_resource::<TerminalKeyBindings>()
             .init_non_send_resource::<TerminalClipboard>()
@@ -28,6 +30,10 @@ impl Plugin for TerminalPlugin {
             .add_systems(Update, handle_keyboard_input)
             .add_systems(Update, handle_mouse_input)
             .add_systems(Update, handle_window_resize)
+            .add_systems(
+                Update,
+                apply_pending_terminal_resize.after(handle_window_resize),
+            )
             .add_systems(
                 Update,
                 apply_terminal_presentation

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -299,6 +299,10 @@ impl TerminalRuntime {
             return;
         }
 
+        if self.parser.screen().size() == (rows, cols) {
+            return;
+        }
+
         let _ = self._master.resize(PtySize {
             rows,
             cols,

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -108,9 +108,9 @@ type PlaneBackResizeQuery<'w, 's> = Query<
 
 const RESIZE_SETTLE_DELAY: Duration = Duration::from_millis(100);
 
-#[derive(Resource)]
 /// Tracks the most recent window resize event so PTY/grid resizing can be deferred until the
 /// resize stream settles.
+#[derive(Resource)]
 pub struct PendingTerminalResize {
     latest_size: Option<Vec2>,
     last_event: Option<Instant>,

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -190,7 +190,6 @@ pub(crate) struct ResizeParams<'w, 's> {
     plane_query:
         Query<'w, 's, &'static mut Transform, (With<TerminalPlane>, Without<TerminalSprite>)>,
     plane_back_query: PlaneBackResizeQuery<'w, 's>,
-    images: ResMut<'w, Assets<Image>>,
 }
 
 /// Handles primary window resize events.
@@ -199,8 +198,7 @@ pub(crate) struct ResizeParams<'w, 's> {
 /// [`TerminalRuntime`], [`TerminalSurface`], [`TerminalViewport`], the 2D terminal sprite and the
 /// front and back terminal plane transforms.
 ///
-/// The updated terminal image is uploaded immediately so later systems in the same frame see the
-/// new geometry.
+/// The updated terminal image is uploaded by the normal redraw system on the next update.
 pub(crate) fn handle_window_resize(
     mut resize_events: MessageReader<WindowResized>,
     mut params: ResizeParams,
@@ -214,7 +212,7 @@ pub(crate) fn handle_window_resize(
         sprite_query,
         plane_query,
         plane_back_query,
-        images,
+        ..
     } = &mut params;
     let Ok(primary_window) = primary_window.single() else {
         return;
@@ -241,7 +239,6 @@ pub(crate) fn handle_window_resize(
 
     runtime.resize(cols, rows);
     terminal.resize(cols, rows);
-    let _ = terminal.sync_image(images, 0.0);
     redraw.request();
 
     for mut sprite in sprite_query.iter_mut() {

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -20,6 +20,7 @@
 
 use std::collections::HashMap;
 use std::sync::mpsc::TryRecvError;
+use std::time::{Duration, Instant};
 
 use crate::config::{AppConfig, CURSOR_DEPTH};
 use crate::inline::{
@@ -105,6 +106,25 @@ type PlaneBackResizeQuery<'w, 's> = Query<
     ),
 >;
 
+const RESIZE_SETTLE_DELAY: Duration = Duration::from_millis(100);
+
+#[derive(Resource)]
+/// Tracks the most recent window resize event so PTY/grid resizing can be deferred until the
+/// resize stream settles.
+pub struct PendingTerminalResize {
+    latest_size: Option<Vec2>,
+    last_event: Option<Instant>,
+}
+
+impl Default for PendingTerminalResize {
+    fn default() -> Self {
+        Self {
+            latest_size: None,
+            last_event: None,
+        }
+    }
+}
+
 /// Pumps PTY output into the terminal parser.
 ///
 /// This runs early in the update schedule, before [`redraw_soft_terminal`]. It drains PTY output
@@ -182,9 +202,6 @@ fn infer_upward_scroll(prev_rows: &[String], next_rows: &[String]) -> u16 {
 #[derive(SystemParam)]
 pub(crate) struct ResizeParams<'w, 's> {
     primary_window: Query<'w, 's, Entity, With<PrimaryWindow>>,
-    runtime: NonSendMut<'w, TerminalRuntime>,
-    terminal: NonSendMut<'w, TerminalSurface>,
-    redraw: ResMut<'w, TerminalRedrawState>,
     viewport: ResMut<'w, TerminalViewport>,
     sprite_query: Query<'w, 's, &'static mut Sprite, With<TerminalSprite>>,
     plane_query:
@@ -194,20 +211,17 @@ pub(crate) struct ResizeParams<'w, 's> {
 
 /// Handles primary window resize events.
 ///
-/// This updates both the PTY grid and the rendered scene dimensions. It resizes
-/// [`TerminalRuntime`], [`TerminalSurface`], [`TerminalViewport`], the 2D terminal sprite and the
-/// front and back terminal plane transforms.
+/// This updates the visible terminal geometry immediately and records the latest size for a
+/// deferred PTY/grid resize once the resize stream settles.
 ///
 /// The updated terminal image is uploaded by the normal redraw system on the next update.
 pub(crate) fn handle_window_resize(
     mut resize_events: MessageReader<WindowResized>,
     mut params: ResizeParams,
+    mut pending_resize: ResMut<PendingTerminalResize>,
 ) {
     let ResizeParams {
         primary_window,
-        runtime,
-        terminal,
-        redraw,
         viewport,
         sprite_query,
         plane_query,
@@ -232,14 +246,8 @@ pub(crate) fn handle_window_resize(
     let viewport_size = Vec2::new(window_size.x.max(1.0), window_size.y.max(1.0));
     viewport.size = viewport_size;
     viewport.center = Vec2::ZERO;
-
-    let char_dims = terminal.char_dimensions().max(UVec2::ONE);
-    let cols = ((viewport_size.x / char_dims.x as f32).floor() as u16).max(1);
-    let rows = ((viewport_size.y / char_dims.y as f32).floor() as u16).max(1);
-
-    runtime.resize(cols, rows);
-    terminal.resize(cols, rows);
-    redraw.request();
+    pending_resize.latest_size = Some(viewport_size);
+    pending_resize.last_event = Some(Instant::now());
 
     for mut sprite in sprite_query.iter_mut() {
         sprite.custom_size = Some(viewport_size);
@@ -252,6 +260,35 @@ pub(crate) fn handle_window_resize(
     for mut transform in plane_back_query.iter_mut() {
         transform.scale = viewport_size.extend(1.0);
     }
+}
+
+/// Applies a deferred PTY/grid resize after window resize events settle.
+pub(crate) fn apply_pending_terminal_resize(
+    mut pending_resize: ResMut<PendingTerminalResize>,
+    mut runtime: NonSendMut<TerminalRuntime>,
+    mut terminal: NonSendMut<TerminalSurface>,
+    mut redraw: ResMut<TerminalRedrawState>,
+) {
+    let Some(last_event) = pending_resize.last_event else {
+        return;
+    };
+    if last_event.elapsed() < RESIZE_SETTLE_DELAY {
+        return;
+    }
+
+    let Some(window_size) = pending_resize.latest_size.take() else {
+        pending_resize.last_event = None;
+        return;
+    };
+    pending_resize.last_event = None;
+
+    let char_dims = terminal.char_dimensions().max(UVec2::ONE);
+    let cols = ((window_size.x / char_dims.x as f32).floor() as u16).max(1);
+    let rows = ((window_size.y / char_dims.y as f32).floor() as u16).max(1);
+
+    runtime.resize(cols, rows);
+    terminal.resize(cols, rows);
+    redraw.request();
 }
 
 /// Applies inline object visibility for the current presentation mode.

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -110,19 +110,10 @@ const RESIZE_SETTLE_DELAY: Duration = Duration::from_millis(100);
 
 /// Tracks the most recent window resize event so PTY/grid resizing can be deferred until the
 /// resize stream settles.
-#[derive(Resource)]
+#[derive(Resource, Default)]
 pub struct PendingTerminalResize {
     latest_size: Option<Vec2>,
     last_event: Option<Instant>,
-}
-
-impl Default for PendingTerminalResize {
-    fn default() -> Self {
-        Self {
-            latest_size: None,
-            last_event: None,
-        }
-    }
 }
 
 /// Pumps PTY output into the terminal parser.
@@ -336,6 +327,7 @@ pub(crate) struct RedrawParams<'w, 's> {
     terminal: NonSendMut<'w, TerminalSurface>,
     selection: Res<'w, TerminalSelection>,
     presentation: Res<'w, TerminalPresentation>,
+    pending_resize: Res<'w, PendingTerminalResize>,
     time: Res<'w, Time>,
     redraw: ResMut<'w, TerminalRedrawState>,
     images: ResMut<'w, Assets<Image>>,
@@ -364,6 +356,7 @@ pub(crate) fn redraw_soft_terminal(mut params: RedrawParams) {
         terminal,
         selection,
         presentation,
+        pending_resize,
         time,
         redraw,
         images,
@@ -379,7 +372,8 @@ pub(crate) fn redraw_soft_terminal(mut params: RedrawParams) {
     let force_live_redraw = matches!(
         presentation.mode,
         TerminalPresentationMode::Plane3d | TerminalPresentationMode::Mobius3d
-    ) && !app_config.cursor.model.visible;
+    ) && !app_config.cursor.model.visible
+        && pending_resize.last_event.is_none();
     if !needs_redraw && !force_live_redraw && model_load_state.loaded {
         return;
     }

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -187,6 +187,10 @@ impl TerminalSurface {
             return;
         }
 
+        if self.cols == cols && self.rows == rows {
+            return;
+        }
+
         self.tui.backend_mut().resize(cols, rows);
         let _ = self.tui.resize(Rect::new(0, 0, cols, rows));
         if self.cursor_model_visible {


### PR DESCRIPTION
Makes the continuous resize smoother

potentiall fixes #46