### PR TITLE
Add Nix compatible build files.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /target
 assets/img
+result
+result-*

--- a/README.md
+++ b/README.md
@@ -59,6 +59,14 @@ cargo install ratty
 sudo pacman -S ratty
 ```
 
+### [Nix](nix/README.md)
+
+See the [Nix packaging docs](nix/README.md) for flake, NixOS, and Home Manager usage.
+
+```bash
+nix run github:orhun/ratty
+```
+
 ### Binary releases
 
 Prebuilt binaries are available on the [GitHub releases page](https://github.com/orhun/ratty/releases) for direct download.

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1777954456,
+        "narHash": "sha256-hGdgeU2Nk87RAuZyYjyDjFL6LK7dAZN5RE9+hrDTkDU=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "549bd84d6279f9852cae6225e372cc67fb91a4c1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,20 @@
 {
   "nodes": {
+    "crane": {
+      "locked": {
+        "lastModified": 1780532242,
+        "narHash": "sha256-D+BsdpxmtUwtqGoY0IXPhHgTlmqgcZKCEo1oMyn7ep0=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "59a82a1222dd3b2080b5cc52a1a2e8d5f1b77f37",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1777954456,
@@ -18,6 +33,7 @@
     },
     "root": {
       "inputs": {
+        "crane": "crane",
         "nixpkgs": "nixpkgs"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -101,6 +101,17 @@
 
       formatter = forEachSystem (system: nixpkgs.legacyPackages.${system}.nixfmt-rfc-style);
 
+      checks = forEachSystem (
+        system:
+        let
+          pkgs = nixpkgs.legacyPackages.${system};
+        in
+        {
+          # Build + run tests (cargo test via cargoCheckHook)
+          ratty = self.packages.${system}.ratty;
+        }
+      );
+
       # Home Manager module — declarative user-level config
       #
       # Usage in home.nix:

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,49 @@
+{
+  description = "Ratty: a GPU-rendered terminal emulator with inline 3D graphics";
+
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+
+  outputs =
+    { self, nixpkgs }:
+    let
+      supportedSystems = [
+        "x86_64-linux"
+        "aarch64-linux"
+        "x86_64-darwin"
+        "aarch64-darwin"
+      ];
+      forEachSystem = nixpkgs.lib.genAttrs supportedSystems;
+    in
+    {
+      packages = forEachSystem (
+        system:
+        let
+          pkgs = nixpkgs.legacyPackages.${system};
+        in
+        {
+          ratty = pkgs.callPackage ./nix/default.nix { };
+          default = self.packages.${system}.ratty;
+        }
+      );
+
+      devShells = forEachSystem (
+        system:
+        let
+          pkgs = nixpkgs.legacyPackages.${system};
+        in
+        {
+          default = pkgs.mkShell {
+            inputsFrom = [ self.packages.${system}.default ];
+            packages = with pkgs; [
+              rust-analyzer
+              cargo
+              clippy
+              rustfmt
+            ];
+          };
+        }
+      );
+
+      formatter = forEachSystem (system: nixpkgs.legacyPackages.${system}.nixfmt-rfc-style);
+    };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -13,6 +13,47 @@
         "aarch64-darwin"
       ];
       forEachSystem = nixpkgs.lib.genAttrs supportedSystems;
+
+      # Shared module options — used by both HM and NixOS modules
+      rattyOptions =
+        {
+          config,
+          lib,
+          pkgs,
+          ...
+        }:
+        let
+          cfg = config.programs.ratty;
+          tomlFormat = pkgs.formats.toml { };
+        in
+        {
+          options.programs.ratty = {
+            enable = lib.mkEnableOption "Ratty, a GPU-rendered terminal emulator";
+
+            package = lib.mkOption {
+              type = lib.types.package;
+              default = self.packages.${pkgs.stdenv.hostPlatform.system}.ratty;
+              defaultText = lib.literalExpression "self.packages.\${pkgs.stdenv.hostPlatform.system}.ratty";
+              description = "The ratty package to install.";
+            };
+
+            settings = lib.mkOption {
+              type = tomlFormat.type;
+              default = { };
+              description = "Ratty configuration (ratty.toml).";
+              example = lib.literalExpression ''
+                {
+                  window = {
+                    opacity = 0.8;
+                  };
+                  shell = {
+                    program = "bash";
+                  };
+                }
+              '';
+            };
+          };
+        };
     in
     {
       packages = forEachSystem (
@@ -21,7 +62,21 @@
           pkgs = nixpkgs.legacyPackages.${system};
         in
         {
-          ratty = pkgs.callPackage ./nix/default.nix { };
+          ratty = pkgs.callPackage ./nix/default.nix {
+            # Pass Darwin frameworks when on Darwin
+            darwinFrameworks = pkgs.lib.optionals pkgs.stdenv.isDarwin (
+              with pkgs.darwin.apple_sdk.frameworks;
+              [
+                Cocoa
+                CoreFoundation
+                CoreGraphics
+                CoreText
+                CoreVideo
+                Metal
+                QuartzCore
+              ]
+            );
+          };
           default = self.packages.${system}.ratty;
         }
       );
@@ -45,5 +100,92 @@
       );
 
       formatter = forEachSystem (system: nixpkgs.legacyPackages.${system}.nixfmt-rfc-style);
+
+      # Home Manager module — declarative user-level config
+      #
+      # Usage in home.nix:
+      #   programs.ratty = {
+      #     enable = true;
+      #     settings = {
+      #       window = { opacity = 0.9; };
+      #       shell = { program = "zsh"; };
+      #     };
+      #   };
+      #
+      # Config is written to $XDG_CONFIG_HOME/ratty/ratty.toml
+      # ratty discovers this path automatically.
+      homeManagerModules.default =
+        args@{
+          config,
+          lib,
+          pkgs,
+          ...
+        }:
+        let
+          cfg = config.programs.ratty;
+          tomlFormat = pkgs.formats.toml { };
+          opts = rattyOptions args;
+        in
+        {
+          inherit (opts) options;
+          config = lib.mkIf cfg.enable {
+            home.packages = [ cfg.package ];
+            xdg.configFile."ratty/ratty.toml" = lib.mkIf (cfg.settings != { }) {
+              source = tomlFormat.generate "ratty.toml" cfg.settings;
+            };
+          };
+        };
+
+      # NixOS module — declarative system-level config
+      #
+      # Usage in configuration.nix:
+      #   programs.ratty = {
+      #     enable = true;
+      #     settings = {
+      #       window = { opacity = 0.9; };
+      #       shell = { program = "zsh"; };
+      #     };
+      #   };
+      #
+      # Config is written to /etc/ratty/ratty.toml
+      # Binary is wrapped with --config-file flag to use system config.
+      nixosModules.default =
+        args@{
+          config,
+          lib,
+          pkgs,
+          ...
+        }:
+        let
+          cfg = config.programs.ratty;
+          tomlFormat = pkgs.formats.toml { };
+          opts = rattyOptions args;
+        in
+        {
+          inherit (opts) options;
+          config = lib.mkIf cfg.enable {
+            environment.systemPackages = [
+              (
+                if cfg.settings == { } then
+                  cfg.package
+                else
+                  pkgs.symlinkJoin {
+                    name = "ratty-system-wrapped";
+                    paths = [ cfg.package ];
+                    nativeBuildInputs = [ pkgs.makeWrapper ];
+                    postBuild = ''
+                      rm -f $out/bin/ratty
+                      makeWrapper ${cfg.package}/bin/ratty $out/bin/ratty \
+                        --add-flags "--config-file /etc/ratty/ratty.toml"
+                    '';
+                  }
+              )
+            ];
+
+            environment.etc."ratty/ratty.toml" = lib.mkIf (cfg.settings != { }) {
+              source = tomlFormat.generate "ratty.toml" cfg.settings;
+            };
+          };
+        };
     };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -1,10 +1,13 @@
 {
   description = "Ratty: a GPU-rendered terminal emulator with inline 3D graphics";
 
-  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    crane.url = "github:ipetkov/crane";
+  };
 
   outputs =
-    { self, nixpkgs }:
+    { self, nixpkgs, crane }:
     let
       supportedSystems = [
         "x86_64-linux"
@@ -60,9 +63,11 @@
         system:
         let
           pkgs = nixpkgs.legacyPackages.${system};
+          craneLib = crane.mkLib pkgs;
         in
         {
           ratty = pkgs.callPackage ./nix/default.nix {
+            inherit craneLib;
             # Pass Darwin frameworks when on Darwin
             darwinFrameworks = pkgs.lib.optionals pkgs.stdenv.isDarwin (
               with pkgs.darwin.apple_sdk.frameworks;

--- a/nix/README.md
+++ b/nix/README.md
@@ -2,16 +2,23 @@
 
 This flake provides a Nix package for [ratty](https://github.com/orhun/ratty), a GPU-rendered terminal emulator with inline 3D graphics.
 
+## Supported Systems
+
+- `x86_64-linux`
+- `aarch64-linux`
+- `x86_64-darwin`
+- `aarch64-darwin`
+
 ## Quick Start
 
 ### Direct usage
 
 ```bash
 # Run directly
-nix run github:DarthPJB/ratty
+nix run github:orhun/ratty
 
 # Install to profile
-nix profile install github:DarthPJB/ratty
+nix profile install github:orhun/ratty
 ```
 
 ### As a flake input
@@ -20,7 +27,7 @@ nix profile install github:DarthPJB/ratty
 {
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
-    ratty.url = "github:DarthPJB/ratty";
+    ratty.url = "github:orhun/ratty";
   };
 
   outputs = { nixpkgs, ratty, ... }: {
@@ -38,7 +45,7 @@ Add ratty to your system packages with optional declarative configuration:
 {
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
-    ratty.url = "github:DarthPJB/ratty";
+    ratty.url = "github:orhun/ratty";
   };
 
   outputs = { nixpkgs, ratty, ... }: {
@@ -78,8 +85,8 @@ Add ratty to your system packages with optional declarative configuration:
 
 This will:
 - Install the ratty package
-- Write configuration to `/etc/ratty/ratty.toml`
-- Wrap the binary to use `--config-file /etc/ratty/ratty.toml`
+- Write configuration to `/etc/ratty/ratty.toml` (only when `settings` is non-empty)
+- Wrap the binary to use `--config-file /etc/ratty/ratty.toml` (only when `settings` is non-empty)
 
 ## Home Manager Configuration
 
@@ -91,7 +98,7 @@ For user-level configuration without root:
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
     home-manager.url = "github:nix-community/home-manager";
-    ratty.url = "github:DarthPJB/ratty";
+    ratty.url = "github:orhun/ratty";
   };
 
   outputs = { nixpkgs, home-manager, ratty, ... }: {
@@ -129,7 +136,7 @@ For user-level configuration without root:
 
 This will:
 - Install the ratty package to your user profile
-- Write configuration to `$XDG_CONFIG_HOME/ratty/ratty.toml` (typically `~/.config/ratty/ratty.toml`)
+- Write configuration to `$XDG_CONFIG_HOME/ratty/ratty.toml` (typically `~/.config/ratty/ratty.toml`) (only when `settings` is non-empty)
 - ratty discovers this path automatically
 
 ## Module Options
@@ -160,8 +167,8 @@ nix develop
 # Build package
 nix build
 
-# Run tests
-nix build .#ratty --check
+# Run with checks
+nix flake check
 ```
 
 ## Maintainer

--- a/nix/README.md
+++ b/nix/README.md
@@ -167,7 +167,7 @@ nix develop
 # Build package
 nix build
 
-# Run with checks
+# Run checks (build + tests)
 nix flake check
 ```
 

--- a/nix/README.md
+++ b/nix/README.md
@@ -1,6 +1,6 @@
-# Nix Packaging for Ratty
+# Nix Packaging
 
-This flake provides a Nix package for [ratty](https://github.com/orhun/ratty), a GPU-rendered terminal emulator with inline 3D graphics.
+This flake provides a Nix package for [Ratty](https://github.com/orhun/ratty), a GPU-rendered terminal emulator with inline 3D graphics.
 
 ## Supported Systems
 
@@ -85,7 +85,7 @@ Add ratty to your system packages with optional declarative configuration:
 
 This will:
 
-- Install the ratty package
+- Install the Ratty package
 - Write configuration to `/etc/ratty/ratty.toml` (only when `settings` is non-empty)
 - Wrap the binary to use `--config-file /etc/ratty/ratty.toml` (only when `settings` is non-empty)
 
@@ -137,9 +137,9 @@ For user-level configuration without root:
 
 This will:
 
-- Install the ratty package to your user profile
+- Install the Ratty package to your user profile
 - Write configuration to `$XDG_CONFIG_HOME/ratty/ratty.toml` (typically `~/.config/ratty/ratty.toml`) (only when `settings` is non-empty)
-- ratty discovers this path automatically
+- Ratty discovers this path automatically
 
 ## Module Options
 
@@ -147,8 +147,8 @@ Both `nixosModules.default` and `homeManagerModules.default` expose:
 
 | Option                    | Type    | Default                        | Description                           |
 | ------------------------- | ------- | ------------------------------ | ------------------------------------- |
-| `programs.ratty.enable`   | bool    | `false`                        | Enable ratty installation             |
-| `programs.ratty.package`  | package | `self.packages.<system>.ratty` | The ratty package to use              |
+| `programs.ratty.enable`   | bool    | `false`                        | Enable Ratty installation             |
+| `programs.ratty.package`  | package | `self.packages.<system>.ratty` | The Ratty package to use              |
 | `programs.ratty.settings` | attrset | `{}`                           | Configuration written to `ratty.toml` |
 
 ## Package Architecture

--- a/nix/README.md
+++ b/nix/README.md
@@ -1,0 +1,169 @@
+# Nix Packaging for Ratty
+
+This flake provides a Nix package for [ratty](https://github.com/orhun/ratty), a GPU-rendered terminal emulator with inline 3D graphics.
+
+## Quick Start
+
+### Direct usage
+
+```bash
+# Run directly
+nix run github:DarthPJB/ratty
+
+# Install to profile
+nix profile install github:DarthPJB/ratty
+```
+
+### As a flake input
+
+```nix
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    ratty.url = "github:DarthPJB/ratty";
+  };
+
+  outputs = { nixpkgs, ratty, ... }: {
+    # Use in your configuration
+  };
+}
+```
+
+## NixOS System Configuration
+
+Add ratty to your system packages with optional declarative configuration:
+
+```nix
+# flake.nix
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    ratty.url = "github:DarthPJB/ratty";
+  };
+
+  outputs = { nixpkgs, ratty, ... }: {
+    nixosConfigurations.myhost = nixpkgs.lib.nixosSystem {
+      system = "x86_64-linux";
+      modules = [
+        ratty.nixosModules.default
+        ./configuration.nix
+      ];
+    };
+  };
+}
+```
+
+```nix
+# configuration.nix
+{
+  programs.ratty = {
+    enable = true;
+    settings = {
+      window = {
+        opacity = 0.9;
+        width = 1200;
+        height = 800;
+      };
+      shell = {
+        program = "zsh";
+      };
+      font = {
+        family = "JetBrains Mono";
+        size = 14;
+      };
+    };
+  };
+}
+```
+
+This will:
+- Install the ratty package
+- Write configuration to `/etc/ratty/ratty.toml`
+- Wrap the binary to use `--config-file /etc/ratty/ratty.toml`
+
+## Home Manager Configuration
+
+For user-level configuration without root:
+
+```nix
+# flake.nix
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    home-manager.url = "github:nix-community/home-manager";
+    ratty.url = "github:DarthPJB/ratty";
+  };
+
+  outputs = { nixpkgs, home-manager, ratty, ... }: {
+    homeConfigurations.myuser = home-manager.lib.homeManagerConfiguration {
+      pkgs = nixpkgs.legacyPackages.x86_64-linux;
+      modules = [
+        ratty.homeManagerModules.default
+        ./home.nix
+      ];
+    };
+  };
+}
+```
+
+```nix
+# home.nix
+{
+  programs.ratty = {
+    enable = true;
+    settings = {
+      window = {
+        opacity = 0.85;
+      };
+      shell = {
+        program = "fish";
+      };
+      theme = {
+        foreground = "#c0caf5";
+        background = "#1a1b26";
+      };
+    };
+  };
+}
+```
+
+This will:
+- Install the ratty package to your user profile
+- Write configuration to `$XDG_CONFIG_HOME/ratty/ratty.toml` (typically `~/.config/ratty/ratty.toml`)
+- ratty discovers this path automatically
+
+## Module Options
+
+Both `nixosModules.default` and `homeManagerModules.default` expose:
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `programs.ratty.enable` | bool | `false` | Enable ratty installation |
+| `programs.ratty.package` | package | `self.packages.<system>.ratty` | The ratty package to use |
+| `programs.ratty.settings` | attrset | `{}` | Configuration written to `ratty.toml` |
+
+## Package Architecture
+
+```
+flake.nix          — Orchestration, modules, devShell
+nix/default.nix    — Standalone package (upstreamable to nixpkgs)
+```
+
+The package definition in `nix/default.nix` is designed to be upstreamed to nixpkgs as `pkgs/by-name/ra/ratty/package.nix`. It takes only standard nixpkgs arguments — no flake-specific constructs.
+
+## Development
+
+```bash
+# Enter dev shell
+nix develop
+
+# Build package
+nix build
+
+# Run tests
+nix build .#ratty --check
+```
+
+## Maintainer
+
+- DarthPJB <darthpjb@gmail.com>

--- a/nix/README.md
+++ b/nix/README.md
@@ -84,6 +84,7 @@ Add ratty to your system packages with optional declarative configuration:
 ```
 
 This will:
+
 - Install the ratty package
 - Write configuration to `/etc/ratty/ratty.toml` (only when `settings` is non-empty)
 - Wrap the binary to use `--config-file /etc/ratty/ratty.toml` (only when `settings` is non-empty)
@@ -135,6 +136,7 @@ For user-level configuration without root:
 ```
 
 This will:
+
 - Install the ratty package to your user profile
 - Write configuration to `$XDG_CONFIG_HOME/ratty/ratty.toml` (typically `~/.config/ratty/ratty.toml`) (only when `settings` is non-empty)
 - ratty discovers this path automatically
@@ -143,11 +145,11 @@ This will:
 
 Both `nixosModules.default` and `homeManagerModules.default` expose:
 
-| Option | Type | Default | Description |
-|--------|------|---------|-------------|
-| `programs.ratty.enable` | bool | `false` | Enable ratty installation |
-| `programs.ratty.package` | package | `self.packages.<system>.ratty` | The ratty package to use |
-| `programs.ratty.settings` | attrset | `{}` | Configuration written to `ratty.toml` |
+| Option                    | Type    | Default                        | Description                           |
+| ------------------------- | ------- | ------------------------------ | ------------------------------------- |
+| `programs.ratty.enable`   | bool    | `false`                        | Enable ratty installation             |
+| `programs.ratty.package`  | package | `self.packages.<system>.ratty` | The ratty package to use              |
+| `programs.ratty.settings` | attrset | `{}`                           | Configuration written to `ratty.toml` |
 
 ## Package Architecture
 

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -19,7 +19,6 @@
   vulkan-loader,
   mesa,
   bash,
-  writeShellScript,
   makeWrapper,
   copyDesktopItems,
   makeDesktopItem,
@@ -43,26 +42,6 @@ let
     ]
   );
 
-  # Wrapper that ensures a working shell on NixOS.
-  # ratty resolves shell as: config.shell.program → $SHELL → /bin/bash.
-  # A config/ratty.toml in CWD (e.g. the upstream repo) may hardcode
-  # program = "/bin/bash" which does not exist on NixOS.  When no
-  # -e/--command flag is given the wrapper injects -e "$SHELL", bypassing
-  # the config entirely.
-  rattyWrapper = writeShellScript "ratty" ''
-    export SHELL='${bash}/bin/bash'
-    export LD_LIBRARY_PATH='${runtimeLibraryPath}'"''${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
-    ${lib.optionalString stdenv.isDarwin ''
-      export DYLD_LIBRARY_PATH='${runtimeLibraryPath}'"''${DYLD_LIBRARY_PATH:+:$DYLD_LIBRARY_PATH}"
-      export DYLD_FALLBACK_LIBRARY_PATH='${runtimeLibraryPath}'"''${DYLD_FALLBACK_LIBRARY_PATH:+:$DYLD_FALLBACK_LIBRARY_PATH}"
-    ''}
-    for _arg in "$@"; do
-      if [ "$_arg" = "-e" ] || [ "$_arg" = "--command" ]; then
-        exec @out@/bin/.ratty-unwrapped "$@"
-      fi
-    done
-    exec @out@/bin/.ratty-unwrapped -e "$SHELL" "$@"
-  '';
 in
 rustPlatform.buildRustPackage rec {
   pname = "ratty";
@@ -120,10 +99,33 @@ rustPlatform.buildRustPackage rec {
     install -Dm644 website/assets/images/ratty-logo.png \
       $out/share/icons/hicolor/512x512/apps/ratty.png
 
-    # Install wrapper script
-    mv $out/bin/ratty $out/bin/.ratty-unwrapped
-    install -Dm755 ${rattyWrapper} $out/bin/ratty
-    substituteInPlace $out/bin/ratty --subst-var-by out $out
+    # Use wrapProgram for env var management (idiomatic nixpkgs).
+    # Handles SHELL, LD_LIBRARY_PATH, and Darwin DYLD_* paths.
+    wrapProgram $out/bin/ratty \
+      --set SHELL '${bash}/bin/bash' \
+      --prefix LD_LIBRARY_PATH : '${runtimeLibraryPath}' \
+      ${lib.optionalString stdenv.isDarwin ''
+        --prefix DYLD_LIBRARY_PATH : '${runtimeLibraryPath}' \
+        --prefix DYLD_FALLBACK_LIBRARY_PATH : '${runtimeLibraryPath}' \
+      ''}
+
+    # Thin wrapper for conditional -e "$SHELL" injection.
+    # ratty resolves shell as: config.shell.program → $SHELL → /bin/bash.
+    # A config/ratty.toml in CWD may hardcode "/bin/bash" which does not
+    # exist on NixOS.  When no -e/--command flag is given, inject
+    # -e "$SHELL" to bypass any stale CWD config.
+    # NOTE: cannot use --add-flags unconditionally because clap's
+    # num_args=1.. would treat a second -e as a command argument.
+    mv $out/bin/ratty $out/bin/.ratty-env-wrapped
+    makeWrapper $out/bin/.ratty-env-wrapped $out/bin/ratty \
+      --run '''
+        for _arg in "$@"; do
+          if [ "$_arg" = "-e" ] || [ "$_arg" = "--command" ]; then
+            exec ${placeholder "out"}/bin/.ratty-env-wrapped "$@"
+          fi
+        done
+        exec ${placeholder "out"}/bin/.ratty-env-wrapped -e "${bash}/bin/bash" "$@"
+      '''
   '';
 
   meta = {

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -4,7 +4,7 @@
 {
   lib,
   stdenv,
-  rustPlatform,
+  craneLib,
   pkg-config,
   fontconfig,
   udev,
@@ -42,20 +42,54 @@ let
     ]
   );
 
+  # Common arguments shared between buildDepsOnly and buildPackage.
+  # buildDepsOnly uses a filtered source (only cargo files) to maximize
+  # cache hit rate — dependency hashes don't change when assets/docs change.
+  commonArgs = {
+    pname = "ratty";
+    version = "0.4.1";
+
+    src = craneLib.cleanCargoSource ../.;
+
+    nativeBuildInputs = [
+      pkg-config
+      makeWrapper
+      copyDesktopItems
+    ];
+
+    buildInputs =
+      lib.optionals stdenv.isLinux [
+        fontconfig
+        udev
+        wayland
+        libxkbcommon
+        libxcb
+        libx11
+        libxcursor
+        libxi
+        libxrandr
+        libxext
+        vulkan-loader
+        mesa
+      ]
+      ++ darwinFrameworks;
+
+    cargoLock = ../Cargo.lock;
+  };
+
+  # Build only the dependencies — this is the key caching layer.
+  # Subsequent builds reuse these artifacts as long as Cargo.lock
+  # and dependency code remain unchanged.
+  cargoArtifacts = craneLib.buildDepsOnly commonArgs;
+
 in
-rustPlatform.buildRustPackage rec {
-  pname = "ratty";
-  version = "0.3.0";
+# Build the full package, reusing cached dependency artifacts.
+craneLib.buildPackage (commonArgs // {
+  inherit cargoArtifacts;
 
+  # The full source (including assets, config, website) is needed for
+  # postInstall below.  buildDepsOnly already handled the filtered source.
   src = ../.;
-
-  cargoLock.lockFile = ../Cargo.lock;
-
-  nativeBuildInputs = [
-    pkg-config
-    makeWrapper
-    copyDesktopItems
-  ];
 
   desktopItems = [
     (makeDesktopItem {
@@ -73,34 +107,17 @@ rustPlatform.buildRustPackage rec {
     })
   ];
 
-  buildInputs =
-    lib.optionals stdenv.isLinux [
-      fontconfig
-      udev
-      wayland
-      libxkbcommon
-      libxcb
-      libx11
-      libxcursor
-      libxi
-      libxrandr
-      libxext
-      vulkan-loader
-      mesa
-    ]
-    ++ darwinFrameworks;
-
   # Assets are embedded at compile time via rust-embed.
   # Copy them to $out/share for reference and custom model discovery fallback.
   postInstall = ''
+    # Step 1: Copy assets
     mkdir -p $out/share/ratty
     cp -r assets/objects $out/share/ratty/
     install -Dm644 config/ratty.toml $out/share/ratty/ratty.toml
     install -Dm644 website/assets/images/ratty-logo.png \
       $out/share/icons/hicolor/512x512/apps/ratty.png
 
-    # Use wrapProgram for env var management (idiomatic nixpkgs).
-    # Handles SHELL, LD_LIBRARY_PATH, and Darwin DYLD_* paths.
+    # Step 2: wrapProgram for env var management
     wrapProgram $out/bin/ratty \
       --set SHELL '${bash}/bin/bash' \
       --prefix LD_LIBRARY_PATH : '${runtimeLibraryPath}' \
@@ -109,13 +126,7 @@ rustPlatform.buildRustPackage rec {
         --prefix DYLD_FALLBACK_LIBRARY_PATH : '${runtimeLibraryPath}' \
       ''}
 
-    # Thin wrapper for conditional -e "$SHELL" injection.
-    # ratty resolves shell as: config.shell.program → $SHELL → /bin/bash.
-    # A config/ratty.toml in CWD may hardcode "/bin/bash" which does not
-    # exist on NixOS.  When no -e/--command flag is given, inject
-    # -e "$SHELL" to bypass any stale CWD config.
-    # NOTE: cannot use --add-flags unconditionally because clap's
-    # num_args=1.. would treat a second -e as a command argument.
+    # Step 3: Thin wrapper for conditional -e "$SHELL" injection
     mv $out/bin/ratty $out/bin/.ratty-env-wrapped
     makeWrapper $out/bin/.ratty-env-wrapped $out/bin/ratty \
       --run '''
@@ -136,4 +147,4 @@ rustPlatform.buildRustPackage rec {
     mainProgram = "ratty";
     platforms = lib.platforms.unix;
   };
-}
+})

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -42,6 +42,17 @@ let
     ]
   );
 
+  # Shell script injected into the wrapper's --run argument.
+  # Defined here to avoid nested ''…'' string issues in postInstall.
+  runScript = ''
+    for _arg in "$@"; do
+      if [ "$_arg" = "-e" ] || [ "$_arg" = "--command" ]; then
+        exec ${placeholder "out"}/bin/.ratty-env-wrapped "$@"
+      fi
+    done
+    exec ${placeholder "out"}/bin/.ratty-env-wrapped -e "${bash}/bin/bash" "$@"
+  '';
+
   # Common arguments shared between buildDepsOnly and buildPackage.
   # buildDepsOnly uses a filtered source (only cargo files) to maximize
   # cache hit rate — dependency hashes don't change when assets/docs change.
@@ -126,17 +137,12 @@ craneLib.buildPackage (commonArgs // {
         --prefix DYLD_FALLBACK_LIBRARY_PATH : '${runtimeLibraryPath}' \
       ''}
 
-    # Step 3: Thin wrapper for conditional -e "$SHELL" injection
+    # Step 3: Thin wrapper for conditional -e "$SHELL" injection.
+    # The --run script is defined as a separate Nix string to avoid
+    # the nested double-tick problem (Nix does not support nested double-tick strings).
     mv $out/bin/ratty $out/bin/.ratty-env-wrapped
     makeWrapper $out/bin/.ratty-env-wrapped $out/bin/ratty \
-      --run ''
-        for _arg in "$@"; do
-          if [ "$_arg" = "-e" ] || [ "$_arg" = "--command" ]; then
-            exec ${placeholder "out"}/bin/.ratty-env-wrapped "$@"
-          fi
-        done
-        exec ${placeholder "out"}/bin/.ratty-env-wrapped -e "${bash}/bin/bash" "$@"
-      ''
+      --run "${runScript}"
   '';
 
   meta = {

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -6,7 +6,6 @@
   stdenv,
   rustPlatform,
   pkg-config,
-  alsa-lib,
   fontconfig,
   udev,
   wayland,
@@ -97,7 +96,6 @@ rustPlatform.buildRustPackage rec {
 
   buildInputs =
     lib.optionals stdenv.isLinux [
-      alsa-lib
       fontconfig
       udev
       wayland

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -129,14 +129,14 @@ craneLib.buildPackage (commonArgs // {
     # Step 3: Thin wrapper for conditional -e "$SHELL" injection
     mv $out/bin/ratty $out/bin/.ratty-env-wrapped
     makeWrapper $out/bin/.ratty-env-wrapped $out/bin/ratty \
-      --run '''
+      --run ''
         for _arg in "$@"; do
           if [ "$_arg" = "-e" ] || [ "$_arg" = "--command" ]; then
-            exec '''$out'''/bin/.ratty-env-wrapped "$@"
+            exec ${placeholder "out"}/bin/.ratty-env-wrapped "$@"
           fi
         done
-        exec '''$out'''/bin/.ratty-env-wrapped -e "'''${bash}'''/bin/bash" "$@"
-      '''
+        exec ${placeholder "out"}/bin/.ratty-env-wrapped -e "${bash}/bin/bash" "$@"
+      ''
   '';
 
   meta = {

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -142,7 +142,7 @@ craneLib.buildPackage (commonArgs // {
     # the nested double-tick problem (Nix does not support nested double-tick strings).
     mv $out/bin/ratty $out/bin/.ratty-env-wrapped
     makeWrapper $out/bin/.ratty-env-wrapped $out/bin/ratty \
-      --run "${runScript}"
+      --run '${runScript}'
   '';
 
   meta = {

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -121,10 +121,10 @@ rustPlatform.buildRustPackage rec {
       --run '''
         for _arg in "$@"; do
           if [ "$_arg" = "-e" ] || [ "$_arg" = "--command" ]; then
-            exec ${placeholder "out"}/bin/.ratty-env-wrapped "$@"
+            exec '''$out'''/bin/.ratty-env-wrapped "$@"
           fi
         done
-        exec ${placeholder "out"}/bin/.ratty-env-wrapped -e "${bash}/bin/bash" "$@"
+        exec '''$out'''/bin/.ratty-env-wrapped -e "'''${bash}'''/bin/bash" "$@"
       '''
   '';
 

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -22,7 +22,10 @@
   bash,
   writeShellScript,
   makeWrapper,
-  darwin,
+  copyDesktopItems,
+  makeDesktopItem,
+  # Darwin frameworks — passed via callPackage override from flake
+  darwinFrameworks ? [ ],
 }:
 
 let
@@ -30,9 +33,14 @@ let
     lib.optionals stdenv.isLinux [
       vulkan-loader
       mesa
+      fontconfig
       libxkbcommon
       libx11
       libxcb
+      libxcursor
+      libxi
+      libxrandr
+      libxext
     ]
   );
 
@@ -45,6 +53,10 @@ let
   rattyWrapper = writeShellScript "ratty" ''
     export SHELL='${bash}/bin/bash'
     export LD_LIBRARY_PATH='${runtimeLibraryPath}'"''${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+    ${lib.optionalString stdenv.isDarwin ''
+      export DYLD_LIBRARY_PATH='${runtimeLibraryPath}'"''${DYLD_LIBRARY_PATH:+:$DYLD_LIBRARY_PATH}"
+      export DYLD_FALLBACK_LIBRARY_PATH='${runtimeLibraryPath}'"''${DYLD_FALLBACK_LIBRARY_PATH:+:$DYLD_FALLBACK_LIBRARY_PATH}"
+    ''}
     for _arg in "$@"; do
       if [ "$_arg" = "-e" ] || [ "$_arg" = "--command" ]; then
         exec @out@/bin/.ratty-unwrapped "$@"
@@ -64,6 +76,23 @@ rustPlatform.buildRustPackage rec {
   nativeBuildInputs = [
     pkg-config
     makeWrapper
+    copyDesktopItems
+  ];
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "ratty";
+      desktopName = "Ratty";
+      comment = "A GPU-rendered terminal emulator with inline 3D graphics";
+      exec = "ratty";
+      terminal = false;
+      categories = [
+        "System"
+        "TerminalEmulator"
+        "Utility"
+      ];
+      icon = "ratty";
+    })
   ];
 
   buildInputs =
@@ -82,19 +111,7 @@ rustPlatform.buildRustPackage rec {
       vulkan-loader
       mesa
     ]
-    ++ lib.optionals stdenv.isDarwin (
-      with darwin.apple_sdk.frameworks;
-      [
-        Cocoa
-        CoreFoundation
-        CoreGraphics
-        CoreText
-        CoreVideo
-        Metal
-        QuartzCore
-        libiconv
-      ]
-    );
+    ++ darwinFrameworks;
 
   # Assets are embedded at compile time via rust-embed.
   # Copy them to $out/share for reference and custom model discovery fallback.
@@ -102,6 +119,8 @@ rustPlatform.buildRustPackage rec {
     mkdir -p $out/share/ratty
     cp -r assets/objects $out/share/ratty/
     install -Dm644 config/ratty.toml $out/share/ratty/ratty.toml
+    install -Dm644 website/assets/images/ratty-logo.png \
+      $out/share/icons/hicolor/512x512/apps/ratty.png
 
     # Install wrapper script
     mv $out/bin/ratty $out/bin/.ratty-unwrapped
@@ -113,7 +132,7 @@ rustPlatform.buildRustPackage rec {
     description = "GPU-rendered terminal emulator with inline 3D graphics";
     homepage = "https://github.com/orhun/ratty";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ ];
+    maintainers = [ "daniejbolt" ];
     mainProgram = "ratty";
     platforms = lib.platforms.unix;
   };

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -1,0 +1,120 @@
+# Standalone package definition for ratty.
+# Designed to be upstreamed to nixpkgs as pkgs/by-name/ra/ratty/package.nix.
+# Takes only standard nixpkgs arguments — no flake-specific constructs.
+{
+  lib,
+  stdenv,
+  rustPlatform,
+  pkg-config,
+  alsa-lib,
+  fontconfig,
+  udev,
+  wayland,
+  libxkbcommon,
+  libxcb,
+  libx11,
+  libxcursor,
+  libxi,
+  libxrandr,
+  libxext,
+  vulkan-loader,
+  mesa,
+  bash,
+  writeShellScript,
+  makeWrapper,
+  darwin,
+}:
+
+let
+  runtimeLibraryPath = lib.makeLibraryPath (
+    lib.optionals stdenv.isLinux [
+      vulkan-loader
+      mesa
+      libxkbcommon
+      libx11
+      libxcb
+    ]
+  );
+
+  # Wrapper that ensures a working shell on NixOS.
+  # ratty resolves shell as: config.shell.program → $SHELL → /bin/bash.
+  # A config/ratty.toml in CWD (e.g. the upstream repo) may hardcode
+  # program = "/bin/bash" which does not exist on NixOS.  When no
+  # -e/--command flag is given the wrapper injects -e "$SHELL", bypassing
+  # the config entirely.
+  rattyWrapper = writeShellScript "ratty" ''
+    export SHELL='${bash}/bin/bash'
+    export LD_LIBRARY_PATH='${runtimeLibraryPath}'"''${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+    for _arg in "$@"; do
+      if [ "$_arg" = "-e" ] || [ "$_arg" = "--command" ]; then
+        exec @out@/bin/.ratty-unwrapped "$@"
+      fi
+    done
+    exec @out@/bin/.ratty-unwrapped -e "$SHELL" "$@"
+  '';
+in
+rustPlatform.buildRustPackage rec {
+  pname = "ratty";
+  version = "0.3.0";
+
+  src = ../.;
+
+  cargoLock.lockFile = ../Cargo.lock;
+
+  nativeBuildInputs = [
+    pkg-config
+    makeWrapper
+  ];
+
+  buildInputs =
+    lib.optionals stdenv.isLinux [
+      alsa-lib
+      fontconfig
+      udev
+      wayland
+      libxkbcommon
+      libxcb
+      libx11
+      libxcursor
+      libxi
+      libxrandr
+      libxext
+      vulkan-loader
+      mesa
+    ]
+    ++ lib.optionals stdenv.isDarwin (
+      with darwin.apple_sdk.frameworks;
+      [
+        Cocoa
+        CoreFoundation
+        CoreGraphics
+        CoreText
+        CoreVideo
+        Metal
+        QuartzCore
+        libiconv
+      ]
+    );
+
+  # Assets are embedded at compile time via rust-embed.
+  # Copy them to $out/share for reference and custom model discovery fallback.
+  postInstall = ''
+    mkdir -p $out/share/ratty
+    cp -r assets/objects $out/share/ratty/
+    install -Dm644 config/ratty.toml $out/share/ratty/ratty.toml
+
+    # Install wrapper script
+    mv $out/bin/ratty $out/bin/.ratty-unwrapped
+    install -Dm755 ${rattyWrapper} $out/bin/ratty
+    substituteInPlace $out/bin/ratty --subst-var-by out $out
+  '';
+
+  meta = {
+    description = "GPU-rendered terminal emulator with inline 3D graphics";
+    homepage = "https://github.com/orhun/ratty";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ ];
+    mainProgram = "ratty";
+    platforms = lib.platforms.unix;
+  };
+}


### PR DESCRIPTION
I am a user of NixOS a nightmarish hellscape of declarative builds and absolute mathematical derivations.

It's a odd place, but for the purposes of easily using your software the inclusion of a flake.nix build-pattern allows me great ease of consumption.

As such, I've added (and will do my best to maintain) the flake.nix required to build under the Nix Package manager; and hopefully wish that you will accept this addition upstream.