### PR TITLE
fix: enable shading for all objects

### DIFF
--- a/src/systems.rs
+++ b/src/systems.rs
@@ -698,7 +698,7 @@ fn spawn_rgp_object(
                 *handles = Some((depth_key, mesh_handles.clone()));
                 mesh_handles
             };
-            let use_lighting = style.depth > 0.0;
+            let use_lighting = true;
             let [r, g, b] = match style.color {
                 Some([r, g, b]) => [r, g, b],
                 None => [255, 255, 255],


### PR DESCRIPTION
This fix enables shading for all objects instead of just objects with a non-zero `depth` property. The `use_lighting` variable is just always set to true now, I didn't remove it as in the future it could be used as is for adding a shading enable/disable toggle to the protocol.
