### PR TITLE
fix: use synthetic mouse events for scrolling in apps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3978,7 +3978,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4054,9 +4054,9 @@ dependencies = [
 
 [[package]]
 name = "parley_ratatui"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e14550b93e5648c33d1f54208a47f852ce95babbf96349d6fcd4f35779934455"
+checksum = "3c7068b94ff255cdfa17af62555934b5b13bf5903cd49a224cc1f403ec44f68b"
 dependencies = [
  "naga 28.0.0",
  "parley",

--- a/src/keyboard.rs
+++ b/src/keyboard.rs
@@ -9,7 +9,7 @@ use bevy::prelude::*;
 use arboard::Clipboard;
 
 use crate::config::{AppConfig, BindingAction, FontConfig, KeyBindingConfig};
-use crate::mouse::TerminalSelection;
+use crate::mouse::{TerminalSelection, encode_mouse_wheel};
 use crate::runtime::TerminalRuntime;
 use crate::scene::{
     MobiusTransition, TerminalPlaneView, TerminalPlaneWarp, TerminalPresentation,
@@ -379,10 +379,6 @@ pub fn handle_keyboard_input(
                 | BindingAction::ScrollPageDown
                 | BindingAction::ScrollUp
                 | BindingAction::ScrollDown => {
-                    if params.runtime.parser.screen().alternate_screen() {
-                        continue;
-                    }
-
                     let amount = match action {
                         BindingAction::ScrollPageUp | BindingAction::ScrollPageDown => {
                             usize::from(params.terminal.rows.saturating_sub(1).max(1))
@@ -396,16 +392,32 @@ pub fn handle_keyboard_input(
                         _ => unreachable!(),
                     };
 
-                    let screen = params.runtime.parser.screen_mut();
-                    let current = screen.scrollback();
-                    let next = if direction.is_positive() {
-                        current.saturating_add(amount)
+                    let mouse_mode = params.runtime.parser.screen().mouse_protocol_mode();
+                    if params.presentation.mode == TerminalPresentationMode::Flat2d
+                        && mouse_mode != vt100::MouseProtocolMode::None
+                    {
+                        let encoding = params.runtime.parser.screen().mouse_protocol_encoding();
+                        let (row, col) = params.runtime.parser.screen().cursor_position();
+                        let cell = UVec2::new(col as u32, row as u32);
+                        for _ in 0..amount {
+                            params.runtime.write_input(&encode_mouse_wheel(
+                                cell,
+                                direction.is_positive(),
+                                encoding,
+                            ));
+                        }
                     } else {
-                        current.saturating_sub(amount)
-                    };
-                    screen.set_scrollback(next);
-                    params.selection.clear();
-                    params.redraw.request();
+                        let screen = params.runtime.parser.screen_mut();
+                        let current = screen.scrollback();
+                        let next = if direction.is_positive() {
+                            current.saturating_add(amount)
+                        } else {
+                            current.saturating_sub(amount)
+                        };
+                        screen.set_scrollback(next);
+                        params.selection.clear();
+                        params.redraw.request();
+                    }
                     continue;
                 }
                 BindingAction::IncreaseWarp | BindingAction::DecreaseWarp => {

--- a/src/mouse.rs
+++ b/src/mouse.rs
@@ -494,6 +494,14 @@ fn encode_mouse_event(
     }
 }
 
+pub(crate) fn encode_mouse_wheel(
+    cell: UVec2,
+    up: bool,
+    encoding: MouseProtocolEncoding,
+) -> Vec<u8> {
+    encode_mouse_event(cell, if up { 64 } else { 65 }, false, encoding)
+}
+
 fn position_to_cell(
     position: Vec2,
     viewport: &TerminalViewport,


### PR DESCRIPTION
This commit routes keyboard scroll actions through synthetic mouse wheel events
when the foreground application has mouse mode enabled.

Ratty's local scrollback is based on `vt100::Screen::set_scrollback(...)`,
which works for scrollback Ratty actually owns. But apps like zellij already
manage their own scrolling behavior and respond correctly to
forwarded mouse wheel input.

Reusing that same path for keyboard scroll bindings makes Alt+Up/Down
behave consistently in those applications instead of relying on Ratty-local scrollback.

See #49
