### PR TITLE
feat: support Windows via OSC envelope

### DIFF
--- a/protocols/graphics.md
+++ b/protocols/graphics.md
@@ -19,6 +19,13 @@ but it is designed for Ratty's inline object layer and 3D renderer.
 
 ## Transport
 
+RGP sequences are framed by a standard terminal escape envelope. Two
+envelopes are defined — **APC** (the primary) and **OSC** (the
+compatibility alternative). Both carry identical body grammar; only the
+framing bytes differ.
+
+### APC Envelope (primary)
+
 Ratty Graphics Protocol uses [APC] (Application Program Command):
 
 ```text
@@ -31,6 +38,58 @@ Where:
 - `g` means graphics
 - [`<verb>`](#verbs) selects the operation
 - additional fields are semicolon-separated `key=value` pairs
+
+### OSC Envelope (compatibility)
+
+On platforms where the parent terminal cannot transit APC sequences
+end-to-end, the same body can be carried inside an [OSC] (Operating
+System Command) envelope using private number **8901**:
+
+```text
+ESC ] 8901;ratty;g;<verb>[;<key=value>...] ESC \
+```
+
+The body after `8901;` is byte-identical to the APC body (starting from
+`ratty;g;`). The OSC envelope additionally accepts **BEL** (`0x07`) as
+an alternative terminator, following the historic xterm convention.
+
+#### When to use OSC
+
+The OSC envelope exists for one reason: **Windows ConPTY** silently
+consumes APC sequences before the hosting terminal can see them. This
+is true even with the newer `PSEUDOCONSOLE_INHERIT_CURSOR` plumbing in
+[Microsoft Terminal] 1.22+. Applications that may run under ConPTY
+(cmd, PowerShell, Windows Terminal, SSH into Windows) should emit the
+OSC envelope so that Ratty can parse the sequences.
+
+Applications running on platforms without this limitation (direct PTY on
+Linux/macOS, or inside Ratty's own PTY) should prefer the APC envelope.
+
+#### Why OSC 8901
+
+OSC 8901 was chosen as a 4-digit private number with no known assignment
+in any surveyed terminal ecosystem. Numbers to avoid:
+
+| Number(s) | Owner |
+|-----------|-------|
+| 0–12, 52, 104, 110–119 | conhost / xterm standard |
+| 99 | Kitty notifications |
+| 133 | FinalTerm / Warp prompt marks |
+| 633 | VS Code shell integration |
+| 777 | urxvt |
+| 1337 | iTerm2 image protocol |
+| 9001 | `WTAction` in Microsoft Terminal's `OscActionCodes` enum |
+
+OSC dispatching in conhost is numeric-first — the `;ratty;` qualifier
+after the number does not prevent a terminal from consuming the whole
+sequence as its own action. A unique number avoids collisions entirely.
+
+#### Support reply
+
+The support reply (`s` verb) is always sent using the APC envelope,
+regardless of which envelope the query arrived in, because the reply
+travels from Ratty to the application over the PTY read path where APC
+is safe.
 
 ## Model
 

--- a/src/inline.rs
+++ b/src/inline.rs
@@ -10,12 +10,24 @@ use vt100::Callbacks;
 use crate::kitty::{KittyOperation, KittyParserState, refresh_kitty_placeholder_anchors};
 use crate::model::{ObjectSource, load_object_source, load_object_source_from_bytes};
 use crate::rgp::{
-    RgpOperation, RgpPlacementStyle, RgpPlacementUpdate, RgpRegisterSource,
+    RGP_OSC_START, RgpOperation, RgpPlacementStyle, RgpPlacementUpdate, RgpRegisterSource,
     consume_sequence as consume_rgp_sequence, support_reply,
 };
 const APC_START: &[u8] = b"\x1b_";
 const ST: &[u8] = b"\x1b\\";
 const C1_ST: u8 = 0x9c;
+const BEL: u8 = 0x07;
+
+/// Envelope variants we slice out of the PTY byte stream for RGP/Kitty
+/// dispatch. APC catches any APC sequence (Kitty graphics, RGP); the OSC
+/// variant is specifically pre-filtered to our RGP prefix so unrelated OSC
+/// traffic (window titles, hyperlinks, prompt marks) passes straight to
+/// vt100.
+#[derive(Clone, Copy)]
+enum EnvelopeKind {
+    Apc,
+    RgpOsc,
+}
 
 /// Marker for 2D inline object sprites.
 #[derive(Component)]
@@ -44,6 +56,11 @@ pub struct TerminalInlineObjects {
     last_rows: u16,
     pub(crate) objects: HashMap<u32, InlineObject>,
     pub(crate) anchors: HashMap<u32, InlineAnchor>,
+    /// Object ids whose `Place` arrived inside the current PTY chunk.
+    /// Drained by [`Self::take_placed_this_chunk`] after each chunk so
+    /// the per-chunk scroll-tracking pass can exempt them — their `row`
+    /// is already in the post-chunk screen frame, not the pre-chunk one.
+    placed_this_chunk: std::collections::HashSet<u32>,
 }
 
 impl TerminalInlineObjects {
@@ -58,9 +75,8 @@ impl TerminalInlineObjects {
 
         let mut cursor = 0;
         loop {
-            let Some(start_offset) = self.pending_bytes[cursor..]
-                .windows(APC_START.len())
-                .position(|window| window == APC_START)
+            let Some((start_offset, kind)) =
+                find_next_envelope(&self.pending_bytes[cursor..])
             else {
                 if cursor < self.pending_bytes.len() {
                     parser.process(&normalize_hvp_sequences(&self.pending_bytes[cursor..]));
@@ -73,14 +89,31 @@ impl TerminalInlineObjects {
                 parser.process(&normalize_hvp_sequences(&self.pending_bytes[cursor..start]));
             }
 
-            let payload_start = start + APC_START.len();
-            let Some(end) = apc_end(&self.pending_bytes, payload_start) else {
+            let header_len = match kind {
+                EnvelopeKind::Apc => APC_START.len(),
+                EnvelopeKind::RgpOsc => RGP_OSC_START.len(),
+            };
+            let payload_start = start + header_len;
+            let end_opt = match kind {
+                EnvelopeKind::Apc => apc_end(&self.pending_bytes, payload_start),
+                EnvelopeKind::RgpOsc => osc_end(&self.pending_bytes, payload_start),
+            };
+            let Some(end) = end_opt else {
+                // Envelope spans the chunk boundary — keep these bytes
+                // pending and wait for the next read.
                 self.pending_bytes.drain(..start);
                 return replies;
             };
             let sequence = self.pending_bytes[start..end].to_vec();
-            let (handled, reply) =
-                self.handle_apc_sequence(&sequence, parser.screen().cursor_position());
+            let (handled, reply) = match kind {
+                EnvelopeKind::Apc => {
+                    self.handle_apc_sequence(&sequence, parser.screen().cursor_position())
+                }
+                EnvelopeKind::RgpOsc => match self.handle_rgp_sequence(&sequence) {
+                    Some(reply) => (true, reply),
+                    None => (false, None),
+                },
+            };
             if let Some(reply) = reply {
                 replies.push(reply);
             }
@@ -108,12 +141,38 @@ impl TerminalInlineObjects {
     }
 
     /// Applies upward scroll to anchored objects.
+    ///
+    /// This unconditionally scrolls every anchor. Prefer
+    /// [`apply_scroll_to_existing`] when the caller can identify which
+    /// anchors existed *before* the chunk that triggered the scroll —
+    /// otherwise a `Place` arriving in the same PTY chunk as a clear +
+    /// repaint will be evicted by the very scroll that chunk produced.
     pub fn apply_scroll(&mut self, rows_scrolled: u16) {
+        self.apply_scroll_to_existing(rows_scrolled, None);
+    }
+
+    /// Like [`apply_scroll`], but only mutates anchors whose object id is
+    /// in `existing_ids`. Anchors added during the chunk that caused the
+    /// scroll (typically by an in-chunk `Place`) are left untouched —
+    /// their row was emitted relative to the post-scroll screen state.
+    pub fn apply_scroll_to_existing(
+        &mut self,
+        rows_scrolled: u16,
+        existing_ids: Option<&std::collections::HashSet<u32>>,
+    ) {
         if rows_scrolled == 0 || self.anchors.is_empty() {
             return;
         }
 
         self.anchors.retain(|object_id, anchor| {
+            if let Some(existing) = existing_ids
+                && !existing.contains(object_id)
+            {
+                // Anchor was added during the chunk that just produced
+                // this scroll diff — its row is already in the new
+                // coordinate space, do not double-apply.
+                return true;
+            }
             if self
                 .objects
                 .get(object_id)
@@ -149,7 +208,18 @@ impl TerminalInlineObjects {
 
     fn set_anchor(&mut self, object_id: u32, anchor: InlineAnchor) {
         self.anchors.insert(object_id, anchor);
+        self.placed_this_chunk.insert(object_id);
         self.dirty = true;
+    }
+
+    /// Drains the set of object ids whose `Place` arrived inside the
+    /// chunk currently being consumed. The caller (`pump_pty_output`)
+    /// uses this to exempt freshly-placed anchors from the chunk's
+    /// scroll diff — their `row` is emitted in post-chunk screen
+    /// coordinates, so applying the same chunk's scroll to them would
+    /// be a double-count.
+    pub fn take_placed_this_chunk(&mut self) -> std::collections::HashSet<u32> {
+        std::mem::take(&mut self.placed_this_chunk)
     }
 
     fn remove_object(&mut self, object_id: u32) {
@@ -487,6 +557,41 @@ fn apc_end(bytes: &[u8], payload_start: usize) -> Option<usize> {
             return Some(index + 2);
         }
         index += 1;
+    }
+}
+
+/// Scans for the OSC string terminator. xterm spec allows BEL, ST (`ESC \`),
+/// or C1 ST (`0x9c`). All three survive ConPTY in our tests.
+fn osc_end(bytes: &[u8], payload_start: usize) -> Option<usize> {
+    let mut index = payload_start;
+    loop {
+        if index >= bytes.len() {
+            return None;
+        }
+        if bytes[index] == BEL || bytes[index] == C1_ST {
+            return Some(index + 1);
+        }
+        if index + 1 < bytes.len() && bytes[index] == ST[0] && bytes[index + 1] == ST[1] {
+            return Some(index + 2);
+        }
+        index += 1;
+    }
+}
+
+/// Returns the byte offset of the next RGP envelope (APC or OSC RGP), and
+/// which envelope kind it is. Picks whichever appears first in the chunk;
+/// arbitrary OSC traffic that isn't RGP-prefixed is left for vt100.
+fn find_next_envelope(bytes: &[u8]) -> Option<(usize, EnvelopeKind)> {
+    let apc = bytes.windows(APC_START.len()).position(|w| w == APC_START);
+    let osc = bytes
+        .windows(RGP_OSC_START.len())
+        .position(|w| w == RGP_OSC_START);
+    match (apc, osc) {
+        (None, None) => None,
+        (Some(a), None) => Some((a, EnvelopeKind::Apc)),
+        (None, Some(o)) => Some((o, EnvelopeKind::RgpOsc)),
+        (Some(a), Some(o)) if a <= o => Some((a, EnvelopeKind::Apc)),
+        (Some(_), Some(o)) => Some((o, EnvelopeKind::RgpOsc)),
     }
 }
 

--- a/src/inline.rs
+++ b/src/inline.rs
@@ -75,8 +75,7 @@ impl TerminalInlineObjects {
 
         let mut cursor = 0;
         loop {
-            let Some((start_offset, kind)) =
-                find_next_envelope(&self.pending_bytes[cursor..])
+            let Some((start_offset, kind)) = find_next_envelope(&self.pending_bytes[cursor..])
             else {
                 if cursor < self.pending_bytes.len() {
                     parser.process(&normalize_hvp_sequences(&self.pending_bytes[cursor..]));

--- a/src/rgp.rs
+++ b/src/rgp.rs
@@ -2,10 +2,35 @@
 
 use base64::Engine as _;
 
-/// Ratty Graphics Protocol APC prefix.
+/// Ratty Graphics Protocol APC envelope prefix (`ESC _ ratty;g;`).
 pub const RGP_APC_START: &[u8] = b"\x1b_ratty;g;";
+
+/// Ratty Graphics Protocol OSC envelope prefix (`ESC ] 8901 ; ratty ; g ;`).
+///
+/// The OSC variant is used on platforms where the parent terminal can't
+/// transit APC sequences end-to-end — notably Windows ConPTY, which
+/// consumes APC silently regardless of the new "passthrough" plumbing in
+/// `microsoft/terminal` 1.22+.
+///
+/// OSC 8901 was chosen as a 4-digit private number with no known
+/// assignment in any surveyed ecosystem. Concrete numbers to avoid and
+/// why:
+///
+/// - 0,1,2,4,7,8,9,10,11,12,52,104,110-119 — recognised by conhost itself.
+/// - 99 — kitty notifications.
+/// - 133 — FinalTerm / Warp prompt marks.
+/// - 633 — VS Code shell integration.
+/// - 777 — urxvt.
+/// - 1337 — iTerm2 image protocol.
+/// - 9001 — `WTAction` in Microsoft Terminal's `OscActionCodes` enum
+///   (`src/terminal/parser/OutputStateMachineEngine.hpp`); dispatching is
+///   numeric-first, so `;ratty;` after the number does *not* prevent
+///   conhost from consuming the whole sequence as a WT action.
+pub const RGP_OSC_START: &[u8] = b"\x1b]8901;ratty;g;";
+
 const ST: &[u8] = b"\x1b\\";
 const C1_ST: u8 = 0x9c;
+const BEL: u8 = 0x07;
 
 /// Placement style for an RGP object.
 #[derive(Clone, Copy, Default)]
@@ -67,20 +92,40 @@ pub enum RgpRegisterSource {
     },
 }
 
-/// Consumes an RGP APC sequence.
+/// Consumes an RGP envelope (APC or OSC) and parses the inner body.
+///
+/// Both envelopes carry the same body grammar (`<verb>;<key=value>;...`)
+/// so they share the parser below.
 pub fn consume_sequence(sequence: &[u8]) -> Option<RgpOperation> {
-    if !sequence.starts_with(RGP_APC_START) {
-        return None;
-    }
-
-    let content_end = if sequence.ends_with(&[C1_ST]) {
-        sequence.len() - 1
-    } else if sequence.ends_with(ST) {
-        sequence.len() - 2
+    let (prefix_len, terminator_len) = if sequence.starts_with(RGP_APC_START) {
+        // APC body terminates with ST or C1 ST. BEL is not a legal APC
+        // terminator, so we deliberately don't accept it on the APC path.
+        let trailing = if sequence.ends_with(&[C1_ST]) {
+            1
+        } else if sequence.ends_with(ST) {
+            2
+        } else {
+            return None;
+        };
+        (RGP_APC_START.len(), trailing)
+    } else if sequence.starts_with(RGP_OSC_START) {
+        // OSC body can terminate with BEL, ST, or C1 ST. xterm's
+        // `ctlseqs` calls out BEL as the historic terminator; modern
+        // emitters tend to use ST. Accept all three.
+        let trailing = if sequence.ends_with(&[BEL]) || sequence.ends_with(&[C1_ST]) {
+            1
+        } else if sequence.ends_with(ST) {
+            2
+        } else {
+            return None;
+        };
+        (RGP_OSC_START.len(), trailing)
     } else {
         return None;
     };
-    let content = std::str::from_utf8(&sequence[RGP_APC_START.len()..content_end]).ok()?;
+
+    let content_end = sequence.len() - terminator_len;
+    let content = std::str::from_utf8(&sequence[prefix_len..content_end]).ok()?;
     let mut parts = content.split(';');
     let verb = parts.next()?;
     let mut id = None;

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -135,15 +135,28 @@ pub fn pump_pty_output(
                 } else {
                     None
                 };
+                // Snapshot anchor ids that existed BEFORE consuming this
+                // chunk. After consume, also collect ids whose `Place`
+                // fired inside the chunk — those rows are already
+                // expressed in post-chunk screen coordinates, so scroll
+                // would double-count. The scroll target is therefore
+                // `pre_anchor_ids \ placed_this_chunk`.
+                let pre_anchor_ids: std::collections::HashSet<u32> =
+                    inline_objects.anchors.keys().copied().collect();
                 let mut replies = inline_objects.consume_pty_output(&chunk, &mut runtime.parser);
                 replies.extend(runtime.parser.callbacks_mut().take_replies());
                 for reply in replies {
                     runtime.write_input(&reply);
                 }
+                let placed_this_chunk = inline_objects.take_placed_this_chunk();
                 if let Some(prev_rows) = prev_rows {
                     let next_rows = screen_rows(runtime.parser.screen());
                     let scrolled = infer_upward_scroll(&prev_rows, &next_rows);
-                    inline_objects.apply_scroll(scrolled);
+                    let eligible: std::collections::HashSet<u32> = pre_anchor_ids
+                        .difference(&placed_this_chunk)
+                        .copied()
+                        .collect();
+                    inline_objects.apply_scroll_to_existing(scrolled, Some(&eligible));
                 }
                 inline_objects.refresh_placeholder_anchors(runtime.parser.screen());
                 processed_output = true;

--- a/widget/src/lib.rs
+++ b/widget/src/lib.rs
@@ -176,7 +176,7 @@ impl<'a> RattyGraphic<'a> {
     /// Returns the RGP register sequence.
     pub fn register_sequence(&self) -> String {
         format!(
-            "\x1b_ratty;g;r;id={};fmt={};path={}\x1b\\",
+            "\x1b]8901;ratty;g;r;id={};fmt={};path={}\x1b\\",
             self.settings.id,
             self.settings.format.as_str(),
             self.settings.path
@@ -209,7 +209,7 @@ impl<'a> RattyGraphic<'a> {
             let chunk = &encoded[chunk_start..chunk_end];
             sequences.push(if index == 0 {
                 format!(
-                    "\x1b_ratty;g;r;id={};fmt={};source=payload;more={};name={};{}\x1b\\",
+                    "\x1b]8901;ratty;g;r;id={};fmt={};source=payload;more={};name={};{}\x1b\\",
                     self.settings.id,
                     self.settings.format.as_str(),
                     more,
@@ -218,7 +218,7 @@ impl<'a> RattyGraphic<'a> {
                 )
             } else {
                 format!(
-                    "\x1b_ratty;g;r;id={};fmt={};source=payload;more={};{}\x1b\\",
+                    "\x1b]8901;ratty;g;r;id={};fmt={};source=payload;more={};{}\x1b\\",
                     self.settings.id,
                     self.settings.format.as_str(),
                     more,
@@ -229,7 +229,7 @@ impl<'a> RattyGraphic<'a> {
 
         if sequences.is_empty() {
             sequences.push(format!(
-                "\x1b_ratty;g;r;id={};fmt={};source=payload;more=0;name={};\x1b\\",
+                "\x1b]8901;ratty;g;r;id={};fmt={};source=payload;more=0;name={};\x1b\\",
                 self.settings.id,
                 self.settings.format.as_str(),
                 name,
@@ -276,7 +276,7 @@ impl<'a> RattyGraphic<'a> {
         let center_row = area.y.saturating_add(area.height.saturating_sub(1) / 2);
         let center_col = area.x.saturating_add(area.width.saturating_sub(1) / 2);
         format!(
-            "\x1b_ratty;g;p;id={};row={};col={};w={};h={};animate={};scale={};depth={};color={};brightness={};px={};py={};pz={};rx={};ry={};rz={};sx={};sy={};sz={}\x1b\\",
+            "\x1b]8901;ratty;g;p;id={};row={};col={};w={};h={};animate={};scale={};depth={};color={};brightness={};px={};py={};pz={};rx={};ry={};rz={};sx={};sy={};sz={}\x1b\\",
             self.settings.id,
             center_row,
             center_col,
@@ -305,7 +305,7 @@ impl<'a> RattyGraphic<'a> {
     /// Returns the RGP update sequence.
     pub fn update_sequence(&self) -> String {
         format!(
-            "\x1b_ratty;g;u;id={};animate={};scale={};depth={};color={};brightness={};px={};py={};pz={};rx={};ry={};rz={};sx={};sy={};sz={}\x1b\\",
+            "\x1b]8901;ratty;g;u;id={};animate={};scale={};depth={};color={};brightness={};px={};py={};pz={};rx={};ry={};rz={};sx={};sy={};sz={}\x1b\\",
             self.settings.id,
             u8::from(self.settings.animate),
             self.settings.scale,
@@ -329,7 +329,7 @@ impl<'a> RattyGraphic<'a> {
 
     /// Returns the RGP delete sequence.
     pub fn delete_sequence(&self) -> String {
-        format!("\x1b_ratty;g;d;id={}\x1b\\", self.settings.id)
+        format!("\x1b]8901;ratty;g;d;id={}\x1b\\", self.settings.id)
     }
 
     /// Writes the RGP delete sequence to stdout.


### PR DESCRIPTION
## Summary

Adds OSC envelope (`ESC ] 8901 ; ratty ; g ; … ESC \`) as an alternative to the existing APC envelope for the Ratty Graphics Protocol, and fixes a related scroll-tracking false-positive. Together these unblock RGP-based widgets — including the bundled `big_rat`, `draw`, and `document` examples — on Windows. Fixes #67.

## Why

Windows ConPTY strips APC sequences (`ESC _ … ESC \`) before they reach the host process. Verified with a minimal `portable-pty`-backed probe: a child running `printf '\x1b_PROBE;hello=world\x1b\'` arrives at the PTY master with only the bash init CSIs (`\x1b[?9001h\x1b[?1004h`) — APC body and ST terminator gone. Equivalent OSC payloads at arbitrary numbers (1337, 9001, 99999, 52, 0) survive intact end-to-end.

This is structural in conhost, not a configuration issue:

- `PSEUDOCONSOLE_PASSTHROUGH_MODE` isn't a real public flag. The value `0x8` in current `winconpty.h` is `PSEUDOCONSOLE_GLYPH_WIDTH_GRAPHEMES` (not passthrough). The `#[allow(dead_code)]` constant in `portable-pty` traces back to a 2019 proposal that never shipped.
- Side-loading the latest `microsoft/terminal` v1.24 `conpty.dll` + `OpenConsole.exe` does not change the APC behavior (empirically tested). The 1.22 "passthrough" PR ([#17510](https://github.com/microsoft/terminal/pull/17510)) was an internal conhost refactor that enables conhost to render unrecognised sequences (Sixel) in its own renderer — not a forwarding feature for third-party hosts.
- OSC, by contrast, is preserved by conhost for any number it doesn't have a hardcoded handler for. Issue #67 has the full investigation.

## Changes

**`src/rgp.rs`** — adds `RGP_OSC_START = b"\x1b]8901;ratty;g;"`. `consume_sequence` is refactored to recognise either envelope and strip the right terminator (APC ends on ST/C1-ST; OSC also accepts BEL). The body grammar (`<verb>;<key=value>;…`) is unchanged, so APC and OSC paths share the same parser.

**`src/inline.rs`** — `consume_pty_output`'s scan loop gains an `EnvelopeKind` discriminator; it picks the next APC (`\x1b_`) *or* the specific RGP OSC prefix and dispatches each through the right path. Unrelated OSC traffic (window titles, hyperlinks, prompt marks) flows straight through to vt100 as before.

**`src/inline.rs` + `src/systems.rs`** — fixes a pre-existing scroll-tracking false-positive that the OSC migration exposes. When a `Place` arrives in the same PTY chunk that clears and repaints the terminal, `infer_upward_scroll` can return a large shift (25 rows on a 32-row screen in this repro) and the old `apply_scroll` evicts the very anchor that chunk just set. Tracked via a new `placed_this_chunk: HashSet<u32>` on `TerminalInlineObjects`; `pump_pty_output` drains it after consume and scrolls only `pre_anchor_ids \ placed_this_chunk`. Public `apply_scroll(rows)` API is unchanged; new `apply_scroll_to_existing(rows, exempt)` is the underlying helper.

**`widget/src/lib.rs`** — `ratatui-ratty`'s seven emit sites (register path, register payload init/chunk/empty, place, update, delete) switch from APC to OSC 8901. ST terminator emitted; parser also accepts BEL.

## OSC 8901 — number choice

Picked as a 4-digit private number with no known assignment in any surveyed terminal codebase, registry, or shell-integration spec. Numbers explicitly avoided:

| Number | Used by |
|---|---|
| 0,1,2,4,7,8,9,10,11,12,52,104,110-119 | conhost hardcoded |
| 99 | kitty notifications |
| 133 | FinalTerm / Warp prompt marks |
| 633 | VS Code shell integration |
| 777 | urxvt |
| 1337 | iTerm2 image protocol |
| **9001** | **Microsoft Terminal's `WTAction`** in `src/terminal/parser/OutputStateMachineEngine.hpp` — dispatching is numeric-first, so the `;ratty;` discriminator does not protect against a numeric collision |

The `;ratty;` discriminator after the number namespaces the payload for the protocol family, leaving room for `g;` (graphics) plus future verb-spaces if you want them.

## Verification

Windows 11 Pro 26200.6457 / RTX 5090 / Vulkan backend. `cargo fmt --check`, `cargo check`, `cargo clippy --all-targets --all-features -- -D warnings` all green.

**Wire-level probe** (vendored `portable-pty 0.8.1` shelling out to `bash.exe`):

```
=== APC (before) ===
Total bytes read: 16
0000: 1b 5b 3f 39 30 30 31 68 1b 5b 3f 31 30 30 34 68    .[?9001h.[?1004h
Contains \x1b_ (APC start)?  false
Contains 'PROBE;' marker?    false

=== OSC 8901 (after) ===
Total bytes read: 167
0000: 1b 5b 3f 39 30 30 31 68 1b 5b 3f 31 30 30 34 68 1b 5b 3f 32 35 6c …
0040: …  .]9001;r…[trimmed]
0080: …;animate=1;scale=1.0;depth=0.0;color=ffffff;brightness=1.0;…
Contains \x1b]8901;ratty;g;…?  true
```

**End-to-end inside `ratty.exe`** — `ratty -e big_rat.exe`:

```
INFO ratty::inline: registered RGP object 7 from assets/objects/SpinyMouse.glb
```

The full RGP register → place → spawn → render chain fires, and the SpinyMouse GLB renders inside Ratty's viewport for the first time on Windows. Screenshot below.

<img width="512" height="355" alt="image" src="https://github.com/user-attachments/assets/711dc6d5-4dae-4d62-90af-41fede1f24e7" />

## Compatibility

Existing APC senders keep working. The parser tries both envelopes per sequence, and `ratatui-ratty`'s on-the-wire behavior is the only change for downstream widget consumers — they get a one-time API recompile but nothing breaks in the body grammar.

## Open follow-ups (separate work)

- ChatGPT deep research flagged that mid-line OSC emission can interact with a conhost ordering bug ([microsoft/terminal#17313](https://github.com/microsoft/terminal/issues/17313)) on pre-1.23 conhost. RGP `place` is already self-describing (`row`, `col`, `w`, `h` carry absolute coordinates), so reordering does not silently mis-anchor the object, but a freshness key (`seq=` or `frame=`) would defeat stale-arrival cases. Worth a follow-up if it ever bites in practice.
- Multiplexers (tmux, screen, zellij) intercept selected OSC numbers and may need a `\ePtmux;…\e\` passthrough wrapper if a user runs RGP-emitting apps through them. Out of scope here.
