### PR TITLE
fix: improve the runtime asset loading

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2057,6 +2057,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "dispatch"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2496,6 +2517,17 @@ checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
 dependencies = [
  "rustix 1.1.4",
  "windows-link 0.2.1",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
 ]
 
 [[package]]
@@ -3953,6 +3985,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
 name = "orbclient"
 version = "0.3.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4607,6 +4645,7 @@ dependencies = [
  "ratatui",
  "rust-embed",
  "serde",
+ "shellexpand",
  "tobj",
  "toml",
  "vt100",
@@ -4670,6 +4709,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
 dependencies = [
  "bitflags 2.11.0",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -5001,6 +5051,15 @@ name = "shell-words"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
+
+[[package]]
+name = "shellexpand"
+version = "3.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32824fab5e16e6c4d86dc1ba84489390419a39f97699852b66480bb87d297ed8"
+dependencies = [
+ "dirs",
+]
 
 [[package]]
 name = "shlex"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ portable-pty = "0.8"
 ratatui = "0.30"
 rust-embed = "8.5"
 serde = { version = "1.0", features = ["derive"] }
+shellexpand = "3.1"
 tobj = "4.0"
 toml = "0.8"
 vt100 = "0.16"

--- a/src/config.rs
+++ b/src/config.rs
@@ -9,6 +9,8 @@ use bevy::prelude::Resource;
 use etcetera::{BaseStrategy, choose_base_strategy};
 use serde::{Deserialize, Deserializer};
 
+use crate::paths::expand_path;
+
 /// Application name used for config discovery.
 pub const APP_NAME: &str = "ratty";
 /// Local fallback config path.
@@ -59,7 +61,7 @@ impl AppConfig {
     /// Returns an error if the selected config file cannot be read or parsed.
     pub fn load_from_path(path: Option<&Path>) -> anyhow::Result<Self> {
         let selected_path = if let Some(path) = path {
-            Some(path.to_path_buf())
+            Some(expand_path(path))
         } else {
             Self::default_config_path()?
         };
@@ -92,16 +94,28 @@ impl AppConfig {
 
     fn resolve_relative_paths(&mut self, path: &Path) {
         let config_dir = path.parent().unwrap_or_else(|| Path::new("."));
-        if self.cursor.model.path.is_relative()
-            && self
-                .cursor
-                .model
-                .path
-                .parent()
-                .is_some_and(|parent| !parent.as_os_str().is_empty())
-        {
-            self.cursor.model.path = config_dir.join(&self.cursor.model.path);
+        self.cursor.model.path = resolve_config_path(config_dir, &self.cursor.model.path);
+        if let Some(program) = self.shell.program.as_mut() {
+            *program = resolve_config_path(config_dir, program);
         }
+    }
+}
+
+fn resolve_config_path(config_dir: &Path, path: &Path) -> PathBuf {
+    let expanded = expand_path(path);
+    if !expanded.is_relative() {
+        return expanded;
+    }
+
+    let config_relative = config_dir.join(&expanded);
+    if expanded
+        .parent()
+        .is_some_and(|parent| !parent.as_os_str().is_empty())
+        || config_relative.exists()
+    {
+        config_relative
+    } else {
+        expanded
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@ pub mod keyboard;
 pub mod kitty;
 pub mod model;
 pub mod mouse;
+pub mod paths;
 pub mod plugin;
 pub mod rendering;
 pub mod rgp;

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,6 +29,7 @@ fn main() -> anyhow::Result<()> {
     let terminal = TerminalSurface::new(&app_config)?;
     let window_title = cli.title;
     let asset_root = runtime_asset_root();
+    std::fs::create_dir_all(&asset_root)?;
 
     App::new()
         .insert_resource(ClearColor(Color::srgba_u8(

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 use std::time::Duration;
 
+use bevy::asset::AssetPlugin;
 use bevy::prelude::*;
 use bevy::window::WindowResolution;
 use bevy::winit::{UpdateMode, WinitSettings};
@@ -7,6 +8,7 @@ use clap::Parser;
 
 use ratty::cli::Cli;
 use ratty::config::AppConfig;
+use ratty::paths::runtime_asset_root;
 use ratty::plugin::TerminalPlugin;
 use ratty::runtime::{RuntimeOptions, TerminalRuntime};
 use ratty::terminal::TerminalSurface;
@@ -26,6 +28,7 @@ fn main() -> anyhow::Result<()> {
     )?;
     let terminal = TerminalSurface::new(&app_config)?;
     let window_title = cli.title;
+    let asset_root = runtime_asset_root();
 
     App::new()
         .insert_resource(ClearColor(Color::srgba_u8(
@@ -42,19 +45,24 @@ fn main() -> anyhow::Result<()> {
             unfocused_mode: UpdateMode::Continuous,
         })
         .add_plugins(
-            DefaultPlugins.set(WindowPlugin {
-                primary_window: Some(Window {
-                    title: window_title,
-                    resolution: WindowResolution::new(
-                        app_config.window.width,
-                        app_config.window.height,
-                    )
-                    .with_scale_factor_override(app_config.window.scale_factor),
-                    transparent: app_config.window.opacity < 1.0,
+            DefaultPlugins
+                .set(WindowPlugin {
+                    primary_window: Some(Window {
+                        title: window_title,
+                        resolution: WindowResolution::new(
+                            app_config.window.width,
+                            app_config.window.height,
+                        )
+                        .with_scale_factor_override(app_config.window.scale_factor),
+                        transparent: app_config.window.opacity < 1.0,
+                        ..default()
+                    }),
+                    ..default()
+                })
+                .set(AssetPlugin {
+                    file_path: asset_root.to_string_lossy().into_owned(),
                     ..default()
                 }),
-                ..default()
-            }),
         )
         .add_plugins(TerminalPlugin)
         .run();

--- a/src/model.rs
+++ b/src/model.rs
@@ -11,6 +11,7 @@ use bevy::prelude::*;
 use rust_embed::RustEmbed;
 
 use crate::config::{AppConfig, CURSOR_DEPTH};
+use crate::paths::{expand_path, runtime_asset_root};
 
 #[derive(RustEmbed)]
 #[folder = "assets/objects/"]
@@ -107,6 +108,8 @@ pub fn spawn_cursor_model(
 ///
 /// Returns an error if the asset cannot be resolved or parsed.
 pub fn load_object_source(path: &Path) -> anyhow::Result<(String, ObjectSource)> {
+    let expanded_path = expand_path(path);
+    let path = expanded_path.as_path();
     if path.exists() {
         let extension = path
             .extension()
@@ -133,7 +136,7 @@ pub fn load_object_source(path: &Path) -> anyhow::Result<(String, ObjectSource)>
                     })
                     .collect::<String>();
                 let candidate = format!("objects/external/{sanitized}.{extension}");
-                let asset_file = Path::new("assets").join(&candidate);
+                let asset_file = runtime_asset_root().join(&candidate);
                 std::fs::create_dir_all(
                     asset_file
                         .parent()
@@ -175,7 +178,7 @@ pub fn load_object_source(path: &Path) -> anyhow::Result<(String, ObjectSource)>
     }
 
     match extension.as_str() {
-        "obj" => load_obj_meshes_from_path(Path::new("assets").join(&candidate).as_path())
+        "obj" => load_obj_meshes_from_path(runtime_asset_root().join(&candidate).as_path())
             .or_else(|_| load_obj_meshes_from_path(path))
             .map(|meshes| (candidate.clone(), ObjectSource::Obj(meshes))),
         "glb" | "gltf" => {
@@ -236,7 +239,7 @@ fn ensure_scene_asset_path(
     candidate: &str,
     embedded: Option<(&str, &[u8])>,
 ) -> anyhow::Result<String> {
-    let asset_file = Path::new("assets").join(candidate);
+    let asset_file = runtime_asset_root().join(candidate);
     if !asset_file.exists() {
         if let Some((name, bytes)) = embedded {
             std::fs::create_dir_all(

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -9,7 +9,5 @@ pub fn expand_path(path: &Path) -> PathBuf {
 
 /// Returns the writable runtime asset root used for scene-backed object files.
 pub fn runtime_asset_root() -> PathBuf {
-    std::env::current_dir()
-        .map(|dir| dir.join("assets"))
-        .unwrap_or_else(|_| std::env::temp_dir().join("ratty-assets"))
+    std::env::temp_dir().join("ratty-assets")
 }

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -1,0 +1,15 @@
+//! Shared filesystem path helpers.
+
+use std::path::{Path, PathBuf};
+
+/// Expands a leading `~` in a path using the current user's home directory.
+pub fn expand_path(path: &Path) -> PathBuf {
+    PathBuf::from(shellexpand::tilde(&path.to_string_lossy()).into_owned())
+}
+
+/// Returns the writable runtime asset root used for scene-backed object files.
+pub fn runtime_asset_root() -> PathBuf {
+    std::env::current_dir()
+        .map(|dir| dir.join("assets"))
+        .unwrap_or_else(|_| std::env::temp_dir().join("ratty-assets"))
+}

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -2,6 +2,8 @@
 
 use std::path::{Path, PathBuf};
 
+use etcetera::{BaseStrategy, choose_base_strategy};
+
 /// Expands a leading `~` in a path using the current user's home directory.
 pub fn expand_path(path: &Path) -> PathBuf {
     PathBuf::from(shellexpand::tilde(&path.to_string_lossy()).into_owned())
@@ -9,5 +11,9 @@ pub fn expand_path(path: &Path) -> PathBuf {
 
 /// Returns the writable runtime asset root used for scene-backed object files.
 pub fn runtime_asset_root() -> PathBuf {
-    std::env::temp_dir().join("ratty-assets")
+    choose_base_strategy()
+        .map(|strategy| strategy.cache_dir())
+        .unwrap_or_else(|_| std::env::temp_dir())
+        .join(env!("CARGO_PKG_NAME"))
+        .join("assets")
 }


### PR DESCRIPTION
see #59 and #45

  - ~/... paths work in the relevant config and object-loading paths
  - installed Ratty no longer depends on repo-local or executable-relative assets/
  - runtime scene-backed assets now live in a writable OS-conventional cache location instead of polluting the workspace
