### PR TITLE
Revert font fallback options

### DIFF
--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -312,14 +312,7 @@ fn build_terminal_renderer(
         ),
         palette,
     };
-    let font_options = FontOptions::default()
-        .with_family(font.family.clone())
-        .with_fallback_family("Apple Symbols")
-        .with_fallback_family("Arial Unicode MS")
-        .with_fallback_family("Noto Sans Symbols 2")
-        .with_fallback_family("Noto Sans Symbols")
-        .with_fallback_family("Symbola")
-        .with_fallback_family("Segoe UI Symbol");
+    let font_options = FontOptions::default().with_family(font.family.clone());
     TerminalRenderer::new(
         FontOptions {
             size: font.size as f32,


### PR DESCRIPTION
## Summary

Reverts the added terminal renderer font fallback families and restores the renderer to use only the configured font family.

## Why

This undoes the behavior introduced by PR #55, removing the hard-coded fallback family list from `build_terminal_renderer`.

## Impact

Users return to the previous font selection behavior based on the configured font family and size.

## Validation

- `cargo test`