### PR TITLE
Add windows x64 target in ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,9 @@ jobs:
           - label: x86_64-unknown-linux-gnu
             os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
+          - label: x86_64-pc-windows-msvc
+            os: windows-latest
+            target: x86_64-pc-windows-msvc
         manifest:
           - Cargo.toml
           - widget/Cargo.toml

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -14,7 +14,7 @@ create-release = false
 # The installers to generate for each app
 installers = []
 # Target platforms to build apps for (Rust target-triple syntax)
-targets = ["aarch64-apple-darwin", "aarch64-unknown-linux-gnu", "x86_64-apple-darwin", "x86_64-unknown-linux-gnu"]
+targets = ["aarch64-apple-darwin", "aarch64-unknown-linux-gnu", "x86_64-apple-darwin", "x86_64-unknown-linux-gnu", "x86_64-pc-windows-msvc"]
 
 [dist.dependencies.apt]
 pkg-config = "*"


### PR DESCRIPTION
ratty works fine on windows. let's add windows x64 target in ci.
