### PR TITLE
Update window title handling to include name property

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -49,7 +49,8 @@ fn main() -> anyhow::Result<()> {
             DefaultPlugins
                 .set(WindowPlugin {
                     primary_window: Some(Window {
-                        title: window_title,
+                        title: window_title.clone(),
+                        name: Some(window_title),
                         resolution: WindowResolution::new(
                             app_config.window.width,
                             app_config.window.height,


### PR DESCRIPTION
In Ubuntu 26.04 using wayland, when a desktop entry is created for Ratty it shows up as an unknown app in the dock.

https://github.com/bevyengine/bevy/pull/7650 adds:
> Add name field to bevy::window::Window. Specifying this field adds different properties to the window: application ID on Wayland, WM_CLASS on X11, or window class name on Windows. It has no effect on other platforms.

With this change the app_id is set to "Ratty" and with the following desktop entry the name and icon now work correctly:
```
[Desktop Entry]
Type=Application
Name=Ratty
Exec=<path to ratty binary>
Categories=Terminal;Emulator;
Keywords=ratty;terminal;emulator
Icon=<icon under ~/.icons>
```