### PR TITLE
Add perspective projection, ability to hotswap between orthographic and perspective

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -202,9 +202,12 @@ pub enum BindingAction {
     /// Disables a binding.
     #[serde(rename = "none")]
     None,
-    /// Toggles between the flat and warped terminal views.
-    #[serde(rename = "Toggle3DMode")]
-    Toggle3DMode,
+    /// Toggles between the flat and orthographic terminal views.
+    #[serde(rename = "ToggleOrtho3DMode")]
+    ToggleOrtho3DMode,
+    /// Toggles the perspective terminal view.
+    #[serde(rename = "TogglePersp3DMode")]
+    TogglePersp3DMode,
     /// Toggles the Mobius-strip terminal view.
     #[serde(rename = "ToggleMobiusMode")]
     ToggleMobiusMode,

--- a/src/keyboard.rs
+++ b/src/keyboard.rs
@@ -59,13 +59,22 @@ impl FromWorld for TerminalKeyBindings {
         let app_config = world.resource::<AppConfig>();
         let mut bindings = vec![
             KeyBinding::new(
-                KeyCode::Enter,
+                KeyCode::KeyO,
                 BindingModifiers {
                     control: true,
                     alt: true,
                     ..default()
                 },
-                BindingAction::Toggle3DMode,
+                BindingAction::ToggleOrtho3DMode,
+            ),
+            KeyBinding::new(
+                KeyCode::KeyP,
+                BindingModifiers {
+                    control: true,
+                    alt: true,
+                    ..default()
+                },
+                BindingAction::TogglePersp3DMode,
             ),
             KeyBinding::new(
                 KeyCode::KeyM,
@@ -353,8 +362,15 @@ pub fn handle_keyboard_input(
 
             match action {
                 BindingAction::None => {}
-                BindingAction::Toggle3DMode => {
+                BindingAction::ToggleOrtho3DMode => {
                     params.presentation.toggle_plane_mode();
+                    params.mobius_transition.stop();
+                    params.selection.clear();
+                    params.redraw.request();
+                    continue;
+                },
+                BindingAction::TogglePersp3DMode => {
+                    params.presentation.toggle_persp_mode();
                     params.mobius_transition.stop();
                     params.selection.clear();
                     params.redraw.request();

--- a/src/mouse.rs
+++ b/src/mouse.rs
@@ -236,10 +236,7 @@ pub(crate) fn handle_mouse_input(
             continue;
         }
 
-        if matches!(
-            presentation.mode,
-            TerminalPresentationMode::Plane3d | TerminalPresentationMode::Mobius3d
-        ) {
+        if presentation.mode.is_3d() {
             if plane_view.rotating {
                 if let Some(last) = plane_view.last_rotate_cursor {
                     let delta = event.position - last;
@@ -316,10 +313,7 @@ pub(crate) fn handle_mouse_input(
                         runtime.write_input(&encode_mouse_event(cell, 0, false, mouse_encoding));
                         forwarded_mouse.last_cell = Some(cell);
                     }
-                } else if matches!(
-                    presentation.mode,
-                    TerminalPresentationMode::Plane3d | TerminalPresentationMode::Mobius3d
-                ) {
+                } else if presentation.mode.is_3d() {
                     plane_view.rotating = true;
                     plane_view.last_rotate_cursor = selection.cursor_position();
                 } else if let Some(pos) = selection.cursor_position()
@@ -340,10 +334,7 @@ pub(crate) fn handle_mouse_input(
                         runtime.write_input(&encode_mouse_event(cell, 0, true, mouse_encoding));
                         forwarded_mouse.last_cell = Some(cell);
                     }
-                } else if matches!(
-                    presentation.mode,
-                    TerminalPresentationMode::Plane3d | TerminalPresentationMode::Mobius3d
-                ) {
+                } else if presentation.mode.is_3d() {
                     plane_view.rotating = false;
                     plane_view.last_rotate_cursor = selection.cursor_position();
                 } else {
@@ -395,19 +386,13 @@ pub(crate) fn handle_mouse_input(
                 }
             }
             (MouseButton::Right, ButtonState::Pressed)
-                if matches!(
-                    presentation.mode,
-                    TerminalPresentationMode::Plane3d | TerminalPresentationMode::Mobius3d
-                ) =>
+                if presentation.mode.is_3d() =>
             {
                 plane_view.panning = true;
                 plane_view.last_pan_cursor = selection.cursor_position();
             }
             (MouseButton::Right, ButtonState::Released)
-                if matches!(
-                    presentation.mode,
-                    TerminalPresentationMode::Plane3d | TerminalPresentationMode::Mobius3d
-                ) =>
+                if presentation.mode.is_3d() =>
             {
                 plane_view.panning = false;
                 plane_view.last_pan_cursor = selection.cursor_position();
@@ -461,10 +446,7 @@ pub(crate) fn handle_mouse_input(
                 selection.clear();
                 redraw.request();
             }
-        } else if matches!(
-            presentation.mode,
-            TerminalPresentationMode::Plane3d | TerminalPresentationMode::Mobius3d
-        ) && delta != 0.0
+        } else if presentation.mode.is_3d() && delta != 0.0
         {
             plane_view.zoom = (plane_view.zoom - delta).clamp(0.1, 4.0);
             redraw.request();

--- a/src/scene/mod.rs
+++ b/src/scene/mod.rs
@@ -4,6 +4,8 @@ mod mobius;
 
 pub use mobius::{MobiusTransition, MobiusTransitionDirection};
 
+use std::f32::consts::PI;
+
 use bevy::asset::RenderAssetUsages;
 use bevy::camera::ClearColorConfig;
 use bevy::ecs::query::With;
@@ -227,10 +229,10 @@ pub fn setup_scene(
             clear_color: ClearColorConfig::None,
             ..default()
         },
-        Projection::Orthographic(OrthographicProjection {
+        Projection::Perspective(PerspectiveProjection {
             near: -2000.0,
             far: 2000.0,
-            ..OrthographicProjection::default_3d()
+            ..PerspectiveProjection::default()
         }),
         Transform::from_xyz(0.0, 0.0, 800.0).looking_at(Vec3::ZERO, Vec3::Y),
         Msaa::Off,
@@ -462,13 +464,13 @@ pub(crate) fn apply_terminal_presentation(
     }
 
     for (mut projection, mut transform) in &mut plane_transforms.p2() {
-        if let Projection::Orthographic(ortho) = projection.as_mut() {
+        if let Projection::Perspective(persp) = projection.as_mut() {
             let zoom = if is_mobius && mobius_transition.active {
                 mobius_transition.current_zoom()
             } else {
                 plane_view.zoom
             };
-            ortho.scale = if is_3d { zoom } else { 1.0 };
+            persp.fov = if is_3d { zoom } else { 1.0 };
         }
 
         let offset = if is_3d {

--- a/src/scene/mod.rs
+++ b/src/scene/mod.rs
@@ -4,8 +4,6 @@ mod mobius;
 
 pub use mobius::{MobiusTransition, MobiusTransitionDirection};
 
-use std::f32::consts::PI;
-
 use bevy::asset::RenderAssetUsages;
 use bevy::camera::ClearColorConfig;
 use bevy::ecs::query::With;
@@ -73,6 +71,8 @@ pub enum TerminalPresentationMode {
     Flat2d,
     /// Warped 3D presentation.
     Plane3d,
+    /// Perspective 3D presentation.
+    Persp3d,
     /// Mobius-strip 3D presentation.
     Mobius3d,
 }
@@ -101,8 +101,18 @@ impl TerminalPresentation {
     pub fn toggle_plane_mode(&mut self) {
         self.mode = match self.mode {
             TerminalPresentationMode::Flat2d => TerminalPresentationMode::Plane3d,
-            TerminalPresentationMode::Plane3d | TerminalPresentationMode::Mobius3d => {
+            TerminalPresentationMode::Plane3d | TerminalPresentationMode::Mobius3d | TerminalPresentationMode::Persp3d => {
                 TerminalPresentationMode::Flat2d
+            }
+        };
+    }
+
+    /// Toggles the Perspective projection terminal view.
+    pub fn toggle_persp_mode(&mut self) {
+        self.mode = match self.mode {
+            TerminalPresentationMode::Persp3d => TerminalPresentationMode::Flat2d,
+            TerminalPresentationMode::Flat2d | TerminalPresentationMode::Plane3d | TerminalPresentationMode::Mobius3d => {
+                TerminalPresentationMode::Persp3d
             }
         };
     }
@@ -111,7 +121,7 @@ impl TerminalPresentation {
     pub fn toggle_mobius_mode(&mut self) {
         self.mode = match self.mode {
             TerminalPresentationMode::Mobius3d => TerminalPresentationMode::Flat2d,
-            TerminalPresentationMode::Flat2d | TerminalPresentationMode::Plane3d => {
+            TerminalPresentationMode::Flat2d | TerminalPresentationMode::Plane3d | TerminalPresentationMode::Persp3d => {
                 TerminalPresentationMode::Mobius3d
             }
         };
@@ -173,7 +183,7 @@ type PlaneTransformQuery<'w, 's> = Query<'w, 's, &'static mut Transform, With<Te
 type PlaneBackTransformQuery<'w, 's> =
     Query<'w, 's, &'static mut Transform, With<TerminalPlaneBack>>;
 type PlaneCameraQuery<'w, 's> =
-    Query<'w, 's, (&'static mut Projection, &'static mut Transform), With<TerminalPlaneCamera>>;
+    Query<'w, 's, (&'static mut Projection, &'static mut Transform, &'static mut Camera), With<TerminalPlaneCamera>>;
 
 #[derive(SystemParam)]
 pub(crate) struct PresentationParams<'w, 's> {
@@ -237,6 +247,23 @@ pub fn setup_scene(
         Transform::from_xyz(0.0, 0.0, 800.0).looking_at(Vec3::ZERO, Vec3::Y),
         Msaa::Off,
     ));
+    commands.spawn((
+        TerminalPlaneCamera,
+        Camera3d::default(),
+        Camera {
+            order: 2,
+            clear_color: ClearColorConfig::None,
+            ..default()
+        },
+        Projection::Orthographic(OrthographicProjection {
+            near: -2000.0,
+            far: 2000.0,
+            ..OrthographicProjection::default_3d()
+        }),
+        Transform::from_xyz(0.0, 0.0, 800.0).looking_at(Vec3::ZERO, Vec3::Y),
+        Msaa::Off,
+    ));
+
 
     let pixmap = terminal.pixmap_dimensions();
     let pixmap_width = pixmap.x;
@@ -463,14 +490,32 @@ pub(crate) fn apply_terminal_presentation(
         }
     }
 
-    for (mut projection, mut transform) in &mut plane_transforms.p2() {
+    for (mut projection, mut transform, mut camera) in &mut plane_transforms.p2() {
+        let active = &mut camera.is_active;
         if let Projection::Perspective(persp) = projection.as_mut() {
-            let zoom = if is_mobius && mobius_transition.active {
-                mobius_transition.current_zoom()
+            if presentation.mode == TerminalPresentationMode::Persp3d {
+                *active = true;
+                let zoom = if is_mobius && mobius_transition.active {
+                    mobius_transition.current_zoom()
+                } else {
+                    plane_view.zoom
+                };
+                persp.fov = if is_3d { zoom } else { 1.0 };
             } else {
-                plane_view.zoom
-            };
-            persp.fov = if is_3d { zoom } else { 1.0 };
+                *active = false;
+            }
+        } else if let Projection::Orthographic(ortho) = projection.as_mut() {
+            if presentation.mode != TerminalPresentationMode::Persp3d {
+                *active = true;
+                let zoom = if is_mobius && mobius_transition.active {
+                    mobius_transition.current_zoom()
+                } else {
+                    plane_view.zoom
+                };
+                ortho.scale = if is_3d { zoom } else { 1.0 };
+            } else {
+                *active = false;
+            }
         }
 
         let offset = if is_3d {

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -273,18 +273,8 @@ pub fn apply_inline_objects(
         ),
     >,
 ) {
-    let sprite_visibility = match presentation.mode {
-        TerminalPresentationMode::Flat2d => Visibility::Visible,
-        TerminalPresentationMode::Plane3d | TerminalPresentationMode::Mobius3d => {
-            Visibility::Hidden
-        }
-    };
-    let plane_visibility = match presentation.mode {
-        TerminalPresentationMode::Flat2d => Visibility::Hidden,
-        TerminalPresentationMode::Plane3d | TerminalPresentationMode::Mobius3d => {
-            Visibility::Visible
-        }
-    };
+    let sprite_visibility = if presentation.mode.is_3d() { Visibility::Visible } else { Visibility::Hidden };
+    let plane_visibility = if presentation.mode.is_3d() { Visibility::Hidden } else { Visibility::Visible };
 
     for mut visibility in &mut sprite_query {
         *visibility = sprite_visibility;
@@ -342,10 +332,7 @@ pub(crate) fn redraw_soft_terminal(mut params: RedrawParams) {
         asset_server,
     } = &mut params;
     let needs_redraw = redraw.take();
-    let force_live_redraw = matches!(
-        presentation.mode,
-        TerminalPresentationMode::Plane3d | TerminalPresentationMode::Mobius3d
-    ) && !app_config.cursor.model.visible;
+    let force_live_redraw = presentation.mode.is_3d() && !app_config.cursor.model.visible;
     if !needs_redraw && !force_live_redraw && model_load_state.loaded {
         return;
     }
@@ -369,18 +356,12 @@ pub(crate) fn redraw_soft_terminal(mut params: RedrawParams) {
     });
 
     let _ = terminal.sync_image(images, time.elapsed_secs());
-    if matches!(
-        presentation.mode,
-        TerminalPresentationMode::Plane3d | TerminalPresentationMode::Mobius3d
-    ) {
+    if presentation.mode.is_3d() {
         sync_terminal_debug_image(terminal, images, screen);
     }
 
     sync_plane_texture(terminal.image_handle.as_ref(), plane_materials, materials);
-    if matches!(
-        presentation.mode,
-        TerminalPresentationMode::Plane3d | TerminalPresentationMode::Mobius3d
-    ) {
+    if presentation.mode.is_3d() {
         sync_plane_texture(
             terminal.back_image_handle.as_ref(),
             plane_back_materials,
@@ -448,10 +429,7 @@ pub(crate) fn sync_inline_objects(mut params: SyncInlineParams) {
         images,
         meshes,
     } = &mut params;
-    let force_warp_sync = matches!(
-        presentation.mode,
-        TerminalPresentationMode::Plane3d | TerminalPresentationMode::Mobius3d
-    ) && plane_warp.amount > 0.0
+    let force_warp_sync = presentation.mode.is_3d() && plane_warp.amount > 0.0
         && !inline_objects.anchors.is_empty();
     if !force_warp_sync && !inline_objects.needs_sync(viewport.size, terminal.cols, terminal.rows) {
         return;
@@ -590,12 +568,7 @@ fn sync_kitty_inline_image(
         TerminalInlineObjectSprite,
         sprite,
         Transform::from_translation(Vec3::new(layout.center_x, layout.center_y, 5.0)),
-        match ctx.mode {
-            TerminalPresentationMode::Flat2d => Visibility::Visible,
-            TerminalPresentationMode::Plane3d | TerminalPresentationMode::Mobius3d => {
-                Visibility::Hidden
-            }
-        },
+        if ctx.mode.is_3d() { Visibility::Visible } else { Visibility::Hidden },
     ));
 
     let x_segments = layout.columns.clamp(2, 24);
@@ -845,36 +818,33 @@ pub(crate) fn sync_rgp_objects(mut params: RgpSyncParams) {
         let object_rotation = base_oblique * explicit_rotation * animated_rotation;
         let object_scale = Vec3::splat(scale) * scale3;
 
-        match presentation.mode {
-            TerminalPresentationMode::Flat2d => {
-                transform.translation = Vec3::new(
-                    layout.center_x + anchor.style.offset.x,
-                    layout.center_y + bob + anchor.style.offset.y,
-                    CURSOR_DEPTH + anchor.style.depth * 4.0 + anchor.style.offset.z,
-                );
-                transform.rotation = object_rotation;
-                transform.scale = object_scale;
-                *visibility = Visibility::Visible;
-            }
-            TerminalPresentationMode::Plane3d | TerminalPresentationMode::Mobius3d => {
-                let Ok(plane_transform) = plane_query.single() else {
-                    *visibility = Visibility::Hidden;
-                    continue;
-                };
-                let local_position = plane_surface_point(
-                    presentation.mode,
-                    layout.local_x,
-                    layout.local_y,
-                    plane_warp.amount,
-                    elapsed_secs,
-                    8.0 + anchor.style.depth * 1.5,
-                    mobius_progress,
-                ) + anchor.style.offset;
-                transform.translation = plane_transform.transform_point(local_position);
-                transform.rotation = plane_transform.rotation * object_rotation;
-                transform.scale = object_scale;
-                *visibility = Visibility::Visible;
-            }
+        if presentation.mode.is_3d() {
+            let Ok(plane_transform) = plane_query.single() else {
+                *visibility = Visibility::Hidden;
+                continue;
+            };
+            let local_position = plane_surface_point(
+                presentation.mode,
+                layout.local_x,
+                layout.local_y,
+                plane_warp.amount,
+                elapsed_secs,
+                8.0 + anchor.style.depth * 1.5,
+                mobius_progress,
+            ) + anchor.style.offset;
+            transform.translation = plane_transform.transform_point(local_position);
+            transform.rotation = plane_transform.rotation * object_rotation;
+            transform.scale = object_scale;
+            *visibility = Visibility::Visible;
+        } else {
+            transform.translation = Vec3::new(
+                layout.center_x + anchor.style.offset.x,
+                layout.center_y + bob + anchor.style.offset.y,
+                CURSOR_DEPTH + anchor.style.depth * 4.0 + anchor.style.offset.z,
+            );
+            transform.rotation = object_rotation;
+            transform.scale = object_scale;
+            *visibility = Visibility::Visible;
         }
     }
 }
@@ -1109,7 +1079,7 @@ pub fn animate_terminal_plane_warp(
 
     let needs_update = match presentation.mode {
         TerminalPresentationMode::Flat2d => false,
-        TerminalPresentationMode::Plane3d => {
+        TerminalPresentationMode::Plane3d | TerminalPresentationMode::Persp3d => {
             presentation.is_changed() || warp.is_changed() || warp.amount > 0.0
         }
         // Reapply the strip every frame so mode switches and time-based motion are visible.
@@ -1216,7 +1186,7 @@ fn apply_plane_warp(
         position[1] = point.y;
         position[2] = match mode {
             TerminalPresentationMode::Plane3d => point.z * direction,
-            TerminalPresentationMode::Flat2d | TerminalPresentationMode::Mobius3d => point.z,
+            TerminalPresentationMode::Flat2d | TerminalPresentationMode::Mobius3d | TerminalPresentationMode::Persp3d => point.z,
         };
     }
 }
@@ -1309,17 +1279,17 @@ fn cursor_pose(
         0.0
     };
 
-    let (translation, rotation, visibility) = match ctx.mode {
-        TerminalPresentationMode::Flat2d => (
-            Vec3::new(local_x, local_y + bob, CURSOR_DEPTH),
-            Quat::from_rotation_y(spin) * Quat::from_rotation_x(-0.25),
-            if !app_config.cursor.model.visible || screen.hide_cursor() {
-                Visibility::Hidden
-            } else {
-                Visibility::Visible
-            },
-        ),
-        TerminalPresentationMode::Plane3d | TerminalPresentationMode::Mobius3d => {
+    let (translation, rotation, visibility) = if ctx.mode.is_3d() {
+            (
+                Vec3::new(local_x, local_y + bob, CURSOR_DEPTH),
+                Quat::from_rotation_y(spin) * Quat::from_rotation_x(-0.25),
+                if !app_config.cursor.model.visible || screen.hide_cursor() {
+                    Visibility::Hidden
+                } else {
+                    Visibility::Visible
+                },
+            )
+        } else {
             let Ok(plane_transform) = ctx.plane_query.single() else {
                 return (Vec3::ZERO, Quat::IDENTITY, scale, Visibility::Hidden);
             };
@@ -1344,7 +1314,6 @@ fn cursor_pose(
                     Visibility::Hidden
                 },
             )
-        }
     };
 
     (translation, rotation, scale, visibility)
@@ -1373,7 +1342,7 @@ fn plane_surface_point(
 ) -> Vec3 {
     match mode {
         TerminalPresentationMode::Flat2d => Vec3::new(local_x, local_y, depth_offset),
-        TerminalPresentationMode::Plane3d => Vec3::new(
+        TerminalPresentationMode::Plane3d | TerminalPresentationMode::Persp3d => Vec3::new(
             local_x,
             local_y,
             plane_surface_z(local_x, local_y, warp_amount, elapsed_secs) + depth_offset,


### PR DESCRIPTION
Hey!
Ctrl + Alt + O -> Regular orthographic view
Ctrl + Alt + P -> New perspective view ('videogame camera' style)
Basically, both cameras are created at startup, but only the requested one is activated in Bevy. Not sure if this might suppose a performance penalty. I am also not an expert in Rust nor Bevy, so sorry if something's improvable :sweat_smile:. I also refactored a bunch of `match` statements into comparisons against `is_3d()` where I thought it might be reasonable, since 3 long enum values per arm seemed silly once I added the new `Persp3d` mode (I can revert this if needed).

I can make an issue if needed to discuss this further, just thought it was worth making a PR over since I had already implemented it. Demo video attached with the fixes from my other PR (for demo purposes since it uses the animation system).

https://github.com/user-attachments/assets/a180a2ce-8781-4d2e-ad88-77863fa76726