### PR TITLE
Fix: report correct window size back to Portable-PTY at all times

### DIFF
--- a/src/keyboard.rs
+++ b/src/keyboard.rs
@@ -483,7 +483,7 @@ pub fn handle_keyboard_input(
                             ((params.viewport.size.x / char_dims.x as f32).floor() as u16).max(1);
                         let rows =
                             ((params.viewport.size.y / char_dims.y as f32).floor() as u16).max(1);
-                        params.runtime.resize(cols, rows);
+                        params.runtime.resize(cols, rows, params.viewport.size.x as u16, params.viewport.size.y as u16);
                         params.terminal.resize(cols, rows);
                         params.redraw.request();
                     }

--- a/src/keyboard.rs
+++ b/src/keyboard.rs
@@ -483,7 +483,12 @@ pub fn handle_keyboard_input(
                             ((params.viewport.size.x / char_dims.x as f32).floor() as u16).max(1);
                         let rows =
                             ((params.viewport.size.y / char_dims.y as f32).floor() as u16).max(1);
-                        params.runtime.resize(cols, rows, params.viewport.size.x as u16, params.viewport.size.y as u16);
+                        params.runtime.resize(
+                            cols,
+                            rows,
+                            params.viewport.size.x as u16,
+                            params.viewport.size.y as u16,
+                        );
                         params.terminal.resize(cols, rows);
                         params.redraw.request();
                     }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -362,7 +362,7 @@ impl TerminalRuntime {
     }
 
     /// Resizes the PTY and parser screen.
-    pub fn resize(&mut self, cols: u16, rows: u16) {
+    pub fn resize(&mut self, cols: u16, rows: u16, pw: u16, ph: u16) {
         if cols == 0 || rows == 0 {
             return;
         }
@@ -370,9 +370,8 @@ impl TerminalRuntime {
         let _ = self._master.resize(PtySize {
             rows,
             cols,
-            pixel_width: 0,
-            pixel_height: 0,
-        });
+            pixel_width: pw,
+            pixel_height: ph,        });
         self.parser.screen_mut().set_size(rows, cols);
     }
 

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -371,7 +371,8 @@ impl TerminalRuntime {
             rows,
             cols,
             pixel_width: pw,
-            pixel_height: ph,        });
+            pixel_height: ph,
+        });
         self.parser.screen_mut().set_size(rows, cols);
     }
 

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -239,7 +239,7 @@ pub(crate) fn handle_window_resize(
     let cols = ((viewport_size.x / char_dims.x as f32).floor() as u16).max(1);
     let rows = ((viewport_size.y / char_dims.y as f32).floor() as u16).max(1);
 
-    runtime.resize(cols, rows);
+    runtime.resize(cols, rows, viewport_size.x as u16, viewport_size.y as u16);
     terminal.resize(cols, rows);
     let _ = terminal.sync_image(images, 0.0);
     redraw.request();


### PR DESCRIPTION
Fixes #95
The reported resolution is that of 2D mode, as that's the viewport size and it is also used by the Kitty Graphics Protocol and such, and by the animation system's normalized device coordinates.