### PR TITLE
Render terminal texture with direct Vello path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1140,7 +1140,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-time",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2178,7 +2178,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2313,7 +2313,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3629,7 +3629,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4049,7 +4049,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4149,9 +4149,9 @@ dependencies = [
 
 [[package]]
 name = "parley_ratatui"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40efa408c041aad816471c16eb2b1be909fed2ddb789b6b46099e9f0549c2f2a"
+checksum = "87e3cc2adfe7f5622f17d285f144ef2f4d7c096f9bcd0bbe0a13bad4283b60e3"
 dependencies = [
  "naga",
  "parley",
@@ -4892,7 +4892,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6513,7 +6513,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1140,7 +1140,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-time",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2179,7 +2179,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2314,7 +2314,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3630,7 +3630,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4050,7 +4050,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4150,9 +4150,9 @@ dependencies = [
 
 [[package]]
 name = "parley_ratatui"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3c4a0467a959680e789f88eb5b69afc8970a39b1a591c7b29dc15076dc97406"
+checksum = "993017a77e34db00adbbf64e51db1bf17ff4cfa3273e93901cf16e90713f14e4"
 dependencies = [
  "naga",
  "parley",
@@ -4578,14 +4578,15 @@ checksum = "ca45419789ae5a7899559e9512e58ca889e41f04f1f2445e9f4b290ceccd1d08"
 
 [[package]]
 name = "ratatui"
-version = "0.30.1"
+version = "0.30.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1695748e3a735b34968c887ceea5a380b43545903868ae8f5b666593100f6b68"
+checksum = "3274ba0a2c5e1bcad2a2005d20f4dc59dad26b2eb0940fb094500dba4099d57d"
 dependencies = [
  "instability",
  "ratatui-core",
  "ratatui-crossterm",
  "ratatui-macros",
+ "ratatui-termina",
  "ratatui-termwiz",
  "ratatui-widgets",
  "serde",
@@ -4593,15 +4594,14 @@ dependencies = [
 
 [[package]]
 name = "ratatui-core"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42d3603f354bba8c595fa47860e60142d7372b7210c27044c6a7d0e1a4336b44"
+checksum = "cbb175c433c8e28a809d1f5773a2ae96e68c0ce40db865cbab1020bf33ae479c"
 dependencies = [
  "bitflags 2.13.0",
  "compact_str",
  "critical-section",
  "hashbrown 0.17.0",
- "indoc",
  "itertools",
  "kasuari",
  "lru",
@@ -4616,9 +4616,9 @@ dependencies = [
 
 [[package]]
 name = "ratatui-crossterm"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b2867bedcbd6a690ca4f8672a687b730ec07660c79844517b084311b529980c"
+checksum = "567584a3b0e6a8203c23de40b4861497266725eb5363dbfd18a1edd603cca9f0"
 dependencies = [
  "cfg-if",
  "crossterm",
@@ -4628,19 +4628,30 @@ dependencies = [
 
 [[package]]
 name = "ratatui-macros"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80fac59720679490d89d200df411faa249be728681adcabed3d047ae72c48f1d"
+checksum = "ed7dc68daa7498a43e4d68e0eb078427e10c38fbcfbb1e42d955f1fa2140d814"
 dependencies = [
  "ratatui-core",
  "ratatui-widgets",
 ]
 
 [[package]]
-name = "ratatui-termwiz"
-version = "0.1.1"
+name = "ratatui-termina"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "386b8ff8f74ed749509391c56d549761a2fcdb408e1f42e467286bcb7dac8967"
+checksum = "c0bf912d9e66f057a759d92e386a280ea886b352ab757d6ac4d653c7ed2c43c2"
+dependencies = [
+ "instability",
+ "ratatui-core",
+ "termina",
+]
+
+[[package]]
+name = "ratatui-termwiz"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf03e0380b7744054d6cb74224fe3adf062a029754933f575ca1e3b4c2ce977"
 dependencies = [
  "ratatui-core",
  "termwiz",
@@ -4648,9 +4659,9 @@ dependencies = [
 
 [[package]]
 name = "ratatui-widgets"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ef4f17dd7ac3abf5adc2b920a03c61eee4bfe6a88fa5191936895525371d79c"
+checksum = "66e3d19bcc9130ca376277d93b60767ff121ace3be06f5f95f81dd68956407d1"
 dependencies = [
  "bitflags 2.13.0",
  "hashbrown 0.17.0",
@@ -4893,7 +4904,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5376,6 +5387,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "termina"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9048a889effe34a5cddee0af7f53285198b16dca3be510858d38dfdb3e62a04e"
+dependencies = [
+ "bitflags 2.13.0",
+ "parking_lot",
+ "rustix 1.1.4",
+ "signal-hook",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6514,7 +6538,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1140,7 +1140,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-time",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2178,7 +2178,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2313,7 +2313,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3629,7 +3629,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4049,7 +4049,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4149,9 +4149,9 @@ dependencies = [
 
 [[package]]
 name = "parley_ratatui"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87e3cc2adfe7f5622f17d285f144ef2f4d7c096f9bcd0bbe0a13bad4283b60e3"
+checksum = "a3c4a0467a959680e789f88eb5b69afc8970a39b1a591c7b29dc15076dc97406"
 dependencies = [
  "naga",
  "parley",
@@ -4892,7 +4892,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6513,7 +6513,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1140,7 +1140,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-time",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2178,7 +2178,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2313,7 +2313,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3629,7 +3629,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4049,7 +4049,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4149,9 +4149,9 @@ dependencies = [
 
 [[package]]
 name = "parley_ratatui"
-version = "0.2.2"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4395814f28ed6096631e6ea53cd5d3f1142ccb5731c2f2ab6b88e7d93b9ae38b"
+checksum = "40efa408c041aad816471c16eb2b1be909fed2ddb789b6b46099e9f0549c2f2a"
 dependencies = [
  "naga",
  "parley",
@@ -4892,7 +4892,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6513,7 +6513,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,29 +20,42 @@ checksum = "366ffbaa4442f4684d91e2cd7c5ea7c4ed8add41959a31447066e279e432b618"
 
 [[package]]
 name = "accesskit"
-version = "0.21.1"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf203f9d3bd8f29f98833d1fbef628df18f759248a547e7e01cfbf63cda36a99"
+checksum = "5351dcebb14b579ccab05f288596b2ae097005be7ee50a7c3d4ca9d0d5a66f6a"
+dependencies = [
+ "uuid",
+]
 
 [[package]]
 name = "accesskit_consumer"
-version = "0.31.0"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db81010a6895d8707f9072e6ce98070579b43b717193d2614014abd5cb17dd43"
+checksum = "53cf47daed85312e763fbf85ceca136e0d7abc68e0a7e12abe11f48172bc3b10"
 dependencies = [
  "accesskit",
- "hashbrown 0.15.5",
+ "hashbrown 0.16.1",
+]
+
+[[package]]
+name = "accesskit_consumer"
+version = "0.36.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25e0d7e25d06f4dc21d1774d67146e9e80d6789216cbd4d1e88185b0095dba60"
+dependencies = [
+ "accesskit",
+ "hashbrown 0.16.1",
 ]
 
 [[package]]
 name = "accesskit_macos"
-version = "0.22.2"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0089e5c0ac0ca281e13ea374773898d9354cc28d15af9f0f7394d44a495b575"
+checksum = "4c5c87e8d94f2ec10cce590aadff24c76f576dab5502d45d0aed9fc3065d4451"
 dependencies = [
  "accesskit",
- "accesskit_consumer",
- "hashbrown 0.15.5",
+ "accesskit_consumer 0.36.0",
+ "hashbrown 0.16.1",
  "objc2 0.5.2",
  "objc2-app-kit 0.2.2",
  "objc2-foundation 0.2.2",
@@ -50,23 +63,23 @@ dependencies = [
 
 [[package]]
 name = "accesskit_windows"
-version = "0.29.2"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2d63dd5041e49c363d83f5419a896ecb074d309c414036f616dc0b04faca971"
+checksum = "eff7009f1a532e917d66970a1e80c965140c6cfbbabbdde3d64e5431e6c78e21"
 dependencies = [
  "accesskit",
- "accesskit_consumer",
- "hashbrown 0.15.5",
+ "accesskit_consumer 0.35.0",
+ "hashbrown 0.16.1",
  "static_assertions",
- "windows 0.61.3",
- "windows-core 0.61.2",
+ "windows",
+ "windows-core",
 ]
 
 [[package]]
 name = "accesskit_winit"
-version = "0.29.2"
+version = "0.32.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8cfabe59d0eaca7412bfb1f70198dd31e3b0496fee7e15b066f9c36a1a140a0"
+checksum = "1fe9a94394896352cc4660ca2288bd4ef883d83238853c038b44070c8f134313"
 dependencies = [
  "accesskit",
  "accesskit_macos",
@@ -116,7 +129,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f2a1bb052857d5dd49572219344a7332b31b76405648eabac5bc68978251bcd"
 dependencies = [
  "android-properties",
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
  "cc",
  "jni",
  "libc",
@@ -402,18 +415,18 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bevy"
-version = "0.18.1"
+version = "0.19.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd310426290cec560221f9750c2f4484be4a8eeea7de3483c423329b465c40e"
+checksum = "d66de79f9778e3458ca92a5a855b9e11cc4ec1b15a6c4330d8244a08d22539d9"
 dependencies = [
  "bevy_internal",
 ]
 
 [[package]]
 name = "bevy_a11y"
-version = "0.18.1"
+version = "0.19.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e887b25c84f384ffe3278a17cf0e4b405eaa3c8fbc3db24d05d560a11780676d"
+checksum = "ded05cb8442d7dae06bf4537b04ef962a955054da9cfe0f3696bcc1fd4030819"
 dependencies = [
  "accesskit",
  "bevy_app",
@@ -424,18 +437,18 @@ dependencies = [
 
 [[package]]
 name = "bevy_android"
-version = "0.18.1"
+version = "0.19.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8c58de772ac1148884112e8a456c4f127a94b95a0e42ab5b160b7a11895a241"
+checksum = "64541e1030f7da413ee8cdb33ab0f495faa9f6abc091f52ae3e6c92c62b87cc2"
 dependencies = [
  "android-activity",
 ]
 
 [[package]]
 name = "bevy_animation"
-version = "0.18.1"
+version = "0.19.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be5bf5b285f0d3fab983b4505e62e195e06930a29007ffc95bdabde834e163a2"
+checksum = "ba0889790e52bde480f668587a47d9fcb22897eb52f7f9382347fd1cad0bee17"
 dependencies = [
  "bevy_animation_macros",
  "bevy_app",
@@ -466,9 +479,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_animation_macros"
-version = "0.18.1"
+version = "0.19.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cf35516d0e7ac9ec25df533be1bf8cbaa20596a8e65f36838a3f7803a267d6d"
+checksum = "dbfe909f9337dbde81937a8a0c2cd694fc922fd7965efbc2b97813cbe04f4ed6"
 dependencies = [
  "bevy_macro_utils",
  "quote",
@@ -477,9 +490,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_app"
-version = "0.18.1"
+version = "0.19.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "def9f41aa5bf9b9dec8beda307a332798609cffb9d44f71005e0cfb45164f2f6"
+checksum = "28f104d73dc68aeb3302cc707b0d7b9dfffc968af1e317eb2a8c763637978f87"
 dependencies = [
  "bevy_derive",
  "bevy_ecs",
@@ -487,7 +500,6 @@ dependencies = [
  "bevy_reflect",
  "bevy_tasks",
  "bevy_utils",
- "cfg-if",
  "console_error_panic_hook",
  "ctrlc",
  "downcast-rs 2.0.2",
@@ -500,9 +512,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_asset"
-version = "0.18.1"
+version = "0.19.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29f86fed15972b9fb1a3f7b092cf0390e67131caaedab15a2707c043e3a3c886"
+checksum = "344fcbc5ddd6d8bb30e345f49e57aaa09a0d0c1a1c3ff799f4e24d7d31a58f0d"
 dependencies = [
  "async-broadcast",
  "async-channel",
@@ -519,7 +531,7 @@ dependencies = [
  "bevy_reflect",
  "bevy_tasks",
  "bevy_utils",
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
  "blake3",
  "crossbeam-channel",
  "derive_more",
@@ -543,9 +555,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_asset_macros"
-version = "0.18.1"
+version = "0.19.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12cb8d948365b06561b43b7d709282e62a6abb756baac5d8e295206d5e156168"
+checksum = "4c4df7c9dc906c5fe51eb04acf074da3da5a25dbd52a076d6ce411586e7b5866"
 dependencies = [
  "bevy_macro_utils",
  "proc-macro2",
@@ -555,9 +567,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_camera"
-version = "0.18.1"
+version = "0.19.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37ed9eed054e14341852236d06a7244597b1ace39ff9ae023fbd188ffde88619"
+checksum = "cc5067df9940c9a2cfff3afa16910b08b7ce4d1faeeb92cb3b58a3311e8f203d"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -576,14 +588,14 @@ dependencies = [
  "serde",
  "smallvec",
  "thiserror 2.0.18",
- "wgpu-types 27.0.1",
+ "wgpu-types",
 ]
 
 [[package]]
 name = "bevy_color"
-version = "0.18.1"
+version = "0.19.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eb41e8310a85811d14a4e75cfc2d6c07ac70661d6a4883509fc960f622970a8"
+checksum = "934c2aaae8a81c52abe727eb81775277474a8ae3fabcaa7b1043a95021d35c5c"
 dependencies = [
  "bevy_math",
  "bevy_reflect",
@@ -592,14 +604,14 @@ dependencies = [
  "encase",
  "serde",
  "thiserror 2.0.18",
- "wgpu-types 27.0.1",
+ "wgpu-types",
 ]
 
 [[package]]
 name = "bevy_core_pipeline"
-version = "0.18.1"
+version = "0.19.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d0810e85c2436e50c67448d48a83bf0bb1b5849899619ae2c7ea817221e9172"
+checksum = "36fabecc78291f004067e67017ed0f659ba9e79fb0f1146b3b753527241f6e66"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -609,6 +621,8 @@ dependencies = [
  "bevy_diagnostic",
  "bevy_ecs",
  "bevy_image",
+ "bevy_light",
+ "bevy_log",
  "bevy_math",
  "bevy_platform",
  "bevy_reflect",
@@ -617,19 +631,16 @@ dependencies = [
  "bevy_transform",
  "bevy_utils",
  "bevy_window",
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
+ "indexmap",
  "nonmax",
- "radsort",
- "smallvec",
- "thiserror 2.0.18",
- "tracing",
 ]
 
 [[package]]
 name = "bevy_derive"
-version = "0.18.1"
+version = "0.19.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "318ee0532c3da93749859d18f89a889c638fbc56aabac4d866583df7b951d103"
+checksum = "77ce110186ef6ea695480a508070fda700f2186420b60c4a4095ab04c8010685"
 dependencies = [
  "bevy_macro_utils",
  "quote",
@@ -638,9 +649,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_diagnostic"
-version = "0.18.1"
+version = "0.19.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec8543a0f7afd56d3499ba80ffab6ef0bad12f93c2d2ca9aa7b1f1b8816c3980"
+checksum = "e27715d97181fbfe169243cd2d8a629eff1538d81cb55198279d6ea8e4bdaa42"
 dependencies = [
  "atomic-waker",
  "bevy_app",
@@ -655,9 +666,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_ecs"
-version = "0.18.1"
+version = "0.19.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9cf7a3ee41342dd7b5a5d82e200d0e8efb933169247fce853b4ad633d51e87d"
+checksum = "f6129aba8aa2e48f834842233ac808205ff0a15dce1db5985ff9527a89e4f932"
 dependencies = [
  "arrayvec",
  "bevy_ecs_macros",
@@ -666,7 +677,7 @@ dependencies = [
  "bevy_reflect",
  "bevy_tasks",
  "bevy_utils",
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
  "bumpalo",
  "concurrent-queue",
  "derive_more",
@@ -682,10 +693,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "bevy_ecs_macros"
-version = "0.18.1"
+name = "bevy_ecs_macro_logic"
+version = "0.19.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "908baf585e2ea16bd53ef0da57b69580478af0059d2dbdb4369991ac9794b618"
+checksum = "04ea00892a6851d3eea365228b1e972805410656043eea137f91990ad0cf8dc6"
 dependencies = [
  "bevy_macro_utils",
  "proc-macro2",
@@ -694,10 +705,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "bevy_encase_derive"
-version = "0.18.1"
+name = "bevy_ecs_macros"
+version = "0.19.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4fee46eeddcbc00a805ae00ffa973f224671fc5cf0fe1a796963804faeade90"
+checksum = "63c96cb4b5a81501b68f2d61f181cf0c868e69f2c005f55e530e8fbd2ed3a06b"
+dependencies = [
+ "bevy_ecs_macro_logic",
+ "bevy_macro_utils",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "bevy_encase_derive"
+version = "0.19.0-rc.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e90eadd102769650cf65ae39b8722ce92bf53ab548685636e2f2101d1d7bd4b"
 dependencies = [
  "bevy_macro_utils",
  "encase_derive_impl",
@@ -705,9 +729,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_gizmos"
-version = "0.18.1"
+version = "0.19.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6aaff0dd5f405c83d290c5cd591835f1ae8009894947ab19dadcb323062bd7e7"
+checksum = "1f0f59390f390748562776b85e2fb2d14d51a49b1084b20a20c62c404f953ffb"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -715,19 +739,22 @@ dependencies = [
  "bevy_color",
  "bevy_ecs",
  "bevy_gizmos_macros",
- "bevy_light",
+ "bevy_input",
+ "bevy_log",
  "bevy_math",
+ "bevy_mesh",
  "bevy_reflect",
  "bevy_time",
  "bevy_transform",
  "bevy_utils",
+ "bevy_window",
 ]
 
 [[package]]
 name = "bevy_gizmos_macros"
-version = "0.18.1"
+version = "0.19.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6960ea308d7e94adcac5c712553ff86614bba6b663511f3f3812f6bec028b51e"
+checksum = "b6f0643399765655d53c399ed7e3b5eaa1da1132a8349452dd52451dc612cbb5"
 dependencies = [
  "bevy_macro_utils",
  "quote",
@@ -736,20 +763,24 @@ dependencies = [
 
 [[package]]
 name = "bevy_gizmos_render"
-version = "0.18.1"
+version = "0.19.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a8d18c089102de4c5e9326023ad96ba618a6961029f8102a33640b966883237"
+checksum = "72f350f91b5fc925fb6b9d7e3d038eb2f9f47a30f25e598337b151dd1287cfe5"
 dependencies = [
  "bevy_app",
  "bevy_asset",
  "bevy_camera",
+ "bevy_color",
  "bevy_core_pipeline",
  "bevy_ecs",
  "bevy_gizmos",
  "bevy_image",
+ "bevy_log",
+ "bevy_material",
  "bevy_math",
  "bevy_mesh",
  "bevy_pbr",
+ "bevy_reflect",
  "bevy_render",
  "bevy_shader",
  "bevy_sprite_render",
@@ -761,9 +792,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_gltf"
-version = "0.18.1"
+version = "0.19.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f37fb52655d0439656ca0a1db027d46926e463c81d893d4b1639668e5d7f1c1"
+checksum = "54f95e926b8b806ca48f7c01095648f373f8fd7079b9c76f3dceccd9ed086ce8"
 dependencies = [
  "async-lock",
  "base64",
@@ -775,15 +806,14 @@ dependencies = [
  "bevy_ecs",
  "bevy_image",
  "bevy_light",
+ "bevy_material",
  "bevy_math",
  "bevy_mesh",
- "bevy_pbr",
  "bevy_platform",
  "bevy_reflect",
- "bevy_render",
- "bevy_scene",
  "bevy_tasks",
  "bevy_transform",
+ "bevy_world_serialization",
  "fixedbitset 0.5.7",
  "gltf",
  "itertools",
@@ -793,13 +823,14 @@ dependencies = [
  "smallvec",
  "thiserror 2.0.18",
  "tracing",
+ "wgpu-types",
 ]
 
 [[package]]
 name = "bevy_image"
-version = "0.18.1"
+version = "0.19.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a71daf9b2afdd032c2b1122d1d501f99126218cb3e9983b3604ec381daa35f22"
+checksum = "afa87f3aeb7bef218a51d97309c596f280b9c74b247ceefb4ebc10047accd0df"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -809,7 +840,7 @@ dependencies = [
  "bevy_platform",
  "bevy_reflect",
  "bevy_utils",
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
  "bytemuck",
  "futures-lite",
  "guillotiere 0.6.2",
@@ -821,14 +852,14 @@ dependencies = [
  "serde",
  "thiserror 2.0.18",
  "tracing",
- "wgpu-types 27.0.1",
+ "wgpu-types",
 ]
 
 [[package]]
 name = "bevy_input"
-version = "0.18.1"
+version = "0.19.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbc8ffbd02df34dfc52faf420a5263985973765e228043adf542fd0d790a6b21"
+checksum = "208968122f122a81e6022fbf46796defa805cb85a72bd27335dfa9e4f12e59a4"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -843,9 +874,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_input_focus"
-version = "0.18.1"
+version = "0.19.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d48a5bceccb9157549a39ab3de4017f5368b65db6471605e9a3f1c19d91bbc"
+checksum = "9570109dde25e58adb8b5a61e5229a65ed3db1b996c2f2af8689ec7d175df71b"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -859,9 +890,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_internal"
-version = "0.18.1"
+version = "0.19.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a11df62e49897def470471551c02f13c6fb488e55dddb5ab7ef098132e07754"
+checksum = "e246a3080097f5332f4ecd1e62fd9540912468f7ad3ceeb5b5acd3cc2ad42094"
 dependencies = [
  "bevy_a11y",
  "bevy_android",
@@ -882,6 +913,7 @@ dependencies = [
  "bevy_input_focus",
  "bevy_light",
  "bevy_log",
+ "bevy_material",
  "bevy_math",
  "bevy_mesh",
  "bevy_pbr",
@@ -900,13 +932,14 @@ dependencies = [
  "bevy_utils",
  "bevy_window",
  "bevy_winit",
+ "bevy_world_serialization",
 ]
 
 [[package]]
 name = "bevy_light"
-version = "0.18.1"
+version = "0.19.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d9d2ac64390a9baacb3c0fa0f5456ac1553959d5a387874c102a09aab8b92cc"
+checksum = "67b9a83185f31f3d3a49e2b0768cf9ffd12664851e9e8ba8d6bc4658e54bd752"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -914,20 +947,24 @@ dependencies = [
  "bevy_color",
  "bevy_ecs",
  "bevy_image",
+ "bevy_log",
  "bevy_math",
  "bevy_mesh",
  "bevy_platform",
  "bevy_reflect",
  "bevy_transform",
  "bevy_utils",
+ "half",
+ "smallvec",
  "tracing",
+ "wgpu-types",
 ]
 
 [[package]]
 name = "bevy_log"
-version = "0.18.1"
+version = "0.19.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2aac1187f83a1ab2eae887564f7fb14b4abb3fbe8b2267a6426663463923120"
+checksum = "92cc20daad0dd2be92f86792c3ad9271d5db6a8bbbe0f4902cbf60e750c89414"
 dependencies = [
  "android_log-sys",
  "bevy_app",
@@ -943,21 +980,55 @@ dependencies = [
 
 [[package]]
 name = "bevy_macro_utils"
-version = "0.18.1"
+version = "0.19.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b147843b81a7ec548876ff97fa7bfdc646ef2567cb465566259237b39664438"
+checksum = "51ea607f95f39b4c5885ce62c526a687219eec645b50d2b62e245816bb0c5e55"
 dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
- "toml_edit 0.23.10+spec-1.0.0",
+ "toml_edit 0.25.11+spec-1.1.0",
+]
+
+[[package]]
+name = "bevy_material"
+version = "0.19.0-rc.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "886ee32dc90db56f24a6da4859ef19a0e1e014887ffa6e7317c207756439e64d"
+dependencies = [
+ "bevy_asset",
+ "bevy_derive",
+ "bevy_ecs",
+ "bevy_material_macros",
+ "bevy_mesh",
+ "bevy_platform",
+ "bevy_reflect",
+ "bevy_shader",
+ "bevy_utils",
+ "encase",
+ "smallvec",
+ "thiserror 2.0.18",
+ "tracing",
+ "variadics_please",
+ "wgpu-types",
+]
+
+[[package]]
+name = "bevy_material_macros"
+version = "0.19.0-rc.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eacd3335d457d0fce081735c5d0e8c2d1a32c7b70bfa76b751af43c85299502"
+dependencies = [
+ "bevy_macro_utils",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "bevy_math"
-version = "0.18.1"
+version = "0.19.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e931fa969f89c83498b22c97432383afe90e90fd1a5e04fa07be8da4d3bcac84"
+checksum = "6c1b67383d4dbfc7852e2e020a33f71c69cbd94e8e0be670f423880517928e98"
 dependencies = [
  "approx",
  "arrayvec",
@@ -966,7 +1037,7 @@ dependencies = [
  "glam",
  "itertools",
  "libm",
- "rand 0.9.4",
+ "rand 0.10.1",
  "rand_distr",
  "serde",
  "thiserror 2.0.18",
@@ -975,41 +1046,45 @@ dependencies = [
 
 [[package]]
 name = "bevy_mesh"
-version = "0.18.1"
+version = "0.19.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "288f590c8173d4cca3cae5f2ba579accd5ed1a35dd3fab338f427eb39d55f05e"
+checksum = "1edf0a03cc43ce42606df561ac169f7f003436836b22f3f8c2551699a404db50"
 dependencies = [
  "bevy_app",
  "bevy_asset",
  "bevy_derive",
  "bevy_ecs",
- "bevy_image",
+ "bevy_encase_derive",
  "bevy_math",
  "bevy_mikktspace",
  "bevy_platform",
  "bevy_reflect",
  "bevy_transform",
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
  "bytemuck",
  "derive_more",
+ "encase",
+ "glam",
+ "half",
  "hexasphere",
  "thiserror 2.0.18",
  "tracing",
- "wgpu-types 27.0.1",
+ "wgpu-types",
 ]
 
 [[package]]
 name = "bevy_mikktspace"
-version = "0.17.0-dev"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ef8e4b7e61dfe7719bb03c884dc270cd46a82efb40f93e9933b990c5c190c59"
+checksum = "bff34eb29ff4b8a8688bc7299f14fb6b597461ca80fec03ed7d22939ab33e48f"
 
 [[package]]
 name = "bevy_pbr"
-version = "0.18.1"
+version = "0.19.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5ab6944ffc6fd71604c0fbca68cc3e2a3654edfcdbfd232f9d8b88e3d20fdc0"
+checksum = "be2e00046d3e3ae73e8e73c54fa32e2f5656df7738cda397d154b2c462d75738"
 dependencies = [
+ "arrayvec",
  "bevy_app",
  "bevy_asset",
  "bevy_camera",
@@ -1018,38 +1093,44 @@ dependencies = [
  "bevy_derive",
  "bevy_diagnostic",
  "bevy_ecs",
+ "bevy_gltf",
  "bevy_image",
  "bevy_light",
  "bevy_log",
+ "bevy_material",
  "bevy_math",
  "bevy_mesh",
  "bevy_platform",
  "bevy_reflect",
  "bevy_render",
  "bevy_shader",
+ "bevy_tasks",
  "bevy_transform",
  "bevy_utils",
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
  "bytemuck",
  "derive_more",
  "fixedbitset 0.5.7",
+ "indexmap",
  "nonmax",
  "offset-allocator",
  "smallvec",
  "static_assertions",
  "thiserror 2.0.18",
  "tracing",
+ "wgpu-types",
 ]
 
 [[package]]
 name = "bevy_platform"
-version = "0.18.1"
+version = "0.19.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec6b36504169b644acd26a5469fd8d371aa6f1d73ee5c01b1b1181ae1cefbf9b"
+checksum = "20db1d0bfabbe4fd77b27ee559685235a214c29ccb0d7b20738cb58f7214bfac"
 dependencies = [
  "critical-section",
  "foldhash 0.2.0",
  "futures-channel",
+ "futures-lite",
  "hashbrown 0.16.1",
  "js-sys",
  "portable-atomic",
@@ -1059,19 +1140,20 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-time",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "bevy_ptr"
-version = "0.18.1"
+version = "0.19.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7a9329e8dc4e01ced480eeec4902e6d7cb56e56ec37f6fbc4323e5c937290a7"
+checksum = "efda0a4a01ca8e81a8b872f824b1095fc7158b17e68763d6e9b3a5bcae6d1f2e"
 
 [[package]]
 name = "bevy_reflect"
-version = "0.18.1"
+version = "0.19.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1dfeb67a9fe4f59003a84f5f99ba6302141c70e926601cbc6abfd4a1eea9ca9"
+checksum = "93acb7a4fa934897c953e831634eff7bd464abae4529978f3d80844e6729ccb6"
 dependencies = [
  "assert_type_match",
  "bevy_platform",
@@ -1093,14 +1175,14 @@ dependencies = [
  "thiserror 2.0.18",
  "uuid",
  "variadics_please",
- "wgpu-types 27.0.1",
+ "wgpu-types",
 ]
 
 [[package]]
 name = "bevy_reflect_derive"
-version = "0.18.1"
+version = "0.19.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "475f68c93e9cd5f17e9167635c8533a4f388f12d38245a202359e4c2721d87ba"
+checksum = "599b51bc40cda45073fd343aa5692e2846d2cb1e1e859144ebeac8471c6469fe"
 dependencies = [
  "bevy_macro_utils",
  "indexmap",
@@ -1112,9 +1194,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_render"
-version = "0.18.1"
+version = "0.19.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "243523e33fe5dfcebc4240b1eb2fc16e855c5d4c0ea6a8393910740956770f44"
+checksum = "6f12973b6953920328c56626a5bfa24324fa7ff761954ce1c6f2fc687c592899"
 dependencies = [
  "async-channel",
  "bevy_app",
@@ -1126,6 +1208,9 @@ dependencies = [
  "bevy_ecs",
  "bevy_encase_derive",
  "bevy_image",
+ "bevy_log",
+ "bevy_material",
+ "bevy_material_macros",
  "bevy_math",
  "bevy_mesh",
  "bevy_platform",
@@ -1137,34 +1222,35 @@ dependencies = [
  "bevy_transform",
  "bevy_utils",
  "bevy_window",
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
  "bytemuck",
  "derive_more",
  "downcast-rs 2.0.2",
  "encase",
- "fixedbitset 0.5.7",
  "glam",
  "image",
  "indexmap",
+ "itertools",
  "js-sys",
- "naga 27.0.3",
+ "naga",
  "nonmax",
  "offset-allocator",
  "send_wrapper",
  "smallvec",
  "thiserror 2.0.18",
- "tracing",
  "variadics_please",
  "wasm-bindgen",
+ "weak-table",
  "web-sys",
- "wgpu 27.0.1",
+ "wgpu",
+ "wgpu-types",
 ]
 
 [[package]]
 name = "bevy_render_macros"
-version = "0.18.1"
+version = "0.19.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66b6325e9c495a71270446784611e8d7f446f927eac8506c4c099fd10cb4c3ed"
+checksum = "a19c1272edca0b7c932ff6abae9b563d2a385ebf42502f30c7ed80be84530be0"
 dependencies = [
  "bevy_macro_utils",
  "proc-macro2",
@@ -1174,9 +1260,253 @@ dependencies = [
 
 [[package]]
 name = "bevy_scene"
-version = "0.18.1"
+version = "0.19.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34cc1047d85ec8048261b63ef675c12f1e6b5782dc0b422fbcee0c140d026bd4"
+checksum = "9cc34818c18ceca123a14a3e52753917b3a2969354b3dd054f1ab224e0f2b950"
+dependencies = [
+ "bevy_app",
+ "bevy_asset",
+ "bevy_derive",
+ "bevy_ecs",
+ "bevy_log",
+ "bevy_platform",
+ "bevy_reflect",
+ "bevy_scene_macros",
+ "bevy_utils",
+ "thiserror 2.0.18",
+ "tracing",
+ "variadics_please",
+]
+
+[[package]]
+name = "bevy_scene_macros"
+version = "0.19.0-rc.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edc3b66a9879c58998b95d9fe8ea17e31f5db5152a1cb0ee464aefcffb1e1041"
+dependencies = [
+ "bevy_ecs_macro_logic",
+ "bevy_macro_utils",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "bevy_shader"
+version = "0.19.0-rc.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28288dd8029513661be8e6c237efbef68d9585d8823671099d6ac806389c7991"
+dependencies = [
+ "bevy_asset",
+ "bevy_platform",
+ "bevy_reflect",
+ "bevy_utils",
+ "naga",
+ "naga_oil",
+ "serde",
+ "thiserror 2.0.18",
+ "tracing",
+ "wgpu-naga-bridge",
+ "wgpu-types",
+]
+
+[[package]]
+name = "bevy_sprite"
+version = "0.19.0-rc.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f872e74ebdcedc85bd6c6cd7ecf1467b3d7241ef9ff6f5b2d98b3f8684032d7"
+dependencies = [
+ "bevy_app",
+ "bevy_asset",
+ "bevy_camera",
+ "bevy_color",
+ "bevy_derive",
+ "bevy_ecs",
+ "bevy_image",
+ "bevy_log",
+ "bevy_math",
+ "bevy_mesh",
+ "bevy_reflect",
+ "bevy_transform",
+ "radsort",
+ "tracing",
+ "wgpu-types",
+]
+
+[[package]]
+name = "bevy_sprite_render"
+version = "0.19.0-rc.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d13c5820d517ba72bca7fd1fe93f0a9b17f81676dbe13937ccb56e4e05d27dcb"
+dependencies = [
+ "bevy_app",
+ "bevy_asset",
+ "bevy_camera",
+ "bevy_color",
+ "bevy_core_pipeline",
+ "bevy_derive",
+ "bevy_ecs",
+ "bevy_image",
+ "bevy_material",
+ "bevy_math",
+ "bevy_mesh",
+ "bevy_platform",
+ "bevy_reflect",
+ "bevy_render",
+ "bevy_shader",
+ "bevy_sprite",
+ "bevy_transform",
+ "bevy_utils",
+ "bitflags 2.13.0",
+ "bytemuck",
+ "derive_more",
+ "fixedbitset 0.5.7",
+ "nonmax",
+ "tracing",
+]
+
+[[package]]
+name = "bevy_state"
+version = "0.19.0-rc.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5223226ca2ecbe56f156b0bb14dfad34b46039c99f151867cc256c7e711c4df7"
+dependencies = [
+ "bevy_app",
+ "bevy_ecs",
+ "bevy_platform",
+ "bevy_reflect",
+ "bevy_state_macros",
+ "bevy_utils",
+ "log",
+ "variadics_please",
+]
+
+[[package]]
+name = "bevy_state_macros"
+version = "0.19.0-rc.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c52f21d1e9923daad5ecc56993f83f9e39482a957297a9265df0e3a6ab71e401"
+dependencies = [
+ "bevy_macro_utils",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "bevy_tasks"
+version = "0.19.0-rc.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ec5fde381db053fa4145149fc25f4204fe23809aaf5bd4d45093c7c66c5ee3b"
+dependencies = [
+ "async-channel",
+ "async-executor",
+ "async-task",
+ "atomic-waker",
+ "bevy_platform",
+ "concurrent-queue",
+ "crossbeam-queue",
+ "derive_more",
+ "futures-lite",
+ "heapless",
+ "web-task",
+]
+
+[[package]]
+name = "bevy_time"
+version = "0.19.0-rc.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ac75a7ade9d89394bd5baf6de4a5694e45791de330620d39a42b58e5bbadb43"
+dependencies = [
+ "bevy_app",
+ "bevy_ecs",
+ "bevy_platform",
+ "bevy_reflect",
+ "crossbeam-channel",
+ "log",
+ "serde",
+]
+
+[[package]]
+name = "bevy_transform"
+version = "0.19.0-rc.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb3940d9f743431dd75309b55d77a7235fdeb4dbbc9d5ac893aefd607cb2e3ec"
+dependencies = [
+ "bevy_app",
+ "bevy_ecs",
+ "bevy_math",
+ "bevy_reflect",
+ "bevy_tasks",
+ "bevy_utils",
+ "derive_more",
+ "serde",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "bevy_utils"
+version = "0.19.0-rc.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a97edfa769c752ea30b9c5f1a5bcd440c5665be4b20f0e94e6ca22cad3ed7c1"
+dependencies = [
+ "async-channel",
+ "bevy_platform",
+ "disqualified",
+ "indexmap",
+ "thread_local",
+]
+
+[[package]]
+name = "bevy_window"
+version = "0.19.0-rc.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0af4a50f23e1c006504eb249603379a4c68f06cf5558a3fd501c780723ae129"
+dependencies = [
+ "bevy_app",
+ "bevy_ecs",
+ "bevy_input",
+ "bevy_math",
+ "bevy_platform",
+ "bevy_reflect",
+ "log",
+ "raw-window-handle",
+ "serde",
+]
+
+[[package]]
+name = "bevy_winit"
+version = "0.19.0-rc.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a753a869232c1c3e7ae4087443b5ead34d772cb219917baf29c2d81dd15243"
+dependencies = [
+ "accesskit",
+ "accesskit_winit",
+ "approx",
+ "bevy_a11y",
+ "bevy_android",
+ "bevy_app",
+ "bevy_derive",
+ "bevy_ecs",
+ "bevy_input",
+ "bevy_input_focus",
+ "bevy_log",
+ "bevy_math",
+ "bevy_platform",
+ "bevy_reflect",
+ "bevy_tasks",
+ "bevy_window",
+ "js-sys",
+ "tracing",
+ "wasm-bindgen",
+ "web-sys",
+ "winit",
+]
+
+[[package]]
+name = "bevy_world_serialization"
+version = "0.19.0-rc.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b190022ab0d6e6cc3cb8fbd8ac661fb5c720cacc4c09c96b8539c2115275e63c"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1195,213 +1525,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bevy_shader"
-version = "0.18.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9eea95f0273c32be13d6a0b799a93bc256ad7830759ede595c404d5234302da2"
-dependencies = [
- "bevy_asset",
- "bevy_platform",
- "bevy_reflect",
- "naga 27.0.3",
- "naga_oil",
- "serde",
- "thiserror 2.0.18",
- "tracing",
- "wgpu-types 27.0.1",
-]
-
-[[package]]
-name = "bevy_sprite"
-version = "0.18.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96ec5bc0cbdee551b610a46f41d30374bbe42b8951ffc676253c6243ab2b9395"
-dependencies = [
- "bevy_app",
- "bevy_asset",
- "bevy_camera",
- "bevy_color",
- "bevy_derive",
- "bevy_ecs",
- "bevy_image",
- "bevy_math",
- "bevy_mesh",
- "bevy_reflect",
- "bevy_transform",
- "radsort",
- "tracing",
- "wgpu-types 27.0.1",
-]
-
-[[package]]
-name = "bevy_sprite_render"
-version = "0.18.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b82cb08905e7ddcea2694a95f757ae7f1fd01e6a7304076bad595d2158e4bfe0"
-dependencies = [
- "bevy_app",
- "bevy_asset",
- "bevy_camera",
- "bevy_color",
- "bevy_core_pipeline",
- "bevy_derive",
- "bevy_ecs",
- "bevy_image",
- "bevy_math",
- "bevy_mesh",
- "bevy_platform",
- "bevy_reflect",
- "bevy_render",
- "bevy_shader",
- "bevy_sprite",
- "bevy_transform",
- "bevy_utils",
- "bitflags 2.11.0",
- "bytemuck",
- "derive_more",
- "fixedbitset 0.5.7",
- "nonmax",
- "tracing",
-]
-
-[[package]]
-name = "bevy_state"
-version = "0.18.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ae0682968e97d29c1eccc8c6bb6283f2678d362779bc03f1bb990967059473b"
-dependencies = [
- "bevy_app",
- "bevy_ecs",
- "bevy_platform",
- "bevy_reflect",
- "bevy_state_macros",
- "bevy_utils",
- "log",
- "variadics_please",
-]
-
-[[package]]
-name = "bevy_state_macros"
-version = "0.18.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73d32f90f9cfcef5a44401db7ce206770daaa1707b0fb95eb7a96a6933f54f1b"
-dependencies = [
- "bevy_macro_utils",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "bevy_tasks"
-version = "0.18.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "384eb04d80aa38664d69988fd30cbbe03e937ecb65c66aa6abe60ce0bca826aa"
-dependencies = [
- "async-channel",
- "async-executor",
- "async-task",
- "atomic-waker",
- "bevy_platform",
- "concurrent-queue",
- "crossbeam-queue",
- "derive_more",
- "futures-lite",
- "heapless",
- "pin-project",
-]
-
-[[package]]
-name = "bevy_time"
-version = "0.18.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5ef9af4e523195e561074cf60fbfad0f4cb8d1db504855fee3c4ce8896c7244"
-dependencies = [
- "bevy_app",
- "bevy_ecs",
- "bevy_platform",
- "bevy_reflect",
- "crossbeam-channel",
- "log",
- "serde",
-]
-
-[[package]]
-name = "bevy_transform"
-version = "0.18.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c3bb3de7842fef699344beb03f22bdbff16599d788fe0f47fbb3b1e6fa320eb"
-dependencies = [
- "bevy_app",
- "bevy_ecs",
- "bevy_log",
- "bevy_math",
- "bevy_reflect",
- "bevy_tasks",
- "bevy_utils",
- "derive_more",
- "serde",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "bevy_utils"
-version = "0.18.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2111910cd7a4b1e6ce07eaaeb6f68a2c0ea0ca609ed0d0d506e3eb161101435b"
-dependencies = [
- "bevy_platform",
- "disqualified",
- "thread_local",
-]
-
-[[package]]
-name = "bevy_window"
-version = "0.18.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6df06e6993a0896bae2fe7644ae6def29a1a92b45dfb1bcebbd92af782be3638"
-dependencies = [
- "bevy_app",
- "bevy_ecs",
- "bevy_input",
- "bevy_math",
- "bevy_platform",
- "bevy_reflect",
- "log",
- "raw-window-handle",
- "serde",
-]
-
-[[package]]
-name = "bevy_winit"
-version = "0.18.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2de1c13d32ab8528435b58eca7ab874a1068184c6d6f266ee11433ae99d4069"
-dependencies = [
- "accesskit",
- "accesskit_winit",
- "approx",
- "bevy_a11y",
- "bevy_android",
- "bevy_app",
- "bevy_derive",
- "bevy_ecs",
- "bevy_input",
- "bevy_input_focus",
- "bevy_log",
- "bevy_math",
- "bevy_platform",
- "bevy_reflect",
- "bevy_tasks",
- "bevy_window",
- "cfg-if",
- "js-sys",
- "tracing",
- "wasm-bindgen",
- "web-sys",
- "winit",
-]
-
-[[package]]
 name = "bit-set"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1412,11 +1535,11 @@ dependencies = [
 
 [[package]]
 name = "bit-set"
-version = "0.8.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+checksum = "34ddef2995421ab6a5c779542c81ee77c115206f4ad9d5a8e05f4ff49716a3dd"
 dependencies = [
- "bit-vec 0.8.0",
+ "bit-vec 0.9.1",
 ]
 
 [[package]]
@@ -1427,9 +1550,9 @@ checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
 name = "bit-vec"
-version = "0.8.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+checksum = "b71798fca2c1fe1086445a7258a4bc81e6e49dcd24c8d0dd9a1e57395b603f51"
 
 [[package]]
 name = "bitflags"
@@ -1439,9 +1562,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 dependencies = [
  "bytemuck",
  "serde_core",
@@ -1460,12 +1583,6 @@ dependencies = [
  "constant_time_eq",
  "cpufeatures 0.3.0",
 ]
-
-[[package]]
-name = "block"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
 
 [[package]]
 name = "block-buffer"
@@ -1514,6 +1631,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
+name = "by_address"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64fa3c856b712db6612c019f14756e64e4bcea13337a6b33b696333a9eaa2d06"
+
+[[package]]
 name = "bytemuck"
 version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1557,7 +1680,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b99da2f8558ca23c71f4fd15dc57c906239752dd27ff3c00a1d56b685b7cbfec"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
  "log",
  "polling",
  "rustix 0.38.44",
@@ -1671,10 +1794,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "color"
-version = "0.3.2"
+name = "codespan-reporting"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a18ef4657441fb193b65f34dc39b3781f0dfec23d3bd94d0eeb4e88cde421edb"
+checksum = "af491d569909a7e4dee0ad7db7f5341fef5c614d5b8ec8cf765732aba3cff681"
+dependencies = [
+ "serde",
+ "termcolor",
+ "unicode-width",
+]
+
+[[package]]
+name = "color"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ec7c5eb7a16992b1904d76c517d170ab353b0e0b3d5a0c81a8a0cd1037893cf"
 
 [[package]]
 name = "colorchoice"
@@ -1782,16 +1916,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "core-foundation"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1804,8 +1928,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c07782be35f9e1140080c6b96f0d44b739e2278479f64e02fdab4e32dfd8b081"
 dependencies = [
  "bitflags 1.3.2",
- "core-foundation 0.9.4",
- "core-graphics-types 0.1.3",
+ "core-foundation",
+ "core-graphics-types",
  "foreign-types",
  "libc",
 ]
@@ -1817,28 +1941,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "45390e6114f68f718cc7a830514a96f903cccd70d02a8f6d9f643ac4ba45afaf"
 dependencies = [
  "bitflags 1.3.2",
- "core-foundation 0.9.4",
+ "core-foundation",
  "libc",
-]
-
-[[package]]
-name = "core-graphics-types"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d44a101f213f6c4cdc1853d4b78aef6db6bdfa3468798cc1d9912f4735013eb"
-dependencies = [
- "bitflags 2.11.0",
- "core-foundation 0.10.1",
- "libc",
-]
-
-[[package]]
-name = "core_maths"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77745e017f5edba1a9c1d854f6f3a52dac8a12dd5af5d2f54aecf61e43d80d30"
-dependencies = [
- "libm",
 ]
 
 [[package]]
@@ -1904,7 +2008,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
  "crossterm_winapi",
  "derive_more",
  "document-features",
@@ -2089,7 +2193,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
  "block2 0.6.2",
  "libc",
  "objc2 0.6.4",
@@ -2269,6 +2373,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fast-srgb8"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd2e7510819d6fbf51a5545c8f922716ecfb14df168a3242f7d33e0239efe6a1"
+
+[[package]]
 name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2377,9 +2487,9 @@ dependencies = [
 
 [[package]]
 name = "fontique"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c20b425addb8661e97fe1d51c4d8bcec3ec29ed6ad0db983976a7521276b8f7"
+checksum = "274fa4f0f0a926ae182c7c076c078cce8a38471d15e61a102a02cac984be9813"
 dependencies = [
  "hashbrown 0.17.0",
  "linebender_resource_handle",
@@ -2389,11 +2499,11 @@ dependencies = [
  "objc2-core-text",
  "objc2-foundation 0.3.2",
  "parlance",
- "read-fonts 0.39.2",
+ "read-fonts",
  "roxmltree",
  "smallvec",
- "windows 0.62.2",
- "windows-core 0.62.2",
+ "windows",
+ "windows-core",
  "yeslogic-fontconfig-sys",
 ]
 
@@ -2516,7 +2626,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
 dependencies = [
  "rustix 1.1.4",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -2568,22 +2678,22 @@ dependencies = [
 
 [[package]]
 name = "glam"
-version = "0.30.10"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19fc433e8437a212d1b6f1e68c7824af3aed907da60afa994e7f542d18d12aa9"
+checksum = "f70749695b063ecbf6b62949ccccde2e733ec3ecbbd71d467dca4e5c6c97cca0"
 dependencies = [
  "bytemuck",
  "encase",
  "libm",
- "rand 0.9.4",
+ "rand 0.10.1",
  "serde_core",
 ]
 
 [[package]]
 name = "glow"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5e5ea60d70410161c8bf5da3fdfeaa1c72ed2c15f8bbb9d19fe3a4fad085f08"
+checksum = "29038e1c483364cc6bb3cf78feee1816002e127c331a1eec55a4d202b9e1adb5"
 dependencies = [
  "js-sys",
  "slotmap",
@@ -2637,37 +2747,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "gpu-alloc"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbcd2dba93594b227a1f57ee09b8b9da8892c34d55aa332e034a228d0fe6a171"
-dependencies = [
- "bitflags 2.11.0",
- "gpu-alloc-types",
-]
-
-[[package]]
-name = "gpu-alloc-types"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98ff03b468aa837d70984d55f5d3f846f6ec31fe34bbb97c4f85219caeee1ca4"
-dependencies = [
- "bitflags 2.11.0",
-]
-
-[[package]]
-name = "gpu-allocator"
-version = "0.27.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c151a2a5ef800297b4e79efa4f4bec035c5f51d5ae587287c9b952bdf734cacd"
-dependencies = [
- "log",
- "presser",
- "thiserror 1.0.69",
- "windows 0.58.0",
-]
-
-[[package]]
 name = "gpu-allocator"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2678,7 +2757,7 @@ dependencies = [
  "log",
  "presser",
  "thiserror 2.0.18",
- "windows 0.62.2",
+ "windows",
 ]
 
 [[package]]
@@ -2687,7 +2766,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b89c83349105e3732062a895becfc71a8f921bb71ecbbdd8ff99263e3b53a0ca"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
  "gpu-descriptor-types",
  "hashbrown 0.15.5",
 ]
@@ -2698,7 +2777,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdf242682df893b86f33a73828fb09ca4b2d3bb6cc95249707fc684d27484b91"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -2727,6 +2806,7 @@ version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
 dependencies = [
+ "bytemuck",
  "cfg-if",
  "crunchy",
  "num-traits",
@@ -2735,14 +2815,13 @@ dependencies = [
 
 [[package]]
 name = "harfrust"
-version = "0.6.0"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9ce5e848d21ba97a324266e41c70e0eb5e2577a610c1fbd546e15096f2e8e37"
+checksum = "d12c7c642d4ce8c2e784b4751a6634bd89583912265add4a679a8882d123fbcd"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
  "bytemuck",
- "core_maths",
- "read-fonts 0.39.2",
+ "read-fonts",
  "smallvec",
 ]
 
@@ -2783,6 +2862,8 @@ version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash 0.2.0",
 ]
 
@@ -2817,9 +2898,9 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hexasphere"
-version = "16.0.0"
+version = "18.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29a164ceff4500f2a72b1d21beaa8aa8ad83aec2b641844c659b190cb3ea2e0b"
+checksum = "177ea6330876de4ef08e184f827b98acc037614a4ce409902c5b0d53a9c2e951"
 dependencies = [
  "constgebra",
  "glam",
@@ -3078,7 +3159,7 @@ dependencies = [
  "simd_cesu8",
  "thiserror 2.0.18",
  "walkdir",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -3174,21 +3255,22 @@ checksum = "e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc"
 
 [[package]]
 name = "ktx2"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff7f53bdf698e7aa7ec916411bbdc8078135da11b66db5182675b2227f6c0d07"
+checksum = "1d50be8a24c37debdf3170be6ca396d5b5b165f37f94837891adac735ca416b8"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
 name = "kurbo"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7564e90fe3c0d5771e1f0bc95322b21baaeaa0d9213fa6a0b61c99f8b17b3bfb"
+checksum = "4b60dfc32f652b926df6192e55525b16d186c69d47876c3ead4da5cc9f8450e2"
 dependencies = [
  "arrayvec",
  "euclid",
+ "polycool",
  "smallvec",
 ]
 
@@ -3223,7 +3305,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
 dependencies = [
  "cfg-if",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -3238,7 +3320,7 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
  "libc",
  "plain",
  "redox_syscall 0.7.4",
@@ -3250,7 +3332,7 @@ version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f50e8f47623268b5407192d26876c4d7f89d686ca130fdc53bced4814cd29f8"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -3300,11 +3382,11 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "lru"
-version = "0.16.3"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1dc47f592c06f33f8e3aea9591776ec7c9f9e4124778ff8a3c3b87159f7e593"
+checksum = "8a860605968fce16869fd239cf4237a82f3ac470723415db603b0e8b6c8d4fb9"
 dependencies = [
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
 ]
 
 [[package]]
@@ -3315,15 +3397,6 @@ checksum = "c0aeb26bf5e836cc1c341c8106051b573f1766dfa05aa87f0b98be5e51b02303"
 dependencies = [
  "nix 0.29.0",
  "winapi",
-]
-
-[[package]]
-name = "malloc_buf"
-version = "0.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb"
-dependencies = [
- "libc",
 ]
 
 [[package]]
@@ -3375,36 +3448,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "metal"
-version = "0.32.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00c15a6f673ff72ddcc22394663290f870fb224c1bfce55734a75c414150e605"
-dependencies = [
- "bitflags 2.11.0",
- "block",
- "core-graphics-types 0.2.0",
- "foreign-types",
- "log",
- "objc",
- "paste",
-]
-
-[[package]]
-name = "metal"
-version = "0.33.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7047791b5bc903b8cd963014b355f71dc9864a9a0b727057676c1dcae5cbc15"
-dependencies = [
- "bitflags 2.11.0",
- "block",
- "core-graphics-types 0.2.0",
- "foreign-types",
- "log",
- "objc",
- "paste",
-]
-
-[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3444,16 +3487,16 @@ dependencies = [
 
 [[package]]
 name = "naga"
-version = "27.0.3"
+version = "29.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "066cf25f0e8b11ee0df221219010f213ad429855f57c494f995590c861a9a7d8"
+checksum = "0dd91265cc2454558f659b3b4b9640f0ddb8cc6521277f166b8a8c181c898079"
 dependencies = [
  "arrayvec",
- "bit-set 0.8.0",
- "bitflags 2.11.0",
+ "bit-set 0.9.1",
+ "bitflags 2.13.0",
  "cfg-if",
  "cfg_aliases",
- "codespan-reporting",
+ "codespan-reporting 0.13.1",
  "half",
  "hashbrown 0.16.1",
  "hexf-parse",
@@ -3470,41 +3513,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "naga"
-version = "28.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "618f667225063219ddfc61251087db8a9aec3c3f0950c916b614e403486f1135"
-dependencies = [
- "arrayvec",
- "bit-set 0.8.0",
- "bitflags 2.11.0",
- "cfg-if",
- "cfg_aliases",
- "codespan-reporting",
- "half",
- "hashbrown 0.16.1",
- "hexf-parse",
- "indexmap",
- "libm",
- "log",
- "num-traits",
- "once_cell",
- "rustc-hash",
- "spirv",
- "thiserror 2.0.18",
- "unicode-ident",
-]
-
-[[package]]
 name = "naga_oil"
-version = "0.20.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "310c347db1b30e69581f3b84dc9a5c311ed583f67851b39b77953cb7a066c97f"
+checksum = "319f03062940ed85c03da020042618356bb8ca5263020322930883b05e30208e"
 dependencies = [
- "codespan-reporting",
+ "codespan-reporting 0.12.0",
  "data-encoding",
  "indexmap",
- "naga 27.0.3",
+ "naga",
  "regex",
  "rustc-hash",
  "thiserror 2.0.18",
@@ -3518,7 +3535,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3f42e7bbe13d351b6bead8286a43aac9534b82bd3cc43e47037f012ebfd62d4"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
  "jni-sys 0.3.1",
  "log",
  "ndk-sys",
@@ -3562,7 +3579,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -3575,7 +3592,7 @@ version = "0.31.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d6d0705320c1e6ba1d912b5e37cf18071b6c2e9b7fa8215a1e8a7651966f5d3"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -3674,15 +3691,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "objc"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "915b1b472bc21c53464d6c8461c9d3af805ba1ef837e1cac254428f4a77177b1"
-dependencies = [
- "malloc_buf",
-]
-
-[[package]]
 name = "objc-sys"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3713,14 +3721,14 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4e89ad9e3d7d297152b17d39ed92cd50ca8063a89a9fa569046d41568891eff"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
  "block2 0.5.1",
  "libc",
  "objc2 0.5.2",
  "objc2-core-data",
  "objc2-core-image",
  "objc2-foundation 0.2.2",
- "objc2-quartz-core",
+ "objc2-quartz-core 0.2.2",
 ]
 
 [[package]]
@@ -3729,7 +3737,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
  "objc2 0.6.4",
  "objc2-core-graphics",
  "objc2-foundation 0.3.2",
@@ -3741,7 +3749,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74dd3b56391c7a0596a295029734d3c1c5e7e510a4cb30245f8221ccea96b009"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
  "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-core-location",
@@ -3765,7 +3773,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "617fbf49e071c178c0b24c080767db52958f716d9eabdf0890523aeae54773ef"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
  "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-foundation 0.2.2",
@@ -3777,7 +3785,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
  "dispatch2",
  "objc2 0.6.4",
 ]
@@ -3788,7 +3796,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
  "dispatch2",
  "objc2 0.6.4",
  "objc2-core-foundation",
@@ -3804,7 +3812,7 @@ dependencies = [
  "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-foundation 0.2.2",
- "objc2-metal",
+ "objc2-metal 0.2.2",
 ]
 
 [[package]]
@@ -3825,7 +3833,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cde0dfb48d25d2b4862161a4d5fcc0e3c24367869ad306b0c9ec0073bfed92d"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
  "objc2-core-foundation",
 ]
 
@@ -3841,7 +3849,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ee638a5da3799329310ad4cfa62fbf045d5f56e3ef5ba4149e7452dcf89d5a8"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
  "block2 0.5.1",
  "dispatch",
  "libc",
@@ -3854,7 +3862,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
  "objc2 0.6.4",
  "objc2-core-foundation",
 ]
@@ -3865,7 +3873,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
  "objc2 0.6.4",
  "objc2-core-foundation",
 ]
@@ -3888,10 +3896,22 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd0cba1276f6023976a406a14ffa85e1fdd19df6b0f737b063b95f6c8c7aadd6"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
  "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-foundation 0.2.2",
+]
+
+[[package]]
+name = "objc2-metal"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0125f776a10d00af4152d74616409f0d4a2053a6f57fa5b7d6aa2854ac04794"
+dependencies = [
+ "bitflags 2.13.0",
+ "block2 0.6.2",
+ "objc2 0.6.4",
+ "objc2-foundation 0.3.2",
 ]
 
 [[package]]
@@ -3900,11 +3920,24 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e42bee7bff906b14b167da2bac5efe6b6a07e6f7c0a21a7308d40c960242dc7a"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
  "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-foundation 0.2.2",
- "objc2-metal",
+ "objc2-metal 0.2.2",
+]
+
+[[package]]
+name = "objc2-quartz-core"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96c1358452b371bf9f104e21ec536d37a650eb10f7ee379fff67d2e08d537f1f"
+dependencies = [
+ "bitflags 2.13.0",
+ "objc2 0.6.4",
+ "objc2-core-foundation",
+ "objc2-foundation 0.3.2",
+ "objc2-metal 0.3.2",
 ]
 
 [[package]]
@@ -3923,7 +3956,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8bb46798b20cd6b91cbd113524c490f1686f4c4e8f49502431415f3512e2b6f"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
  "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-cloud-kit",
@@ -3932,7 +3965,7 @@ dependencies = [
  "objc2-core-location",
  "objc2-foundation 0.2.2",
  "objc2-link-presentation",
- "objc2-quartz-core",
+ "objc2-quartz-core 0.2.2",
  "objc2-symbols",
  "objc2-uniform-type-identifiers",
  "objc2-user-notifications",
@@ -3955,7 +3988,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76cfcbf642358e8689af64cee815d139339f3ed8ad05103ed5eaf73db8d84cb3"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
  "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-core-location",
@@ -4029,6 +4062,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "palette"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cbf71184cc5ecc2e4e1baccdb21026c20e5fc3dcf63028a086131b3ab00b6e6"
+dependencies = [
+ "approx",
+ "fast-srgb8",
+ "libm",
+ "palette_derive",
+]
+
+[[package]]
+name = "palette_derive"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5030daf005bface118c096f510ffb781fc28f9ab6a32ab224d8631be6851d30"
+dependencies = [
+ "by_address",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "parking"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4054,7 +4111,7 @@ dependencies = [
  "libc",
  "redox_syscall 0.5.18",
  "smallvec",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -4065,9 +4122,9 @@ checksum = "4b6937eda350acc1a5d05872c3cbf99fe78619c269096e2be3d4a350058639d5"
 
 [[package]]
 name = "parley"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fad031076f48f0d4d85ce1aea9b94b4e715a4d636a030a123038f8f5b5e4343"
+checksum = "6b1cfcf399c774719fb1fa51bc6b91e86bdf003b03202a0902f1827ba6750746"
 dependencies = [
  "fontique",
  "harfrust",
@@ -4078,25 +4135,25 @@ dependencies = [
  "linebender_resource_handle",
  "parlance",
  "parley_data",
- "skrifa 0.42.1",
+ "skrifa",
 ]
 
 [[package]]
 name = "parley_data"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19ab9ace3fad1b9ed603ddac5b595e69931fc50263d7e04e4055015b77b02da5"
+checksum = "d1d3755e2cc12c0625b0cd2f2773c6a37dd11d1531940c945ade4aeb78f2b145"
 dependencies = [
  "icu_properties",
 ]
 
 [[package]]
 name = "parley_ratatui"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c7068b94ff255cdfa17af62555934b5b13bf5903cd49a224cc1f403ec44f68b"
+checksum = "4395814f28ed6096631e6ea53cd5d3f1142ccb5731c2f2ab6b88e7d93b9ae38b"
 dependencies = [
- "naga 28.0.0",
+ "naga",
  "parley",
  "ratatui",
  "swash",
@@ -4105,16 +4162,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "paste"
-version = "1.0.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
-
-[[package]]
 name = "peniko"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2b6aadb221872732e87d465213e9be5af2849b0e8cc5300a8ba98fffa2e00a"
+checksum = "839c8299360d2e998bdb106dc0a6cd71dcc5f4df51df1b620361bf50e283cca6"
 dependencies = [
  "color",
  "kurbo",
@@ -4297,7 +4348,7 @@ version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
  "crc32fast",
  "fdeflate",
  "flate2",
@@ -4319,10 +4370,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "pollster"
+name = "polycool"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f3a9f18d041e6d0e102a0a46750538147e5e8992d3b4873aaafee2520b00ce3"
+checksum = "50596ddc09eb5ad5f75cacd40209568e66df71baf86e1499a0e99c4cff12a5a6"
+dependencies = [
+ "arrayvec",
+]
 
 [[package]]
 name = "portable-atomic"
@@ -4384,15 +4438,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb458bb7f6e250e6eb79d5026badc10a3ebb8f9a15d1fff0f13d17c71f4d6dee"
 dependencies = [
  "unicode-xid",
-]
-
-[[package]]
-name = "ppv-lite86"
-version = "0.2.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
-dependencies = [
- "zerocopy",
 ]
 
 [[package]]
@@ -4494,22 +4539,12 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.4"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
- "rand_chacha",
- "rand_core 0.9.5",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.9.5",
+ "getrandom 0.4.2",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -4520,21 +4555,18 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "rand_core"
-version = "0.9.5"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
-dependencies = [
- "getrandom 0.3.4",
-]
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rand_distr"
-version = "0.5.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8615d50dcf34fa31f7ab52692afec947c4dd0ab803cc87cb3b0b4570ff7463"
+checksum = "4d431c2703ccf129de4d45253c03f49ebb22b97d6ad79ee3ecfc7e3f4862c1d8"
 dependencies = [
  "num-traits",
- "rand 0.9.4",
+ "rand 0.10.1",
 ]
 
 [[package]]
@@ -4545,9 +4577,9 @@ checksum = "ca45419789ae5a7899559e9512e58ca889e41f04f1f2445e9f4b290ceccd1d08"
 
 [[package]]
 name = "ratatui"
-version = "0.30.0"
+version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1ce67fb8ba4446454d1c8dbaeda0557ff5e94d39d5e5ed7f10a65eb4c8266bc"
+checksum = "1695748e3a735b34968c887ceea5a380b43545903868ae8f5b666593100f6b68"
 dependencies = [
  "instability",
  "ratatui-core",
@@ -4555,21 +4587,25 @@ dependencies = [
  "ratatui-macros",
  "ratatui-termwiz",
  "ratatui-widgets",
+ "serde",
 ]
 
 [[package]]
 name = "ratatui-core"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ef8dea09a92caaf73bff7adb70b76162e5937524058a7e5bff37869cbbec293"
+checksum = "42d3603f354bba8c595fa47860e60142d7372b7210c27044c6a7d0e1a4336b44"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
  "compact_str",
- "hashbrown 0.16.1",
+ "critical-section",
+ "hashbrown 0.17.0",
  "indoc",
  "itertools",
  "kasuari",
  "lru",
+ "palette",
+ "serde",
  "strum",
  "thiserror 2.0.18",
  "unicode-segmentation",
@@ -4579,9 +4615,9 @@ dependencies = [
 
 [[package]]
 name = "ratatui-crossterm"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "577c9b9f652b4c121fb25c6a391dd06406d3b092ba68827e6d2f09550edc54b3"
+checksum = "2b2867bedcbd6a690ca4f8672a687b730ec07660c79844517b084311b529980c"
 dependencies = [
  "cfg-if",
  "crossterm",
@@ -4591,9 +4627,9 @@ dependencies = [
 
 [[package]]
 name = "ratatui-macros"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7f1342a13e83e4bb9d0b793d0ea762be633f9582048c892ae9041ef39c936f4"
+checksum = "80fac59720679490d89d200df411faa249be728681adcabed3d047ae72c48f1d"
 dependencies = [
  "ratatui-core",
  "ratatui-widgets",
@@ -4601,9 +4637,9 @@ dependencies = [
 
 [[package]]
 name = "ratatui-termwiz"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f76fe0bd0ed4295f0321b1676732e2454024c15a35d01904ddb315afd3d545c"
+checksum = "386b8ff8f74ed749509391c56d549761a2fcdb408e1f42e467286bcb7dac8967"
 dependencies = [
  "ratatui-core",
  "termwiz",
@@ -4611,17 +4647,18 @@ dependencies = [
 
 [[package]]
 name = "ratatui-widgets"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7dbfa023cd4e604c2553483820c5fe8aa9d71a42eea5aa77c6e7f35756612db"
+checksum = "7ef4f17dd7ac3abf5adc2b920a03c61eee4bfe6a88fa5191936895525371d79c"
 dependencies = [
- "bitflags 2.11.0",
- "hashbrown 0.16.1",
+ "bitflags 2.13.0",
+ "hashbrown 0.17.0",
  "indoc",
  "instability",
  "itertools",
  "line-clipping",
  "ratatui-core",
+ "serde",
  "strum",
  "time",
  "unicode-segmentation",
@@ -4640,7 +4677,6 @@ dependencies = [
  "etcetera",
  "image",
  "parley_ratatui",
- "pollster",
  "portable-pty",
  "ratatui",
  "rust-embed",
@@ -4661,13 +4697,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
 
 [[package]]
-name = "read-fonts"
-version = "0.37.0"
+name = "raw-window-metal"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b634fabf032fab15307ffd272149b622260f55974d9fad689292a5d33df02e5"
+checksum = "40d213455a5f1dc59214213c7330e074ddf8114c9a42411eb890c767357ce135"
 dependencies = [
- "bytemuck",
- "font-types",
+ "objc2 0.6.4",
+ "objc2-core-foundation",
+ "objc2-foundation 0.3.2",
+ "objc2-quartz-core 0.3.2",
 ]
 
 [[package]]
@@ -4677,7 +4715,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4ed38b89c2c77ff968c524145ad65fb010f38af5c7a224b53b81d47ac2daa81"
 dependencies = [
  "bytemuck",
- "core_maths",
  "font-types",
 ]
 
@@ -4702,7 +4739,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -4711,7 +4748,7 @@ version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -4766,7 +4803,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4147b952f3f819eca0e99527022f7d6a8d05f111aeb0a62960c74eb283bec8fc"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
  "once_cell",
  "serde",
  "serde_derive",
@@ -4838,7 +4875,7 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
@@ -4851,7 +4888,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
@@ -5140,22 +5177,12 @@ checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
 
 [[package]]
 name = "skrifa"
-version = "0.40.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fbdfe3d2475fbd7ddd1f3e5cf8288a30eb3e5f95832829570cd88115a7434ac"
-dependencies = [
- "bytemuck",
- "read-fonts 0.37.0",
-]
-
-[[package]]
-name = "skrifa"
 version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c34617370ae968efb7161bb2beb517d9084659aae19e24b89e3db25b46e4564"
 dependencies = [
  "bytemuck",
- "read-fonts 0.39.2",
+ "read-fonts",
 ]
 
 [[package]]
@@ -5185,7 +5212,7 @@ version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3457dea1f0eb631b4034d61d4d8c32074caa6cd1ab2d59f2327bd8461e2c0016"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
  "calloop",
  "calloop-wayland-source",
  "cursor-icon",
@@ -5224,11 +5251,11 @@ dependencies = [
 
 [[package]]
 name = "spirv"
-version = "0.3.0+sdk-1.3.268.0"
+version = "0.4.0+sdk-1.4.341.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eda41003dc44290527a59b13432d4a0379379fa074b70174882adfbdfd917844"
+checksum = "d9571ea910ebd84c86af4b3ed27f9dbdc6ad06f17c5f96146b2b671e2976744f"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -5272,18 +5299,18 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"
-version = "0.27.2"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
 dependencies = [
  "strum_macros",
 ]
 
 [[package]]
 name = "strum_macros"
-version = "0.27.2"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -5299,11 +5326,11 @@ checksum = "0193cc4331cfd2f3d2011ef287590868599a2f33c3e69bc22c1a3d3acf9e02fb"
 
 [[package]]
 name = "swash"
-version = "0.2.7"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "842f3cd369c2ba38966204f983eaa5e54a8e84a7d7159ed36ade2b6c335aae64"
+checksum = "d1804632b66a35ca2b1d277eb0a138e10f46cb365b9a6d297e876b69ef79de43"
 dependencies = [
- "skrifa 0.40.0",
+ "skrifa",
  "yazi",
  "zeno",
 ]
@@ -5388,7 +5415,7 @@ checksum = "4676b37242ccbd1aabf56edb093a4827dc49086c0ffd764a5705899e0f35f8f7"
 dependencies = [
  "anyhow",
  "base64",
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
  "fancy-regex",
  "filedescriptor",
  "finl_unicode",
@@ -5604,15 +5631,6 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.7.5+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
-dependencies = [
- "serde_core",
-]
-
-[[package]]
-name = "toml_datetime"
 version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
@@ -5631,18 +5649,6 @@ dependencies = [
  "serde_spanned 0.6.9",
  "toml_datetime 0.6.11",
  "toml_write",
- "winnow 0.7.15",
-]
-
-[[package]]
-name = "toml_edit"
-version = "0.23.10+spec-1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84c8b9f757e028cee9fa244aea147aab2a9ec09d5325a9b01e0a49730c2b5269"
-dependencies = [
- "indexmap",
- "toml_datetime 0.7.5+spec-1.1.0",
- "toml_parser",
  "winnow 0.7.15",
 ]
 
@@ -5889,45 +5895,45 @@ dependencies = [
 
 [[package]]
 name = "vello"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7484a935acbced16ca6b2a7e6c8d6aa2b32ca0aff269c1b95f62be9b8f672c41"
+checksum = "261359dbef879f8110ef7e1c442246c838d33d3d91cb05e0ea9288d432760c9f"
 dependencies = [
  "bytemuck",
  "futures-intrusive",
  "log",
  "peniko",
  "png",
- "skrifa 0.40.0",
+ "skrifa",
  "static_assertions",
  "thiserror 2.0.18",
  "vello_encoding",
  "vello_shaders",
- "wgpu 28.0.0",
+ "wgpu",
 ]
 
 [[package]]
 name = "vello_encoding"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d53d864987821f40431e62608bf0f58342db57f2f2860628c8cfc28e16a1cc39"
+checksum = "2346f5f0d7dccb3582fcd397b4a57b43165209f1424e0d76e85dd814db164af7"
 dependencies = [
  "bytemuck",
  "guillotiere 0.7.0",
  "peniko",
- "skrifa 0.40.0",
+ "skrifa",
  "smallvec",
 ]
 
 [[package]]
 name = "vello_shaders"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c455e04d570129212ecc4c0fdaa051ad66e5be15781a75b38c519d08120db374"
+checksum = "9dd38937516fa4b47423d9255bb5e4a65e839ec9d57c38c4af6189ce56bf46b7"
 dependencies = [
  "bytemuck",
  "log",
- "naga 28.0.0",
+ "naga",
  "thiserror 2.0.18",
  "vello_encoding",
 ]
@@ -6085,7 +6091,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
@@ -6111,7 +6117,7 @@ version = "0.31.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "645c7c96bb74690c3189b5c9cb4ca1627062bb23693a4fad9d8c3de958260144"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
  "rustix 1.1.4",
  "wayland-backend",
  "wayland-scanner",
@@ -6123,7 +6129,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "625c5029dbd43d25e6aa9615e88b829a5cad13b2819c4ae129fdbb7c31ab4c7e"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
  "cursor-icon",
  "wayland-backend",
 ]
@@ -6145,7 +6151,7 @@ version = "0.32.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "563a85523cade2429938e790815fd7319062103b9f4a2dc806e9b53b95982d8f"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
  "wayland-backend",
  "wayland-client",
  "wayland-scanner",
@@ -6157,7 +6163,7 @@ version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b6d8cf1eb2c1c31ed1f5643c88a6e53538129d4af80030c8cabd1f9fa884d91"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
  "wayland-backend",
  "wayland-client",
  "wayland-protocols",
@@ -6170,7 +6176,7 @@ version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb04e52f7836d7c7976c78ca0250d61e33873c34156a2a1fc9474828ec268234"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
  "wayland-backend",
  "wayland-client",
  "wayland-protocols",
@@ -6196,8 +6202,15 @@ checksum = "d8eab23fefc9e41f8e841df4a9c707e8a8c4ed26e944ef69297184de2785e3be"
 dependencies = [
  "dlib",
  "log",
+ "once_cell",
  "pkg-config",
 ]
+
+[[package]]
+name = "weak-table"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "323f4da9523e9a669e1eaf9c6e763892769b1d38c623913647bfdc1532fe4549"
 
 [[package]]
 name = "web-sys"
@@ -6205,6 +6218,18 @@ version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
 dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-task"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cdc136a53ccd64a1211f107ccc34404769fbcc0f165f1afa065f5d88ab93538"
+dependencies = [
+ "async-task",
+ "cfg-if",
  "js-sys",
  "wasm-bindgen",
 ]
@@ -6299,36 +6324,12 @@ dependencies = [
 
 [[package]]
 name = "wgpu"
-version = "27.0.1"
+version = "29.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfe68bac7cde125de7a731c3400723cadaaf1703795ad3f4805f187459cd7a77"
+checksum = "bb3feacc458f7bee8bc1737149b42b6c731aa461039a4264a67bb6681646b250"
 dependencies = [
  "arrayvec",
- "bitflags 2.11.0",
- "cfg-if",
- "cfg_aliases",
- "document-features",
- "hashbrown 0.16.1",
- "log",
- "naga 27.0.3",
- "portable-atomic",
- "profiling",
- "raw-window-handle",
- "smallvec",
- "static_assertions",
- "wgpu-core 27.0.3",
- "wgpu-hal 27.0.4",
- "wgpu-types 27.0.1",
-]
-
-[[package]]
-name = "wgpu"
-version = "28.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9cb534d5ffd109c7d1135f34cdae29e60eab94855a625dcfe1705f8bc7ad79f"
-dependencies = [
- "arrayvec",
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
  "bytemuck",
  "cfg-if",
  "cfg_aliases",
@@ -6336,7 +6337,7 @@ dependencies = [
  "hashbrown 0.16.1",
  "js-sys",
  "log",
- "naga 28.0.0",
+ "naga",
  "parking_lot",
  "portable-atomic",
  "profiling",
@@ -6346,28 +6347,28 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "wgpu-core 28.0.1",
- "wgpu-hal 28.0.1",
- "wgpu-types 28.0.0",
+ "wgpu-core",
+ "wgpu-hal",
+ "wgpu-types",
 ]
 
 [[package]]
 name = "wgpu-core"
-version = "27.0.3"
+version = "29.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27a75de515543b1897b26119f93731b385a19aea165a1ec5f0e3acecc229cae7"
+checksum = "02da3ad1b568337f25513b317870960ef87073ea0945502e44b864b67a8c77b7"
 dependencies = [
  "arrayvec",
- "bit-set 0.8.0",
- "bit-vec 0.8.0",
- "bitflags 2.11.0",
+ "bit-set 0.9.1",
+ "bit-vec 0.9.1",
+ "bitflags 2.13.0",
  "bytemuck",
  "cfg_aliases",
  "document-features",
  "hashbrown 0.16.1",
  "indexmap",
  "log",
- "naga 27.0.3",
+ "naga",
  "once_cell",
  "parking_lot",
  "portable-atomic",
@@ -6376,150 +6377,59 @@ dependencies = [
  "rustc-hash",
  "smallvec",
  "thiserror 2.0.18",
- "wgpu-core-deps-apple 27.0.0",
- "wgpu-core-deps-windows-linux-android 27.0.0",
- "wgpu-hal 27.0.4",
- "wgpu-types 27.0.1",
-]
-
-[[package]]
-name = "wgpu-core"
-version = "28.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d23f4642f53f666adcfd2d3218ab174d1e6681101aef18696b90cbe64d1c10f9"
-dependencies = [
- "arrayvec",
- "bit-set 0.8.0",
- "bit-vec 0.8.0",
- "bitflags 2.11.0",
- "bytemuck",
- "cfg_aliases",
- "document-features",
- "hashbrown 0.16.1",
- "indexmap",
- "log",
- "naga 28.0.0",
- "once_cell",
- "parking_lot",
- "portable-atomic",
- "profiling",
- "raw-window-handle",
- "rustc-hash",
- "smallvec",
- "thiserror 2.0.18",
- "wgpu-core-deps-apple 28.0.0",
+ "wgpu-core-deps-apple",
  "wgpu-core-deps-emscripten",
- "wgpu-core-deps-windows-linux-android 28.0.0",
- "wgpu-hal 28.0.1",
- "wgpu-types 28.0.0",
+ "wgpu-core-deps-windows-linux-android",
+ "wgpu-hal",
+ "wgpu-naga-bridge",
+ "wgpu-types",
 ]
 
 [[package]]
 name = "wgpu-core-deps-apple"
-version = "27.0.0"
+version = "29.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0772ae958e9be0c729561d5e3fd9a19679bcdfb945b8b1a1969d9bfe8056d233"
+checksum = "62e51b5447e144b3dbba4feb01f80f4fa21696fa0cd99afb2c3df1affd6fdb28"
 dependencies = [
- "wgpu-hal 27.0.4",
-]
-
-[[package]]
-name = "wgpu-core-deps-apple"
-version = "28.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87b7b696b918f337c486bf93142454080a32a37832ba8a31e4f48221890047da"
-dependencies = [
- "wgpu-hal 28.0.1",
+ "wgpu-hal",
 ]
 
 [[package]]
 name = "wgpu-core-deps-emscripten"
-version = "28.0.0"
+version = "29.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34b251c331f84feac147de3c4aa3aa45112622a95dd7ee1b74384fa0458dbd79"
+checksum = "3487cd6293a963bc5c0c0396f6a2192043c50003c07f4efdccbad3d90ec9d819"
 dependencies = [
- "wgpu-hal 28.0.1",
+ "wgpu-hal",
 ]
 
 [[package]]
 name = "wgpu-core-deps-windows-linux-android"
-version = "27.0.0"
+version = "29.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71197027d61a71748e4120f05a9242b2ad142e3c01f8c1b47707945a879a03c3"
+checksum = "1bfb01076d0aa08b0ba9bd741e178b5cc440f5abe99d9581323a4c8b5d1a1916"
 dependencies = [
- "wgpu-hal 27.0.4",
-]
-
-[[package]]
-name = "wgpu-core-deps-windows-linux-android"
-version = "28.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68ca976e72b2c9964eb243e281f6ce7f14a514e409920920dcda12ae40febaae"
-dependencies = [
- "wgpu-hal 28.0.1",
+ "wgpu-hal",
 ]
 
 [[package]]
 name = "wgpu-hal"
-version = "27.0.4"
+version = "29.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b21cb61c57ee198bc4aff71aeadff4cbb80b927beb912506af9c780d64313ce"
+checksum = "31f8e1a9e7a8512f276f7c62e018c7fa8d60954303fed2e5750114332049193f"
 dependencies = [
  "android_system_properties",
  "arrayvec",
  "ash",
- "bit-set 0.8.0",
- "bitflags 2.11.0",
- "block",
+ "bit-set 0.9.1",
+ "bitflags 2.13.0",
+ "block2 0.6.2",
  "bytemuck",
  "cfg-if",
  "cfg_aliases",
- "core-graphics-types 0.2.0",
- "gpu-alloc",
- "gpu-allocator 0.27.0",
- "gpu-descriptor",
- "hashbrown 0.16.1",
- "libc",
- "libloading",
- "log",
- "metal 0.32.0",
- "naga 27.0.3",
- "objc",
- "once_cell",
- "ordered-float",
- "parking_lot",
- "portable-atomic",
- "portable-atomic-util",
- "profiling",
- "range-alloc",
- "raw-window-handle",
- "renderdoc-sys",
- "smallvec",
- "thiserror 2.0.18",
- "wgpu-types 27.0.1",
- "windows 0.58.0",
- "windows-core 0.58.0",
-]
-
-[[package]]
-name = "wgpu-hal"
-version = "28.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d6cb474beb218824dcc9e1ce679d973f719262789bfb27407da560cac20eeb"
-dependencies = [
- "android_system_properties",
- "arrayvec",
- "ash",
- "bit-set 0.8.0",
- "bitflags 2.11.0",
- "block",
- "bytemuck",
- "cfg-if",
- "cfg_aliases",
- "core-graphics-types 0.2.0",
  "glow",
  "glutin_wgl_sys",
- "gpu-allocator 0.28.0",
+ "gpu-allocator",
  "gpu-descriptor",
  "hashbrown 0.16.1",
  "js-sys",
@@ -6527,10 +6437,13 @@ dependencies = [
  "libc",
  "libloading",
  "log",
- "metal 0.33.0",
- "naga 28.0.0",
+ "naga",
  "ndk-sys",
- "objc",
+ "objc2 0.6.4",
+ "objc2-core-foundation",
+ "objc2-foundation 0.3.2",
+ "objc2-metal 0.3.2",
+ "objc2-quartz-core 0.3.2",
  "once_cell",
  "ordered-float",
  "parking_lot",
@@ -6539,41 +6452,42 @@ dependencies = [
  "profiling",
  "range-alloc",
  "raw-window-handle",
+ "raw-window-metal",
  "renderdoc-sys",
  "smallvec",
  "thiserror 2.0.18",
  "wasm-bindgen",
+ "wayland-sys",
  "web-sys",
- "wgpu-types 28.0.0",
- "windows 0.62.2",
- "windows-core 0.62.2",
+ "wgpu-naga-bridge",
+ "wgpu-types",
+ "windows",
+ "windows-core",
+ "windows-result",
+]
+
+[[package]]
+name = "wgpu-naga-bridge"
+version = "29.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59c654c483f058800972c3645e95388a7eca31bf9fe1933bc20e036588a0be02"
+dependencies = [
+ "naga",
+ "wgpu-types",
 ]
 
 [[package]]
 name = "wgpu-types"
-version = "27.0.1"
+version = "29.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afdcf84c395990db737f2dd91628706cb31e86d72e53482320d368e52b5da5eb"
+checksum = "a9bcc31518a0e9735aefebedb5f7a9ef3ed1c42549c9f4c882fa9060ceaac639"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
  "bytemuck",
  "js-sys",
  "log",
+ "raw-window-handle",
  "serde",
- "thiserror 2.0.18",
- "web-sys",
-]
-
-[[package]]
-name = "wgpu-types"
-version = "28.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e18308757e594ed2cd27dddbb16a139c42a683819d32a2e0b1b0167552f5840c"
-dependencies = [
- "bitflags 2.11.0",
- "bytemuck",
- "js-sys",
- "log",
  "web-sys",
 ]
 
@@ -6610,46 +6524,14 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
-version = "0.58.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
-dependencies = [
- "windows-core 0.58.0",
- "windows-targets",
-]
-
-[[package]]
-name = "windows"
-version = "0.61.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
-dependencies = [
- "windows-collections 0.2.0",
- "windows-core 0.61.2",
- "windows-future 0.2.1",
- "windows-link 0.1.3",
- "windows-numerics 0.2.0",
-]
-
-[[package]]
-name = "windows"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
 dependencies = [
- "windows-collections 0.3.2",
- "windows-core 0.62.2",
- "windows-future 0.3.2",
- "windows-numerics 0.3.1",
-]
-
-[[package]]
-name = "windows-collections"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
-dependencies = [
- "windows-core 0.61.2",
+ "windows-collections",
+ "windows-core",
+ "windows-future",
+ "windows-numerics",
 ]
 
 [[package]]
@@ -6658,33 +6540,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
 dependencies = [
- "windows-core 0.62.2",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.58.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99"
-dependencies = [
- "windows-implement 0.58.0",
- "windows-interface 0.58.0",
- "windows-result 0.2.0",
- "windows-strings 0.1.0",
- "windows-targets",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.61.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
-dependencies = [
- "windows-implement 0.60.2",
- "windows-interface 0.59.3",
- "windows-link 0.1.3",
- "windows-result 0.3.4",
- "windows-strings 0.4.2",
+ "windows-core",
 ]
 
 [[package]]
@@ -6693,22 +6549,11 @@ version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
- "windows-implement 0.60.2",
- "windows-interface 0.59.3",
- "windows-link 0.2.1",
- "windows-result 0.4.1",
- "windows-strings 0.5.1",
-]
-
-[[package]]
-name = "windows-future"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
-dependencies = [
- "windows-core 0.61.2",
- "windows-link 0.1.3",
- "windows-threading 0.1.0",
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
 ]
 
 [[package]]
@@ -6717,20 +6562,9 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
 dependencies = [
- "windows-core 0.62.2",
- "windows-link 0.2.1",
- "windows-threading 0.2.1",
-]
-
-[[package]]
-name = "windows-implement"
-version = "0.58.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
+ "windows-core",
+ "windows-link",
+ "windows-threading",
 ]
 
 [[package]]
@@ -6738,17 +6572,6 @@ name = "windows-implement"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "windows-interface"
-version = "0.58.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6768,25 +6591,9 @@ dependencies = [
 
 [[package]]
 name = "windows-link"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
-
-[[package]]
-name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
-
-[[package]]
-name = "windows-numerics"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
-dependencies = [
- "windows-core 0.61.2",
- "windows-link 0.1.3",
-]
 
 [[package]]
 name = "windows-numerics"
@@ -6794,26 +6601,8 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
 dependencies = [
- "windows-core 0.62.2",
- "windows-link 0.2.1",
-]
-
-[[package]]
-name = "windows-result"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
-dependencies = [
- "windows-targets",
-]
-
-[[package]]
-name = "windows-result"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
-dependencies = [
- "windows-link 0.1.3",
+ "windows-core",
+ "windows-link",
 ]
 
 [[package]]
@@ -6822,26 +6611,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
- "windows-link 0.2.1",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
-dependencies = [
- "windows-result 0.2.0",
- "windows-targets",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
-dependencies = [
- "windows-link 0.1.3",
+ "windows-link",
 ]
 
 [[package]]
@@ -6850,7 +6620,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -6877,7 +6647,7 @@ version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -6898,20 +6668,11 @@ dependencies = [
 
 [[package]]
 name = "windows-threading"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
-dependencies = [
- "windows-link 0.1.3",
-]
-
-[[package]]
-name = "windows-threading"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -6971,13 +6732,13 @@ dependencies = [
  "ahash",
  "android-activity",
  "atomic-waker",
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
  "block2 0.5.1",
  "bytemuck",
  "calloop",
  "cfg_aliases",
  "concurrent-queue",
- "core-foundation 0.9.4",
+ "core-foundation",
  "core-graphics",
  "cursor-icon",
  "dpi",
@@ -7109,7 +6870,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
  "indexmap",
  "log",
  "serde",
@@ -7207,7 +6968,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d039de8032a9a8856a6be89cea3e5d12fdd82306ab7c94d74e6deab2460651c5"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
  "dlib",
  "log",
  "once_cell",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1140,7 +1140,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-time",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2179,7 +2179,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2314,7 +2314,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3630,7 +3630,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4050,7 +4050,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4150,9 +4150,9 @@ dependencies = [
 
 [[package]]
 name = "parley_ratatui"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "993017a77e34db00adbbf64e51db1bf17ff4cfa3273e93901cf16e90713f14e4"
+checksum = "86bd13ccedb5428c7d681defa8f05efbcf17e18a337e04447c3703d1f863d9ab"
 dependencies = [
  "naga",
  "parley",
@@ -4904,7 +4904,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5338,9 +5338,9 @@ checksum = "0193cc4331cfd2f3d2011ef287590868599a2f33c3e69bc22c1a3d3acf9e02fb"
 
 [[package]]
 name = "swash"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1804632b66a35ca2b1d277eb0a138e10f46cb365b9a6d297e876b69ef79de43"
+checksum = "0811b01ca2c4e8718760713911feaf4675c24f94e50530a015ec646cfb622f7c"
 dependencies = [
  "skrifa",
  "yazi",
@@ -6538,7 +6538,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -415,18 +415,18 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bevy"
-version = "0.19.0-rc.2"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d66de79f9778e3458ca92a5a855b9e11cc4ec1b15a6c4330d8244a08d22539d9"
+checksum = "950238d3049d81006a6fd6b898a34cfc01bb5462a7668795a54d640aed19fd0a"
 dependencies = [
  "bevy_internal",
 ]
 
 [[package]]
 name = "bevy_a11y"
-version = "0.19.0-rc.2"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ded05cb8442d7dae06bf4537b04ef962a955054da9cfe0f3696bcc1fd4030819"
+checksum = "e86f2cb45b000a9d121a5a7606f9af4a49e72b8b6a3885dc2acac2f0897a04f1"
 dependencies = [
  "accesskit",
  "bevy_app",
@@ -437,18 +437,18 @@ dependencies = [
 
 [[package]]
 name = "bevy_android"
-version = "0.19.0-rc.2"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64541e1030f7da413ee8cdb33ab0f495faa9f6abc091f52ae3e6c92c62b87cc2"
+checksum = "e6e5e2a949be318bf7184eb084622892afcc1e8b2af44973ac53ab53201756e0"
 dependencies = [
  "android-activity",
 ]
 
 [[package]]
 name = "bevy_animation"
-version = "0.19.0-rc.2"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba0889790e52bde480f668587a47d9fcb22897eb52f7f9382347fd1cad0bee17"
+checksum = "7da2fcd94cc32ba1c875c62e88506c0ba4775555a413e34cd172ea95fa26098e"
 dependencies = [
  "bevy_animation_macros",
  "bevy_app",
@@ -479,9 +479,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_animation_macros"
-version = "0.19.0-rc.2"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbfe909f9337dbde81937a8a0c2cd694fc922fd7965efbc2b97813cbe04f4ed6"
+checksum = "4fa3d816d7788e27da936b9c7ec27f9828906d53cb1d06e26c58cac5c5ee799f"
 dependencies = [
  "bevy_macro_utils",
  "quote",
@@ -490,9 +490,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_app"
-version = "0.19.0-rc.2"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28f104d73dc68aeb3302cc707b0d7b9dfffc968af1e317eb2a8c763637978f87"
+checksum = "671ae6f3a8d84f9ed696c531a138558596e041231a8414b6efeafa8469e841f9"
 dependencies = [
  "bevy_derive",
  "bevy_ecs",
@@ -512,9 +512,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_asset"
-version = "0.19.0-rc.2"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "344fcbc5ddd6d8bb30e345f49e57aaa09a0d0c1a1c3ff799f4e24d7d31a58f0d"
+checksum = "43a05907de6a362d2c609a7a1d1b4dca3b58b768f746b719ca1a3c7dfa87d391"
 dependencies = [
  "async-broadcast",
  "async-channel",
@@ -555,9 +555,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_asset_macros"
-version = "0.19.0-rc.2"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c4df7c9dc906c5fe51eb04acf074da3da5a25dbd52a076d6ce411586e7b5866"
+checksum = "c9444998cc37b51dfd1572c23a501865733ea65619a7d88b47aa654ae2290a4f"
 dependencies = [
  "bevy_macro_utils",
  "proc-macro2",
@@ -567,9 +567,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_camera"
-version = "0.19.0-rc.2"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc5067df9940c9a2cfff3afa16910b08b7ce4d1faeeb92cb3b58a3311e8f203d"
+checksum = "20105c3e77c2fb391bf3ded3a473d60e4058b837c9bf4e3412225833e524c75a"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -593,9 +593,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_color"
-version = "0.19.0-rc.2"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "934c2aaae8a81c52abe727eb81775277474a8ae3fabcaa7b1043a95021d35c5c"
+checksum = "7e2dfc0091be6eb62fec9158b2d3e6f21b002be7bdb42dd3b8322e949c8426b0"
 dependencies = [
  "bevy_math",
  "bevy_reflect",
@@ -609,9 +609,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_core_pipeline"
-version = "0.19.0-rc.2"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36fabecc78291f004067e67017ed0f659ba9e79fb0f1146b3b753527241f6e66"
+checksum = "885d640bbff6c4fa3beadbb043d0d1ae53b2fda864da18a2bf2670fb90428865"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -638,9 +638,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_derive"
-version = "0.19.0-rc.2"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77ce110186ef6ea695480a508070fda700f2186420b60c4a4095ab04c8010685"
+checksum = "293df2b2f7ed65ef2ce02b2e7359faac1a9a92a8cc96c182c9de77eb06049ae0"
 dependencies = [
  "bevy_macro_utils",
  "quote",
@@ -649,9 +649,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_diagnostic"
-version = "0.19.0-rc.2"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e27715d97181fbfe169243cd2d8a629eff1538d81cb55198279d6ea8e4bdaa42"
+checksum = "a73e11555051f37c3e0e9ef7775e77108f2482310242996fb5bb6ef8b685b78e"
 dependencies = [
  "atomic-waker",
  "bevy_app",
@@ -666,9 +666,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_ecs"
-version = "0.19.0-rc.2"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6129aba8aa2e48f834842233ac808205ff0a15dce1db5985ff9527a89e4f932"
+checksum = "4654b9b3535fa7813d2878a50e1b5ad80a361dc1c913b96ded57667f65d70a01"
 dependencies = [
  "arrayvec",
  "bevy_ecs_macros",
@@ -694,9 +694,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_ecs_macro_logic"
-version = "0.19.0-rc.2"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04ea00892a6851d3eea365228b1e972805410656043eea137f91990ad0cf8dc6"
+checksum = "ee0b98a74141ce8dce4654c60020ebbaefab32646f42af6bbae55f282ae65ff7"
 dependencies = [
  "bevy_macro_utils",
  "proc-macro2",
@@ -706,9 +706,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_ecs_macros"
-version = "0.19.0-rc.2"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63c96cb4b5a81501b68f2d61f181cf0c868e69f2c005f55e530e8fbd2ed3a06b"
+checksum = "4dc958a194d226d618404e0fea99a3c8b4146207a00a3ba07fa712bf71607240"
 dependencies = [
  "bevy_ecs_macro_logic",
  "bevy_macro_utils",
@@ -719,9 +719,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_encase_derive"
-version = "0.19.0-rc.2"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e90eadd102769650cf65ae39b8722ce92bf53ab548685636e2f2101d1d7bd4b"
+checksum = "14dc5bf9e6cb46c4401a66625b5f7eb9654a7f3c8586423c428b79586a1c55cd"
 dependencies = [
  "bevy_macro_utils",
  "encase_derive_impl",
@@ -729,9 +729,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_gizmos"
-version = "0.19.0-rc.2"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f0f59390f390748562776b85e2fb2d14d51a49b1084b20a20c62c404f953ffb"
+checksum = "9c0cbd55cc33b6412777d60d8c24a96bee148c82a5731f35ac85b2df4a7cf957"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -752,9 +752,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_gizmos_macros"
-version = "0.19.0-rc.2"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6f0643399765655d53c399ed7e3b5eaa1da1132a8349452dd52451dc612cbb5"
+checksum = "9903f2614f53bacacb92bef1e407afe3a27a4abddb500bfd479909c5d7b254df"
 dependencies = [
  "bevy_macro_utils",
  "quote",
@@ -763,9 +763,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_gizmos_render"
-version = "0.19.0-rc.2"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72f350f91b5fc925fb6b9d7e3d038eb2f9f47a30f25e598337b151dd1287cfe5"
+checksum = "dd569456c4b19bafa6d37c1bd9cc743fdadda3a2f23d79d2ceb0a088ea8d475f"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -792,9 +792,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_gltf"
-version = "0.19.0-rc.2"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54f95e926b8b806ca48f7c01095648f373f8fd7079b9c76f3dceccd9ed086ce8"
+checksum = "84e21ad83b7dc8d456491ea3d50057685d8c4cca8bc52a1b4a7161c86c369842"
 dependencies = [
  "async-lock",
  "base64",
@@ -828,9 +828,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_image"
-version = "0.19.0-rc.2"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afa87f3aeb7bef218a51d97309c596f280b9c74b247ceefb4ebc10047accd0df"
+checksum = "37bc41f69a0c6ade2e7961602517545b39ab8e42bc8c4a729bd24ffee3bcd904"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -857,9 +857,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_input"
-version = "0.19.0-rc.2"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "208968122f122a81e6022fbf46796defa805cb85a72bd27335dfa9e4f12e59a4"
+checksum = "fd221cf0732f5bf06caf594bdb233361ac735d4d416cf5849757b64bf4e8472a"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -874,9 +874,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_input_focus"
-version = "0.19.0-rc.2"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9570109dde25e58adb8b5a61e5229a65ed3db1b996c2f2af8689ec7d175df71b"
+checksum = "0e1a14f56c6e722048ec9dc20dbbc6f46b8037f61e319ea776829199278da166"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -890,9 +890,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_internal"
-version = "0.19.0-rc.2"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e246a3080097f5332f4ecd1e62fd9540912468f7ad3ceeb5b5acd3cc2ad42094"
+checksum = "d52a85632a749f956f92b7b391c31ce1f229e57b06de879d1b60a3bb91e4e240"
 dependencies = [
  "bevy_a11y",
  "bevy_android",
@@ -937,9 +937,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_light"
-version = "0.19.0-rc.2"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b9a83185f31f3d3a49e2b0768cf9ffd12664851e9e8ba8d6bc4658e54bd752"
+checksum = "bd7b5009e9cc765c30b21daf2277ea4423cbd347b05280ea0943b50c5a80cd42"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -962,9 +962,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_log"
-version = "0.19.0-rc.2"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92cc20daad0dd2be92f86792c3ad9271d5db6a8bbbe0f4902cbf60e750c89414"
+checksum = "2017a5fe12ea230d00cfdca00c65c262924be26e0324f7e0033c64f8cc265888"
 dependencies = [
  "android_log-sys",
  "bevy_app",
@@ -980,9 +980,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_macro_utils"
-version = "0.19.0-rc.2"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51ea607f95f39b4c5885ce62c526a687219eec645b50d2b62e245816bb0c5e55"
+checksum = "746a19912c6dc1bbe79188778573e8a253d5832c696b2fcb95578c17b29ff7ba"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -992,9 +992,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_material"
-version = "0.19.0-rc.2"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "886ee32dc90db56f24a6da4859ef19a0e1e014887ffa6e7317c207756439e64d"
+checksum = "423710403b4a4d8e9ee872c6ac8108787f2396422b582d15a660a40731ddfbf0"
 dependencies = [
  "bevy_asset",
  "bevy_derive",
@@ -1015,9 +1015,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_material_macros"
-version = "0.19.0-rc.2"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5eacd3335d457d0fce081735c5d0e8c2d1a32c7b70bfa76b751af43c85299502"
+checksum = "e6928e167592472f6ee900f80de199cc2dafd31d4f082a86e8d594b81b973e3d"
 dependencies = [
  "bevy_macro_utils",
  "quote",
@@ -1026,9 +1026,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_math"
-version = "0.19.0-rc.2"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c1b67383d4dbfc7852e2e020a33f71c69cbd94e8e0be670f423880517928e98"
+checksum = "d7c280440d2a5bc07ea393b5346b5712eec73ea30f0133097b8b13dade385beb"
 dependencies = [
  "approx",
  "arrayvec",
@@ -1046,9 +1046,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_mesh"
-version = "0.19.0-rc.2"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1edf0a03cc43ce42606df561ac169f7f003436836b22f3f8c2551699a404db50"
+checksum = "c59863e6f37ef0ba1f37021bce9dd940f9dc31d15e03f548cda5fd3e674f409e"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1080,9 +1080,9 @@ checksum = "bff34eb29ff4b8a8688bc7299f14fb6b597461ca80fec03ed7d22939ab33e48f"
 
 [[package]]
 name = "bevy_pbr"
-version = "0.19.0-rc.2"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be2e00046d3e3ae73e8e73c54fa32e2f5656df7738cda397d154b2c462d75738"
+checksum = "38ebc777de2d7f45888c68e8e04949bfb8a40aee62f700283fc340f525e67f52"
 dependencies = [
  "arrayvec",
  "bevy_app",
@@ -1123,9 +1123,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_platform"
-version = "0.19.0-rc.2"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20db1d0bfabbe4fd77b27ee559685235a214c29ccb0d7b20738cb58f7214bfac"
+checksum = "3120670bb2308980f723477c9d82476fcda31f08be9b256c3f0acdee82a65094"
 dependencies = [
  "critical-section",
  "foldhash 0.2.0",
@@ -1140,20 +1140,20 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-time",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "bevy_ptr"
-version = "0.19.0-rc.2"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efda0a4a01ca8e81a8b872f824b1095fc7158b17e68763d6e9b3a5bcae6d1f2e"
+checksum = "b511e89f7078fd21fdea77061a0ca3e737297c7011bb10c073e0aecb17c9fea6"
 
 [[package]]
 name = "bevy_reflect"
-version = "0.19.0-rc.2"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93acb7a4fa934897c953e831634eff7bd464abae4529978f3d80844e6729ccb6"
+checksum = "92abd59cbba1524c1847e9a50f74d94e6b7836c80a8edfa9c47e59f7fd81021d"
 dependencies = [
  "assert_type_match",
  "bevy_platform",
@@ -1180,9 +1180,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_reflect_derive"
-version = "0.19.0-rc.2"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "599b51bc40cda45073fd343aa5692e2846d2cb1e1e859144ebeac8471c6469fe"
+checksum = "90fa4e6b97fd2d582dd5ed96762a70d04505a477c833cf4f69d016dcd03d2d04"
 dependencies = [
  "bevy_macro_utils",
  "indexmap",
@@ -1194,9 +1194,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_render"
-version = "0.19.0-rc.2"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f12973b6953920328c56626a5bfa24324fa7ff761954ce1c6f2fc687c592899"
+checksum = "a89b2cc850a4c3fd12a6a088a4fc3e80118b2e1b569da8936f6d4d99ca1b6ee7"
 dependencies = [
  "async-channel",
  "bevy_app",
@@ -1248,9 +1248,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_render_macros"
-version = "0.19.0-rc.2"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a19c1272edca0b7c932ff6abae9b563d2a385ebf42502f30c7ed80be84530be0"
+checksum = "e0eb5cffe5253a6ab4e4b84b2e40a6a2f4673deb16fd63ab9dfc4a015449873a"
 dependencies = [
  "bevy_macro_utils",
  "proc-macro2",
@@ -1260,9 +1260,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_scene"
-version = "0.19.0-rc.2"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cc34818c18ceca123a14a3e52753917b3a2969354b3dd054f1ab224e0f2b950"
+checksum = "28a3c891148c40e1352fc41001c0e1894ba63fc4e2d3aca33447343c4122b782"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1273,6 +1273,7 @@ dependencies = [
  "bevy_reflect",
  "bevy_scene_macros",
  "bevy_utils",
+ "smallvec",
  "thiserror 2.0.18",
  "tracing",
  "variadics_please",
@@ -1280,9 +1281,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_scene_macros"
-version = "0.19.0-rc.2"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edc3b66a9879c58998b95d9fe8ea17e31f5db5152a1cb0ee464aefcffb1e1041"
+checksum = "b4bc33a36a4e9e344985a96cd8b4abc816cf2c5d2fa002d72fd7bcd11396589c"
 dependencies = [
  "bevy_ecs_macro_logic",
  "bevy_macro_utils",
@@ -1293,9 +1294,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_shader"
-version = "0.19.0-rc.2"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28288dd8029513661be8e6c237efbef68d9585d8823671099d6ac806389c7991"
+checksum = "fa0ac51378bb6a021165ee334f846b515cd06082e24ce962adce58ad7df1c39a"
 dependencies = [
  "bevy_asset",
  "bevy_platform",
@@ -1312,9 +1313,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_sprite"
-version = "0.19.0-rc.2"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f872e74ebdcedc85bd6c6cd7ecf1467b3d7241ef9ff6f5b2d98b3f8684032d7"
+checksum = "c679b88cc655881d403929bcdf02d30f688fd8916eb1635e6e7f8585d8ae6894"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1335,9 +1336,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_sprite_render"
-version = "0.19.0-rc.2"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d13c5820d517ba72bca7fd1fe93f0a9b17f81676dbe13937ccb56e4e05d27dcb"
+checksum = "e5a65ca9a286dd5815ca4d2d41d4f83bdbb22c8a639d10b4c33eac114b369c36"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1367,9 +1368,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_state"
-version = "0.19.0-rc.2"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5223226ca2ecbe56f156b0bb14dfad34b46039c99f151867cc256c7e711c4df7"
+checksum = "8c22e694ea52e42994aea6ed2d0b378fa1e9d5a9b615db88626e33508bc03f35"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1383,9 +1384,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_state_macros"
-version = "0.19.0-rc.2"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c52f21d1e9923daad5ecc56993f83f9e39482a957297a9265df0e3a6ab71e401"
+checksum = "835f45091fa0df1ff3cb10f4ca5a397d4e9249b550f1be6893b08a2a06d6eed7"
 dependencies = [
  "bevy_macro_utils",
  "quote",
@@ -1394,9 +1395,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_tasks"
-version = "0.19.0-rc.2"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ec5fde381db053fa4145149fc25f4204fe23809aaf5bd4d45093c7c66c5ee3b"
+checksum = "fa34e6b9b804851ec08a41c0346c859d82e2fa98c906d74b965ee61bbbb688e4"
 dependencies = [
  "async-channel",
  "async-executor",
@@ -1413,9 +1414,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_time"
-version = "0.19.0-rc.2"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ac75a7ade9d89394bd5baf6de4a5694e45791de330620d39a42b58e5bbadb43"
+checksum = "c21e3be2aa4426ea1e0a7036d3d1dbbded84c319459d9f3e2a616b33563372f2"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1428,9 +1429,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_transform"
-version = "0.19.0-rc.2"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb3940d9f743431dd75309b55d77a7235fdeb4dbbc9d5ac893aefd607cb2e3ec"
+checksum = "c95fefe69c9223d10e6b52a0fdf12811bab9d0c7dcb27570cb86824b451f180d"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1445,9 +1446,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_utils"
-version = "0.19.0-rc.2"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a97edfa769c752ea30b9c5f1a5bcd440c5665be4b20f0e94e6ca22cad3ed7c1"
+checksum = "3aceea6c7ffdd568f866d5ca4dfe50c33440c54f7bc230c13a9ba7ab0c91aed1"
 dependencies = [
  "async-channel",
  "bevy_platform",
@@ -1458,9 +1459,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_window"
-version = "0.19.0-rc.2"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0af4a50f23e1c006504eb249603379a4c68f06cf5558a3fd501c780723ae129"
+checksum = "efcc255b43db156fba393b2ff8fa552aac5e7e02ae4c6298eacdbab655ddf988"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1475,9 +1476,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_winit"
-version = "0.19.0-rc.2"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a753a869232c1c3e7ae4087443b5ead34d772cb219917baf29c2d81dd15243"
+checksum = "308c9eb04f74f340593b3def6a7c1778fd42581d779c6db836d690c7d471f94c"
 dependencies = [
  "accesskit",
  "accesskit_winit",
@@ -1504,9 +1505,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_world_serialization"
-version = "0.19.0-rc.2"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b190022ab0d6e6cc3cb8fbd8ac661fb5c720cacc4c09c96b8539c2115275e63c"
+checksum = "de58ae74410d4f940e3f00484f58603b4f1a53a7d84ebe3fca258d2a3aa96620"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -2178,7 +2179,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2313,7 +2314,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3629,7 +3630,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4049,7 +4050,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4892,7 +4893,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6513,7 +6514,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ bevy = { version = "0.19.0-rc.2", default-features = false, features = [
 clap = { version = "4.5", features = ["derive"] }
 etcetera = "0.11"
 image = { version = "0.25", default-features = false, features = ["png", "ico"] }
-parley_ratatui = "0.3.1"
+parley_ratatui = "0.3.2"
 portable-pty = "0.8"
 ratatui = "0.30"
 rust-embed = "8.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ exclude = ["website/**", ".github/**", "widget/**"]
 anyhow = "1.0"
 arboard = { version = "3.6", features = ["wayland-data-control"] }
 base64 = "0.22"
-bevy = { version = "0.19.0-rc.2", default-features = false, features = [
+bevy = { version = "0.19.0", default-features = false, features = [
     "std",
     "async_executor",
     "bevy_asset",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ bevy = { version = "0.19.0", default-features = false, features = [
 clap = { version = "4.5", features = ["derive"] }
 etcetera = "0.11"
 image = { version = "0.25", default-features = false, features = ["png", "ico"] }
-parley_ratatui = "0.3.3"
+parley_ratatui = "0.3.4"
 portable-pty = "0.8"
 ratatui = "0.30"
 rust-embed = "8.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ bevy = { version = "0.19.0", default-features = false, features = [
 clap = { version = "4.5", features = ["derive"] }
 etcetera = "0.11"
 image = { version = "0.25", default-features = false, features = ["png", "ico"] }
-parley_ratatui = "0.3.2"
+parley_ratatui = "0.3.3"
 portable-pty = "0.8"
 ratatui = "0.30"
 rust-embed = "8.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ exclude = ["website/**", ".github/**", "widget/**"]
 anyhow = "1.0"
 arboard = { version = "3.6", features = ["wayland-data-control"] }
 base64 = "0.22"
-bevy = { version = "0.18.1", default-features = false, features = [
+bevy = { version = "0.19.0-rc.2", default-features = false, features = [
     "std",
     "async_executor",
     "bevy_asset",
@@ -24,6 +24,7 @@ bevy = { version = "0.18.1", default-features = false, features = [
     "bevy_gltf",
     "bevy_log",
     "bevy_pbr",
+    "bevy_scene",
     "bevy_sprite",
     "bevy_sprite_render",
     "bevy_winit",
@@ -41,8 +42,7 @@ bevy = { version = "0.18.1", default-features = false, features = [
 clap = { version = "4.5", features = ["derive"] }
 etcetera = "0.11"
 image = { version = "0.25", default-features = false, features = ["png", "ico"] }
-parley_ratatui = "0.2.1"
-pollster = "0.4"
+parley_ratatui = "0.2.2"
 portable-pty = "0.8"
 ratatui = "0.30"
 rust-embed = "8.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ bevy = { version = "0.19.0-rc.2", default-features = false, features = [
 clap = { version = "4.5", features = ["derive"] }
 etcetera = "0.11"
 image = { version = "0.25", default-features = false, features = ["png", "ico"] }
-parley_ratatui = "0.2.2"
+parley_ratatui = "0.3.0"
 portable-pty = "0.8"
 ratatui = "0.30"
 rust-embed = "8.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ bevy = { version = "0.19.0-rc.2", default-features = false, features = [
 clap = { version = "4.5", features = ["derive"] }
 etcetera = "0.11"
 image = { version = "0.25", default-features = false, features = ["png", "ico"] }
-parley_ratatui = "0.3.0"
+parley_ratatui = "0.3.1"
 portable-pty = "0.8"
 ratatui = "0.30"
 rust-embed = "8.5"

--- a/README.md
+++ b/README.md
@@ -226,9 +226,11 @@ Current workflow:
 2. `parley_ratatui` shapes the buffer with Parley and records it as a Vello scene
 3. The scene is handed to Bevy's render world through a double-buffered
    exchange (scenes are recycled between frames, never cloned or re-recorded)
-4. Vello renders the scene directly into the Bevy-owned GPU texture on Bevy's
-   render-world device, with no CPU readback in between
-5. Bevy presents that texture in the 2D and 3D scenes
+4. Vello renders the scene on Bevy's render-world device into a plain
+   `Rgba8Unorm` storage texture, with no CPU readback in between
+5. That storage texture is copied into an `Rgba8UnormSrgb` present texture
+   (sampled through an sRGB view, so Vello's sRGB-encoded output is decoded on
+   sample instead of re-encoded), which Bevy presents in the 2D and 3D scenes
 
 The terminal image is fully GPU-resident: the only data crossing from the main
 world to the render world each frame is the recorded scene, not pixels.

--- a/README.md
+++ b/README.md
@@ -233,27 +233,6 @@ Current workflow:
 The terminal image is fully GPU-resident: the only data crossing from the main
 world to the render world each frame is the recorded scene, not pixels.
 
-### Sizing and scale
-
-Cell metrics drive every layout decision, so it helps to know where each
-number comes from:
-
-- The configured font size is in points and converts to pixels at 96 dpi
-  (1pt = 4/3px). Metrics are measured at physical pixel size, i.e. after
-  multiplying by the render scale.
-- The render scale comes from the display by default (2.0 on HiDPI screens).
-  Setting `window.scale_factor` in the config overrides it explicitly.
-- Measured cell dimensions stay fractional
-  (`CellQuantization::Fractional`). Rounding them to whole pixels would make
-  font-size zoom steps uneven: a +1pt step grows the cell height by more than
-  a pixel but the cell width by well under one, so quantized widths can stay
-  unchanged while the height grows and the zoom collapses into a
-  vertical-only stretch.
-- The grid is sized as `cols/rows = floor(logical window size / logical cell
-  size)`; the texture is `ceil(cols × cell width)` by `ceil(rows × cell
-  height)` in physical pixels and is presented at `texture size / render
-  scale` logical units, so the texture is never resampled.
-
 ## Endorsements
 
 - _"This is like a legitimately cool project but also I just spent like 20 minutes adjusting the config for the rat spinning to see him spin faster and more erratically and it cracked me up"_ - [@vimlena.com](https://bsky.app/profile/vimlena.com/post/3mkoshbzpvs2y)

--- a/README.md
+++ b/README.md
@@ -222,19 +222,37 @@ and [Bevy](https://bevyengine.org/) for scene presentation.
 
 Current workflow:
 
-1. Ratatui buffer on CPU
-2. Parley/Vello renders on GPU
-3. Read back RGBA to CPU
-4. Copy into Bevy image
-5. Bevy presents that image in 2D and 3D
+1. PTY output is parsed by `vt100` and drawn into a Ratatui buffer on CPU
+2. `parley_ratatui` shapes the buffer with Parley and records it as a Vello scene
+3. The scene is handed to Bevy's render world through a double-buffered
+   exchange (scenes are recycled between frames, never cloned or re-recorded)
+4. Vello renders the scene directly into the Bevy-owned GPU texture on Bevy's
+   render-world device, with no CPU readback in between
+5. Bevy presents that texture in the 2D and 3D scenes
 
-Terminal drawing is GPU-rendered through Parley/Vello, but the main terminal
-image still crosses back through CPU memory before Bevy presents it. This is a
-GPU-powered bridge, not a fully GPU-resident shared-texture path.
+The terminal image is fully GPU-resident: the only data crossing from the main
+world to the render world each frame is the recorded scene, not pixels.
 
-If the project later moves to a fully GPU-resident path, that will require a
-dedicated Bevy render integration that renders into a Bevy-owned texture on
-Bevy's render-world device instead of using the current readback bridge.
+### Sizing and scale
+
+Cell metrics drive every layout decision, so it helps to know where each
+number comes from:
+
+- The configured font size is in points and converts to pixels at 96 dpi
+  (1pt = 4/3px). Metrics are measured at physical pixel size, i.e. after
+  multiplying by the render scale.
+- The render scale comes from the display by default (2.0 on HiDPI screens).
+  Setting `window.scale_factor` in the config overrides it explicitly.
+- Measured cell dimensions stay fractional
+  (`CellQuantization::Fractional`). Rounding them to whole pixels would make
+  font-size zoom steps uneven: a +1pt step grows the cell height by more than
+  a pixel but the cell width by well under one, so quantized widths can stay
+  unchanged while the height grows and the zoom collapses into a
+  vertical-only stretch.
+- The grid is sized as `cols/rows = floor(logical window size / logical cell
+  size)`; the texture is `ceil(cols × cell width)` by `ceil(rows × cell
+  height)` in physical pixels and is presented at `texture size / render
+  scale` logical units, so the texture is never resampled.
 
 ## Endorsements
 

--- a/config/ratty.toml
+++ b/config/ratty.toml
@@ -1,7 +1,8 @@
 [window]
 width = 960
 height = 620
-scale_factor = 1.0
+# Overrides the display scale factor; leave unset to render at native scale.
+# scale_factor = 1.0
 opacity = 0.8
 
 [terminal]
@@ -19,6 +20,7 @@ TERM = "xterm-256color"
 [font]
 family = "DejaVu Sans Mono"
 style = "Regular"
+# Font size in points.
 size = 18
 
 [cursor.model]

--- a/config/ratty.toml
+++ b/config/ratty.toml
@@ -1,9 +1,8 @@
 [window]
 width = 960
 height = 620
-# Overrides the display scale factor; leave unset to render at native scale.
-# scale_factor = 1.0
 opacity = 0.8
+# scale_factor = 1.0
 
 [terminal]
 default_cols = 104
@@ -20,8 +19,7 @@ TERM = "xterm-256color"
 [font]
 family = "DejaVu Sans Mono"
 style = "Regular"
-# Font size in points.
-size = 18
+size = 12
 
 [cursor.model]
 path = "CairoSpinyMouse.obj"

--- a/src/config.rs
+++ b/src/config.rs
@@ -15,8 +15,10 @@ use crate::paths::expand_path;
 pub const APP_NAME: &str = "ratty";
 /// Local fallback config path.
 pub const CONFIG_PATH: &str = "config/ratty.toml";
-/// Label used for the terminal render target.
+/// Label used for the terminal present texture (sampled by the materials).
 pub const TERMINAL_TEXTURE_LABEL: &str = "ratty.parley_ratatui";
+/// Label used for the terminal render target (Vello's storage texture).
+pub const TERMINAL_RENDER_TEXTURE_LABEL: &str = "ratty.parley_ratatui.render";
 /// Z depth used for the cursor model root.
 pub const CURSOR_DEPTH: f32 = 10.0;
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -127,8 +127,8 @@ pub struct WindowConfig {
     pub width: u32,
     /// Window height in logical pixels.
     pub height: u32,
-    /// Window scale-factor override.
-    pub scale_factor: f32,
+    /// Window scale-factor override. Defaults to the display's scale factor.
+    pub scale_factor: Option<f32>,
     /// Window opacity from `0.0` to `1.0`.
     pub opacity: f32,
 }
@@ -138,7 +138,7 @@ impl Default for WindowConfig {
         Self {
             width: 960,
             height: 620,
-            scale_factor: 1.0,
+            scale_factor: None,
             opacity: 1.0,
         }
     }
@@ -251,7 +251,7 @@ pub struct FontConfig {
     pub family: String,
     /// Font style override.
     pub style: FontStyleConfig,
-    /// Font size in logical pixels.
+    /// Font size in points (1pt = 4/3 logical pixels).
     pub size: i32,
 }
 

--- a/src/direct_render.rs
+++ b/src/direct_render.rs
@@ -176,12 +176,12 @@ pub(crate) fn new_terminal_image(width: u32, height: u32, label: &'static str) -
         format: Some(TextureFormat::Rgba8UnormSrgb),
         ..Default::default()
     });
-    // Linear filtering: the terminal texture is mapped onto transformable 3D
-    // geometry (warped/tilted/Mobius plane modes) and scaled to fit, so it is
-    // sampled at non-integer ratios. Point sampling would expose the texel grid
-    // as pixelation. Cell-edge seams are prevented at authoring time in
-    // parley_ratatui (pixel-snapped cell fills), not by the sampler.
-    image.sampler = ImageSampler::linear();
+    // Nearest (point) filtering: the texture is authored at physical resolution
+    // and the flat 2D view presents it 1:1 via `textureLoad` (no sampler), so the
+    // 3D plane modes use point sampling too for a consistent, crisp pixel grid.
+    // Cell-edge seams are prevented at authoring time in parley_ratatui
+    // (pixel-snapped cell fills), not by linear blending.
+    image.sampler = ImageSampler::nearest();
     image
 }
 

--- a/src/direct_render.rs
+++ b/src/direct_render.rs
@@ -160,6 +160,11 @@ pub(crate) fn new_terminal_image(width: u32, height: u32, label: &'static str) -
         format: Some(TextureFormat::Rgba8UnormSrgb),
         ..Default::default()
     });
+    // Linear filtering: the terminal texture is mapped onto transformable 3D
+    // geometry (warped/tilted/Mobius plane modes) and scaled to fit, so it is
+    // sampled at non-integer ratios. Point sampling would expose the texel grid
+    // as pixelation. Cell-edge seams are prevented at authoring time in
+    // parley_ratatui (pixel-snapped cell fills), not by the sampler.
     image.sampler = ImageSampler::linear();
     image
 }

--- a/src/direct_render.rs
+++ b/src/direct_render.rs
@@ -1,0 +1,222 @@
+//! Direct Vello-to-Bevy texture rendering for the terminal surface.
+
+use std::sync::{Arc, Mutex};
+
+use bevy::asset::RenderAssetUsages;
+use bevy::image::ImageSampler;
+use bevy::prelude::*;
+use bevy::render::render_asset::RenderAssets;
+use bevy::render::render_resource::{Extent3d, TextureDimension, TextureFormat, TextureUsages};
+use bevy::render::renderer::{RenderDevice, RenderQueue};
+use bevy::render::texture::GpuImage;
+use bevy::render::{Extract, ExtractSchedule, Render, RenderApp, RenderSystems};
+use parley_ratatui::ratatui::buffer::Buffer;
+use parley_ratatui::ratatui::layout::Position;
+use parley_ratatui::vello::Scene;
+use parley_ratatui::vello::peniko::Color as PenikoColor;
+use parley_ratatui::{GpuRenderer, TerminalRenderer};
+
+/// Plugin that renders terminal Vello scenes directly into Bevy GPU textures.
+pub(crate) struct DirectTerminalRenderPlugin;
+
+impl Plugin for DirectTerminalRenderPlugin {
+    fn build(&self, app: &mut App) {
+        app.init_resource::<DirectTerminalSceneExchange>();
+        let exchange = app
+            .world()
+            .resource::<DirectTerminalSceneExchange>()
+            .clone();
+
+        let render_app = app.sub_app_mut(RenderApp);
+        render_app
+            .world_mut()
+            .insert_non_send(DirectTerminalRenderState::default());
+        render_app.world_mut().insert_resource(exchange);
+        render_app.init_resource::<ExtractedDirectTerminalFrame>();
+        render_app.add_systems(ExtractSchedule, extract_terminal_frame);
+        render_app.add_systems(Render, render_terminal_frame.in_set(RenderSystems::Prepare));
+    }
+}
+
+struct DirectTerminalFrame {
+    image: Handle<Image>,
+    width: u32,
+    height: u32,
+    base_color: PenikoColor,
+    scene: Scene,
+}
+
+/// Shared bounded exchange between the main world and Bevy render world.
+#[derive(Resource, Clone, Default)]
+pub(crate) struct DirectTerminalSceneExchange {
+    inner: Arc<DirectTerminalSceneExchangeInner>,
+}
+
+#[derive(Default)]
+struct DirectTerminalSceneExchangeInner {
+    pending: Mutex<Option<DirectTerminalFrame>>,
+    recycled: Mutex<Option<Scene>>,
+}
+
+#[derive(Default)]
+struct DirectTerminalRenderState {
+    renderer: Option<GpuRenderer>,
+}
+
+#[derive(Resource, Default)]
+struct ExtractedDirectTerminalFrame(Option<DirectTerminalFrame>);
+
+impl DirectTerminalSceneExchange {
+    fn take_recycled_scene(&self) -> Scene {
+        self.inner
+            .recycled
+            .lock()
+            .expect("direct terminal recycled scene lock")
+            .take()
+            .unwrap_or_default()
+    }
+
+    fn recycle_scene(&self, mut scene: Scene) {
+        scene.reset();
+
+        let mut recycled = self
+            .inner
+            .recycled
+            .lock()
+            .expect("direct terminal recycled scene lock");
+        if recycled.is_none() {
+            *recycled = Some(scene);
+        }
+    }
+
+    fn publish_frame(&self, frame: DirectTerminalFrame) {
+        let previous = self
+            .inner
+            .pending
+            .lock()
+            .expect("direct terminal pending frame lock")
+            .replace(frame);
+
+        if let Some(previous) = previous {
+            self.recycle_scene(previous.scene);
+        }
+    }
+
+    fn take_pending_frame(&self) -> Option<DirectTerminalFrame> {
+        self.inner
+            .pending
+            .lock()
+            .expect("direct terminal pending frame lock")
+            .take()
+    }
+}
+
+pub(crate) fn new_terminal_image(width: u32, height: u32, label: &'static str) -> Image {
+    let mut image = Image::new_uninit(
+        Extent3d {
+            width,
+            height,
+            depth_or_array_layers: 1,
+        },
+        TextureDimension::D2,
+        TextureFormat::Rgba8Unorm,
+        RenderAssetUsages::RENDER_WORLD | RenderAssetUsages::MAIN_WORLD,
+    );
+    image.texture_descriptor.label = Some(label);
+    image.texture_descriptor.usage =
+        TextureUsages::TEXTURE_BINDING | TextureUsages::COPY_DST | TextureUsages::STORAGE_BINDING;
+    image.sampler = ImageSampler::linear();
+    image
+}
+
+pub(crate) fn resize_terminal_image(image: &mut Image, width: u32, height: u32) {
+    if image.texture_descriptor.size.width == width
+        && image.texture_descriptor.size.height == height
+    {
+        return;
+    }
+
+    image.resize(Extent3d {
+        width,
+        height,
+        depth_or_array_layers: 1,
+    });
+}
+
+pub(crate) fn update_direct_terminal_frame(
+    exchange: &DirectTerminalSceneExchange,
+    image: Handle<Image>,
+    terminal_renderer: &mut TerminalRenderer,
+    buffer: &Buffer,
+    cursor: Option<Position>,
+    cursor_visible: bool,
+    elapsed_seconds: f32,
+) {
+    let build_scene = exchange.take_recycled_scene();
+    let spare_scene = terminal_renderer.replace_scene(build_scene);
+    let (width, height) = terminal_renderer.texture_size_for_buffer(buffer);
+    let base_color = terminal_renderer.theme().background.to_peniko();
+    terminal_renderer.build_scene_with_elapsed(buffer, cursor, cursor_visible, elapsed_seconds);
+    let scene = terminal_renderer.replace_scene(spare_scene);
+
+    exchange.publish_frame(DirectTerminalFrame {
+        image,
+        width,
+        height,
+        base_color,
+        scene,
+    });
+}
+
+fn extract_terminal_frame(
+    mut frame: ResMut<ExtractedDirectTerminalFrame>,
+    exchange: Extract<Res<DirectTerminalSceneExchange>>,
+) {
+    if let Some(next_frame) = exchange.take_pending_frame()
+        && let Some(previous_frame) = frame.0.replace(next_frame)
+    {
+        exchange.recycle_scene(previous_frame.scene);
+    }
+}
+
+fn render_terminal_frame(
+    mut state: NonSendMut<DirectTerminalRenderState>,
+    exchange: Res<DirectTerminalSceneExchange>,
+    mut frame: ResMut<ExtractedDirectTerminalFrame>,
+    gpu_images: Res<RenderAssets<GpuImage>>,
+    render_device: Res<RenderDevice>,
+    render_queue: Res<RenderQueue>,
+) {
+    let Some(frame) = frame.0.take() else {
+        return;
+    };
+    let Some(gpu_image) = gpu_images.get(&frame.image) else {
+        exchange.recycle_scene(frame.scene);
+        return;
+    };
+
+    let size = gpu_image.texture_descriptor.size;
+    if size.width != frame.width || size.height != frame.height {
+        exchange.recycle_scene(frame.scene);
+        return;
+    }
+
+    let device = render_device.wgpu_device();
+    let renderer = state
+        .renderer
+        .get_or_insert_with(|| GpuRenderer::new(device).expect("vello renderer"));
+
+    renderer
+        .render_scene_to_texture_view(
+            device,
+            &render_queue,
+            &gpu_image.texture_view,
+            frame.width,
+            frame.height,
+            frame.base_color,
+            &frame.scene,
+        )
+        .expect("render terminal scene into Bevy texture");
+
+    exchange.recycle_scene(frame.scene);
+}

--- a/src/direct_render.rs
+++ b/src/direct_render.rs
@@ -10,9 +10,9 @@ use bevy::render::render_asset::RenderAssets;
 use bevy::render::render_resource::{
     Extent3d, TextureDimension, TextureFormat, TextureUsages, TextureViewDescriptor,
 };
-use bevy::render::renderer::{RenderDevice, RenderQueue};
+use bevy::render::renderer::{RenderDevice, RenderGraph, RenderGraphSystems, RenderQueue};
 use bevy::render::texture::GpuImage;
-use bevy::render::{Extract, ExtractSchedule, Render, RenderApp, RenderSystems};
+use bevy::render::{Extract, ExtractSchedule, RenderApp};
 use parley_ratatui::ratatui::buffer::Buffer;
 use parley_ratatui::ratatui::layout::Position;
 use parley_ratatui::vello::Scene;
@@ -35,7 +35,13 @@ impl Plugin for DirectTerminalRenderPlugin {
         render_app.world_mut().insert_resource(exchange);
         render_app.init_resource::<ExtractedDirectTerminalFrame>();
         render_app.add_systems(ExtractSchedule, extract_terminal_frame);
-        render_app.add_systems(Render, render_terminal_frame.in_set(RenderSystems::Prepare));
+        // Render inside the render-graph schedule so Vello's submission is
+        // ordered with the frame's GPU work: `Begin` runs before the camera
+        // passes that sample the terminal texture.
+        render_app.add_systems(
+            RenderGraph,
+            render_terminal_frame.in_set(RenderGraphSystems::Begin),
+        );
     }
 }
 

--- a/src/direct_render.rs
+++ b/src/direct_render.rs
@@ -7,7 +7,9 @@ use bevy::image::ImageSampler;
 use bevy::platform::cell::SyncCell;
 use bevy::prelude::*;
 use bevy::render::render_asset::RenderAssets;
-use bevy::render::render_resource::{Extent3d, TextureDimension, TextureFormat, TextureUsages};
+use bevy::render::render_resource::{
+    Extent3d, TextureDimension, TextureFormat, TextureUsages, TextureViewDescriptor,
+};
 use bevy::render::renderer::{RenderDevice, RenderQueue};
 use bevy::render::texture::GpuImage;
 use bevy::render::{Extract, ExtractSchedule, Render, RenderApp, RenderSystems};
@@ -124,20 +126,34 @@ impl DirectTerminalSceneExchange {
     }
 }
 
+/// Creates the terminal render target.
+///
+/// Vello requires an `Rgba8Unorm` storage texture and writes sRGB-encoded,
+/// display-ready bytes into it. Bevy samples through a separate
+/// `Rgba8UnormSrgb` view so those bytes are decoded on sample instead of
+/// being re-encoded at the swapchain (which washes out colors). The data is
+/// zero-filled so a frame that samples the texture before Vello first writes
+/// it shows transparent black rather than uninitialized memory.
 pub(crate) fn new_terminal_image(width: u32, height: u32, label: &'static str) -> Image {
-    let mut image = Image::new_uninit(
+    let mut image = Image::new_fill(
         Extent3d {
             width,
             height,
             depth_or_array_layers: 1,
         },
         TextureDimension::D2,
+        &[0, 0, 0, 0],
         TextureFormat::Rgba8Unorm,
         RenderAssetUsages::RENDER_WORLD | RenderAssetUsages::MAIN_WORLD,
     );
     image.texture_descriptor.label = Some(label);
     image.texture_descriptor.usage =
         TextureUsages::TEXTURE_BINDING | TextureUsages::COPY_DST | TextureUsages::STORAGE_BINDING;
+    image.texture_descriptor.view_formats = &[TextureFormat::Rgba8UnormSrgb];
+    image.texture_view_descriptor = Some(TextureViewDescriptor {
+        format: Some(TextureFormat::Rgba8UnormSrgb),
+        ..Default::default()
+    });
     image.sampler = ImageSampler::linear();
     image
 }
@@ -200,17 +216,24 @@ fn render_terminal_frame(
     render_device: Res<RenderDevice>,
     render_queue: Res<RenderQueue>,
 ) {
-    let Some(frame) = frame.0.take() else {
+    let Some(current) = frame.0.take() else {
         return;
     };
-    let Some(gpu_image) = gpu_images.get(&frame.image) else {
-        exchange.recycle_scene(frame.scene);
+    // Retain undrawable frames and retry on the next render frame; a newer
+    // published frame supersedes a retained one during extraction.
+    let Some(gpu_image) = gpu_images.get(&current.image) else {
+        debug!("retaining terminal frame: GPU image not yet prepared");
+        frame.0 = Some(current);
         return;
     };
 
     let size = gpu_image.texture_descriptor.size;
-    if size.width != frame.width || size.height != frame.height {
-        exchange.recycle_scene(frame.scene);
+    if size.width != current.width || size.height != current.height {
+        debug!(
+            "retaining terminal frame: texture is {}x{}, frame is {}x{}",
+            size.width, size.height, current.width, current.height
+        );
+        frame.0 = Some(current);
         return;
     }
 
@@ -220,17 +243,25 @@ fn render_terminal_frame(
         .get()
         .get_or_insert_with(|| GpuRenderer::new(device).expect("vello renderer"));
 
+    // The GPU image's own view decodes sRGB for sampling; Vello needs a plain
+    // `Rgba8Unorm` view to bind the texture as a storage target.
+    let storage_view = gpu_image.texture.create_view(&TextureViewDescriptor {
+        label: Some("terminal vello storage view"),
+        format: Some(TextureFormat::Rgba8Unorm),
+        ..Default::default()
+    });
+
     renderer
         .render_scene_to_texture_view(
             device,
             &render_queue,
-            &gpu_image.texture_view,
-            frame.width,
-            frame.height,
-            frame.base_color,
-            &frame.scene,
+            &storage_view,
+            current.width,
+            current.height,
+            current.base_color,
+            &current.scene,
         )
         .expect("render terminal scene into Bevy texture");
 
-    exchange.recycle_scene(frame.scene);
+    exchange.recycle_scene(current.scene);
 }

--- a/src/direct_render.rs
+++ b/src/direct_render.rs
@@ -46,6 +46,14 @@ impl Plugin for DirectTerminalRenderPlugin {
     }
 }
 
+/// The pair of textures a terminal frame is rendered through: Vello rasterizes
+/// into `render` (a plain `Rgba8Unorm` storage texture) and it is copied into
+/// `present` (sampled via an sRGB view) for the materials to sample.
+pub(crate) struct TerminalImages {
+    pub render: Handle<Image>,
+    pub present: Handle<Image>,
+}
+
 struct DirectTerminalFrame {
     /// Plain `Rgba8Unorm` storage texture Vello rasterizes into.
     render_image: Handle<Image>,
@@ -219,8 +227,7 @@ pub(crate) fn resize_terminal_image(image: &mut Image, width: u32, height: u32) 
 
 pub(crate) fn update_direct_terminal_frame(
     exchange: &DirectTerminalSceneExchange,
-    render_image: Handle<Image>,
-    present_image: Handle<Image>,
+    images: TerminalImages,
     terminal_renderer: &mut TerminalRenderer,
     buffer: &Buffer,
     cursor: Option<Position>,
@@ -235,8 +242,8 @@ pub(crate) fn update_direct_terminal_frame(
     let scene = terminal_renderer.replace_scene(spare_scene);
 
     exchange.publish_frame(DirectTerminalFrame {
-        render_image,
-        present_image,
+        render_image: images.render,
+        present_image: images.present,
         width,
         height,
         base_color,

--- a/src/direct_render.rs
+++ b/src/direct_render.rs
@@ -8,7 +8,8 @@ use bevy::platform::cell::SyncCell;
 use bevy::prelude::*;
 use bevy::render::render_asset::RenderAssets;
 use bevy::render::render_resource::{
-    Extent3d, TextureDimension, TextureFormat, TextureUsages, TextureViewDescriptor,
+    CommandEncoderDescriptor, Extent3d, TextureDimension, TextureFormat, TextureUsages,
+    TextureViewDescriptor,
 };
 use bevy::render::renderer::{RenderDevice, RenderGraph, RenderGraphSystems, RenderQueue};
 use bevy::render::texture::GpuImage;
@@ -46,7 +47,11 @@ impl Plugin for DirectTerminalRenderPlugin {
 }
 
 struct DirectTerminalFrame {
-    image: Handle<Image>,
+    /// Plain `Rgba8Unorm` storage texture Vello rasterizes into.
+    render_image: Handle<Image>,
+    /// `Rgba8Unorm` texture (sampled via an sRGB view) the render image is
+    /// copied into for the materials to sample.
+    present_image: Handle<Image>,
     width: u32,
     height: u32,
     base_color: PenikoColor,
@@ -132,14 +137,18 @@ impl DirectTerminalSceneExchange {
     }
 }
 
-/// Creates the terminal render target.
+/// Creates the terminal **present** texture that the plane material and sprite
+/// sample.
 ///
-/// Vello requires an `Rgba8Unorm` storage texture and writes sRGB-encoded,
-/// display-ready bytes into it. Bevy samples through a separate
-/// `Rgba8UnormSrgb` view so those bytes are decoded on sample instead of
-/// being re-encoded at the swapchain (which washes out colors). The data is
-/// zero-filled so a frame that samples the texture before Vello first writes
-/// it shows transparent black rather than uninitialized memory.
+/// Vello renders into the separate [`new_terminal_render_image`] storage
+/// texture and writes sRGB-encoded, display-ready bytes; those bytes are copied
+/// here each frame (same `Rgba8Unorm` format) and sampled through an
+/// `Rgba8UnormSrgb` view so they are decoded on sample instead of being
+/// re-encoded at the swapchain (which washes out colors). This texture has no
+/// `STORAGE_BINDING`, so the sRGB view is valid on every backend — wgpu rejects
+/// an sRGB view of a storage texture. The data is zero-filled so a frame
+/// sampled before the first copy shows transparent black rather than
+/// uninitialized memory.
 pub(crate) fn new_terminal_image(width: u32, height: u32, label: &'static str) -> Image {
     let mut image = Image::new_fill(
         Extent3d {
@@ -153,8 +162,7 @@ pub(crate) fn new_terminal_image(width: u32, height: u32, label: &'static str) -
         RenderAssetUsages::RENDER_WORLD | RenderAssetUsages::MAIN_WORLD,
     );
     image.texture_descriptor.label = Some(label);
-    image.texture_descriptor.usage =
-        TextureUsages::TEXTURE_BINDING | TextureUsages::COPY_DST | TextureUsages::STORAGE_BINDING;
+    image.texture_descriptor.usage = TextureUsages::TEXTURE_BINDING | TextureUsages::COPY_DST;
     image.texture_descriptor.view_formats = &[TextureFormat::Rgba8UnormSrgb];
     image.texture_view_descriptor = Some(TextureViewDescriptor {
         format: Some(TextureFormat::Rgba8UnormSrgb),
@@ -166,6 +174,32 @@ pub(crate) fn new_terminal_image(width: u32, height: u32, label: &'static str) -
     // as pixelation. Cell-edge seams are prevented at authoring time in
     // parley_ratatui (pixel-snapped cell fills), not by the sampler.
     image.sampler = ImageSampler::linear();
+    image
+}
+
+/// Creates the terminal **render** texture that Vello rasterizes into.
+///
+/// Vello binds it as a compute storage target, so it must be a plain
+/// `Rgba8Unorm` texture with no sRGB view: wgpu rejects an sRGB view of a
+/// storage texture (`STORAGE_BINDING`), which crashes bind-group creation on
+/// strict backends. Its sRGB-encoded contents are copied into the
+/// [`new_terminal_image`] present texture for sampling, so this texture is only
+/// ever a copy source and is never sampled directly.
+pub(crate) fn new_terminal_render_image(width: u32, height: u32, label: &'static str) -> Image {
+    let mut image = Image::new_fill(
+        Extent3d {
+            width,
+            height,
+            depth_or_array_layers: 1,
+        },
+        TextureDimension::D2,
+        &[0, 0, 0, 0],
+        TextureFormat::Rgba8Unorm,
+        RenderAssetUsages::RENDER_WORLD | RenderAssetUsages::MAIN_WORLD,
+    );
+    image.texture_descriptor.label = Some(label);
+    image.texture_descriptor.usage =
+        TextureUsages::STORAGE_BINDING | TextureUsages::COPY_SRC | TextureUsages::COPY_DST;
     image
 }
 
@@ -185,7 +219,8 @@ pub(crate) fn resize_terminal_image(image: &mut Image, width: u32, height: u32) 
 
 pub(crate) fn update_direct_terminal_frame(
     exchange: &DirectTerminalSceneExchange,
-    image: Handle<Image>,
+    render_image: Handle<Image>,
+    present_image: Handle<Image>,
     terminal_renderer: &mut TerminalRenderer,
     buffer: &Buffer,
     cursor: Option<Position>,
@@ -200,7 +235,8 @@ pub(crate) fn update_direct_terminal_frame(
     let scene = terminal_renderer.replace_scene(spare_scene);
 
     exchange.publish_frame(DirectTerminalFrame {
-        image,
+        render_image,
+        present_image,
         width,
         height,
         base_color,
@@ -232,17 +268,30 @@ fn render_terminal_frame(
     };
     // Retain undrawable frames and retry on the next render frame; a newer
     // published frame supersedes a retained one during extraction.
-    let Some(gpu_image) = gpu_images.get(&current.image) else {
+    let (Some(render_image), Some(present_image)) = (
+        gpu_images.get(&current.render_image),
+        gpu_images.get(&current.present_image),
+    ) else {
         debug!("retaining terminal frame: GPU image not yet prepared");
         frame.0 = Some(current);
         return;
     };
 
-    let size = gpu_image.texture_descriptor.size;
-    if size.width != current.width || size.height != current.height {
+    let render_size = render_image.texture_descriptor.size;
+    let present_size = present_image.texture_descriptor.size;
+    if render_size.width != current.width
+        || render_size.height != current.height
+        || present_size.width != current.width
+        || present_size.height != current.height
+    {
         debug!(
-            "retaining terminal frame: texture is {}x{}, frame is {}x{}",
-            size.width, size.height, current.width, current.height
+            "retaining terminal frame: render {}x{}, present {}x{}, frame {}x{}",
+            render_size.width,
+            render_size.height,
+            present_size.width,
+            present_size.height,
+            current.width,
+            current.height
         );
         frame.0 = Some(current);
         return;
@@ -254,25 +303,36 @@ fn render_terminal_frame(
         .get()
         .get_or_insert_with(|| GpuRenderer::new(device).expect("vello renderer"));
 
-    // The GPU image's own view decodes sRGB for sampling; Vello needs a plain
-    // `Rgba8Unorm` view to bind the texture as a storage target.
-    let storage_view = gpu_image.texture.create_view(&TextureViewDescriptor {
-        label: Some("terminal vello storage view"),
-        format: Some(TextureFormat::Rgba8Unorm),
-        ..Default::default()
-    });
-
+    // Vello rasterizes into the plain `Rgba8Unorm` storage texture; its default
+    // view is storage-compatible (no sRGB reinterpretation).
     renderer
         .render_scene_to_texture_view(
             device,
             &render_queue,
-            &storage_view,
+            &render_image.texture_view,
             current.width,
             current.height,
             current.base_color,
             &current.scene,
         )
         .expect("render terminal scene into Bevy texture");
+
+    // Copy the rendered, sRGB-encoded bytes into the present texture, which the
+    // materials sample through an `Rgba8UnormSrgb` view to decode them. Both
+    // textures are `Rgba8Unorm`, so this is a plain same-format texel copy.
+    let mut encoder = device.create_command_encoder(&CommandEncoderDescriptor {
+        label: Some("terminal present copy"),
+    });
+    encoder.copy_texture_to_texture(
+        render_image.texture.as_image_copy(),
+        present_image.texture.as_image_copy(),
+        Extent3d {
+            width: current.width,
+            height: current.height,
+            depth_or_array_layers: 1,
+        },
+    );
+    render_queue.submit([encoder.finish()]);
 
     exchange.recycle_scene(current.scene);
 }

--- a/src/direct_render.rs
+++ b/src/direct_render.rs
@@ -4,6 +4,7 @@ use std::sync::{Arc, Mutex};
 
 use bevy::asset::RenderAssetUsages;
 use bevy::image::ImageSampler;
+use bevy::platform::cell::SyncCell;
 use bevy::prelude::*;
 use bevy::render::render_asset::RenderAssets;
 use bevy::render::render_resource::{Extent3d, TextureDimension, TextureFormat, TextureUsages};
@@ -28,9 +29,7 @@ impl Plugin for DirectTerminalRenderPlugin {
             .clone();
 
         let render_app = app.sub_app_mut(RenderApp);
-        render_app
-            .world_mut()
-            .insert_non_send(DirectTerminalRenderState::default());
+        render_app.init_resource::<DirectTerminalRenderState>();
         render_app.world_mut().insert_resource(exchange);
         render_app.init_resource::<ExtractedDirectTerminalFrame>();
         render_app.add_systems(ExtractSchedule, extract_terminal_frame);
@@ -58,9 +57,23 @@ struct DirectTerminalSceneExchangeInner {
     recycled: Mutex<Option<Scene>>,
 }
 
-#[derive(Default)]
+/// Render-world Vello renderer state.
+///
+/// `vello::Renderer` is `Send` but not `Sync`, so the renderer lives in a
+/// [`SyncCell`] to qualify as a regular [`Resource`]. A non-send resource
+/// would pin [`render_terminal_frame`] to a specific thread, which deadlocks
+/// the pipelined render app on its final update during shutdown.
+#[derive(Resource)]
 struct DirectTerminalRenderState {
-    renderer: Option<GpuRenderer>,
+    renderer: SyncCell<Option<GpuRenderer>>,
+}
+
+impl Default for DirectTerminalRenderState {
+    fn default() -> Self {
+        Self {
+            renderer: SyncCell::new(None),
+        }
+    }
 }
 
 #[derive(Resource, Default)]
@@ -180,7 +193,7 @@ fn extract_terminal_frame(
 }
 
 fn render_terminal_frame(
-    mut state: NonSendMut<DirectTerminalRenderState>,
+    mut state: ResMut<DirectTerminalRenderState>,
     exchange: Res<DirectTerminalSceneExchange>,
     mut frame: ResMut<ExtractedDirectTerminalFrame>,
     gpu_images: Res<RenderAssets<GpuImage>>,
@@ -204,6 +217,7 @@ fn render_terminal_frame(
     let device = render_device.wgpu_device();
     let renderer = state
         .renderer
+        .get()
         .get_or_insert_with(|| GpuRenderer::new(device).expect("vello renderer"));
 
     renderer

--- a/src/inline.rs
+++ b/src/inline.rs
@@ -555,7 +555,7 @@ pub enum RgpInlineObject {
         /// Scene asset path.
         asset_path: String,
         /// Cached scene handle.
-        handle: Option<Handle<Scene>>,
+        handle: Option<Handle<WorldAsset>>,
     },
 }
 

--- a/src/keyboard.rs
+++ b/src/keyboard.rs
@@ -14,8 +14,8 @@ use crate::mouse::{TerminalSelection, encode_mouse_wheel};
 use crate::runtime::TerminalRuntime;
 use crate::scene::{
     MobiusTransition, TerminalPlaneBackLayoutQuery, TerminalPlaneLayoutQuery, TerminalPlaneView,
-    TerminalPlaneWarp, TerminalPresentation, TerminalPresentationMode, TerminalSpriteLayoutQuery,
-    TerminalViewport, sync_terminal_layout,
+    TerminalPlaneWarp, TerminalPresentation, TerminalPresentationMode, TerminalViewport,
+    sync_terminal_layout,
 };
 use crate::terminal::{TerminalRedrawState, TerminalSurface, render_scale_for_window};
 
@@ -320,7 +320,6 @@ pub struct KeyboardSystemParams<'w, 's> {
     terminal: ResMut<'w, TerminalSurface>,
     primary_window: Query<'w, 's, &'static Window, With<PrimaryWindow>>,
     viewport: ResMut<'w, TerminalViewport>,
-    sprite_query: TerminalSpriteLayoutQuery<'w, 's>,
     plane_query: TerminalPlaneLayoutQuery<'w, 's>,
     plane_back_query: TerminalPlaneBackLayoutQuery<'w, 's>,
     bindings: Res<'w, TerminalKeyBindings>,
@@ -501,7 +500,6 @@ pub fn handle_keyboard_input(
                         sync_terminal_layout(
                             layout,
                             &mut params.viewport,
-                            &mut params.sprite_query,
                             &mut params.plane_query,
                             &mut params.plane_back_query,
                         );

--- a/src/keyboard.rs
+++ b/src/keyboard.rs
@@ -5,6 +5,7 @@ use bevy::ecs::world::FromWorld;
 use bevy::input::ButtonState;
 use bevy::input::keyboard::{Key, KeyboardInput};
 use bevy::prelude::*;
+use bevy::window::{PrimaryWindow, Window};
 
 use arboard::Clipboard;
 
@@ -12,10 +13,11 @@ use crate::config::{AppConfig, BindingAction, FontConfig, KeyBindingConfig};
 use crate::mouse::{TerminalSelection, encode_mouse_wheel};
 use crate::runtime::TerminalRuntime;
 use crate::scene::{
-    MobiusTransition, TerminalPlaneView, TerminalPlaneWarp, TerminalPresentation,
-    TerminalPresentationMode, TerminalViewport,
+    MobiusTransition, TerminalPlaneBackLayoutQuery, TerminalPlaneLayoutQuery, TerminalPlaneView,
+    TerminalPlaneWarp, TerminalPresentation, TerminalPresentationMode, TerminalSpriteLayoutQuery,
+    TerminalViewport, sync_terminal_layout,
 };
-use crate::terminal::{TerminalRedrawState, TerminalSurface};
+use crate::terminal::{TerminalRedrawState, TerminalSurface, render_scale_for_window};
 
 /// Clipboard bridge for terminal copy and paste.
 pub struct TerminalClipboard {
@@ -316,7 +318,11 @@ pub struct KeyboardSystemParams<'w, 's> {
     clipboard: NonSendMut<'w, TerminalClipboard>,
     runtime: NonSendMut<'w, TerminalRuntime>,
     terminal: NonSendMut<'w, TerminalSurface>,
-    viewport: Res<'w, TerminalViewport>,
+    primary_window: Query<'w, 's, &'static Window, With<PrimaryWindow>>,
+    viewport: ResMut<'w, TerminalViewport>,
+    sprite_query: TerminalSpriteLayoutQuery<'w, 's>,
+    plane_query: TerminalPlaneLayoutQuery<'w, 's>,
+    plane_back_query: TerminalPlaneBackLayoutQuery<'w, 's>,
     bindings: Res<'w, TerminalKeyBindings>,
     redraw: ResMut<'w, TerminalRedrawState>,
     _marker: std::marker::PhantomData<&'s ()>,
@@ -478,19 +484,28 @@ pub fn handle_keyboard_input(
                         _ => false,
                     };
                     if resized {
-                        let char_dims = params.terminal.char_dimensions().max(UVec2::ONE);
-                        let cols =
-                            ((params.viewport.size.x / char_dims.x as f32).floor() as u16).max(1);
-                        let rows =
-                            ((params.viewport.size.y / char_dims.y as f32).floor() as u16).max(1);
-                        params.runtime.resize(
-                            cols,
-                            rows,
-                            params.viewport.size.x as u16,
-                            params.viewport.size.y as u16,
+                        let Ok(window) = params.primary_window.single() else {
+                            continue;
+                        };
+                        let layout = params.terminal.resize_to_fit(
+                            window.resolution.size().max(Vec2::ONE),
+                            render_scale_for_window(window),
                         );
-                        params.terminal.resize(cols, rows);
-                        params.redraw.request();
+                        let pty_pixels = layout.pty_pixels();
+                        params.runtime.resize(
+                            layout.cols,
+                            layout.rows,
+                            pty_pixels.x as u16,
+                            pty_pixels.y as u16,
+                        );
+                        sync_terminal_layout(
+                            layout,
+                            &mut params.viewport,
+                            &mut params.sprite_query,
+                            &mut params.plane_query,
+                            &mut params.plane_back_query,
+                        );
+                        params.redraw.request_immediate();
                     }
                     continue;
                 }

--- a/src/keyboard.rs
+++ b/src/keyboard.rs
@@ -316,8 +316,8 @@ pub struct KeyboardSystemParams<'w, 's> {
     presentation: ResMut<'w, TerminalPresentation>,
     mobius_transition: ResMut<'w, MobiusTransition>,
     clipboard: NonSendMut<'w, TerminalClipboard>,
-    runtime: NonSendMut<'w, TerminalRuntime>,
-    terminal: NonSendMut<'w, TerminalSurface>,
+    runtime: ResMut<'w, TerminalRuntime>,
+    terminal: ResMut<'w, TerminalSurface>,
     primary_window: Query<'w, 's, &'static Window, With<PrimaryWindow>>,
     viewport: ResMut<'w, TerminalViewport>,
     sprite_query: TerminalSpriteLayoutQuery<'w, 's>,
@@ -505,7 +505,7 @@ pub fn handle_keyboard_input(
                             &mut params.plane_query,
                             &mut params.plane_back_query,
                         );
-                        params.redraw.request_immediate();
+                        params.redraw.request();
                     }
                     continue;
                 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@
 
 pub mod cli;
 pub mod config;
+mod direct_render;
 pub mod inline;
 pub mod keyboard;
 pub mod kitty;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,7 @@ pub mod model;
 pub mod mouse;
 pub mod paths;
 pub mod plugin;
+pub mod present;
 pub mod rendering;
 pub mod rgp;
 pub mod runtime;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,3 @@
-use std::time::Duration;
-
 #[cfg(any(target_os = "linux", target_os = "windows"))]
 use anyhow::anyhow;
 use bevy::asset::AssetPlugin;
@@ -7,7 +5,7 @@ use bevy::prelude::*;
 use bevy::render::RenderPlugin;
 use bevy::render::settings::{WgpuSettings, WgpuSettingsPriority};
 use bevy::window::{PrimaryWindow, WindowCreated, WindowResolution};
-use bevy::winit::{UpdateMode, WINIT_WINDOWS, WinitSettings};
+use bevy::winit::{WINIT_WINDOWS, WinitSettings};
 use clap::Parser;
 
 #[cfg(target_os = "windows")]
@@ -21,8 +19,6 @@ use ratty::plugin::TerminalPlugin;
 use ratty::runtime::{RuntimeOptions, TerminalRuntime};
 use ratty::terminal::TerminalSurface;
 
-/// Focused-window update interval for low-power winit mode.
-const FOCUSED_UPDATE_INTERVAL: Duration = Duration::from_millis(33);
 // Matches the default icon id used by `winresource::WindowsResource::set_icon`.
 #[cfg(target_os = "windows")]
 const WINDOW_ICON_RESOURCE_ID: u16 = 1;
@@ -67,13 +63,13 @@ fn main() -> anyhow::Result<()> {
             (app_config.window.opacity.clamp(0.0, 1.0) * 255.0).round() as u8,
         )))
         .insert_resource(app_config.clone())
-        .insert_non_send(runtime)
-        .insert_non_send(terminal)
+        .insert_resource(runtime)
+        .insert_resource(terminal)
         .insert_non_send(AppWindowIcon { icon: window_icon })
-        .insert_resource(WinitSettings {
-            focused_mode: UpdateMode::reactive_low_power(FOCUSED_UPDATE_INTERVAL),
-            unfocused_mode: UpdateMode::Continuous,
-        })
+        // Always update continuously, focused or not. Bevy's default switches
+        // unfocused windows to a reactive mode, which would delay background
+        // PTY output.
+        .insert_resource(WinitSettings::continuous())
         .add_plugins(
             DefaultPlugins
                 .set(WindowPlugin {

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,7 @@ use bevy::asset::AssetPlugin;
 use bevy::prelude::*;
 use bevy::render::RenderPlugin;
 use bevy::render::settings::{WgpuSettings, WgpuSettingsPriority};
-use bevy::window::{PrimaryWindow, WindowCreated, WindowResolution};
+use bevy::window::{PrimaryWindow, WindowCreated, WindowResizeConstraints, WindowResolution};
 use bevy::winit::{WINIT_WINDOWS, WinitSettings};
 use clap::Parser;
 
@@ -77,6 +77,11 @@ fn main() -> anyhow::Result<()> {
                         title: window_title.clone(),
                         name: Some(window_title),
                         resolution: window_resolution(&app_config),
+                        resize_constraints: WindowResizeConstraints {
+                            min_width: 1.0,
+                            min_height: 1.0,
+                            ..default()
+                        },
                         transparent: app_config.window.opacity < 1.0,
                         visible: false,
                         ..default()

--- a/src/main.rs
+++ b/src/main.rs
@@ -88,12 +88,12 @@ fn main() -> anyhow::Result<()> {
                     ..default()
                 })
                 .set(RenderPlugin {
-                    render_creation: bevy::render::settings::RenderCreation::Automatic(
+                    render_creation: bevy::render::settings::RenderCreation::Automatic(Box::new(
                         WgpuSettings {
-                            priority: WgpuSettingsPriority::Compatibility,
+                            priority: WgpuSettingsPriority::WebGPU,
                             ..default()
                         },
-                    ),
+                    )),
                     ..default()
                 }),
         )

--- a/src/main.rs
+++ b/src/main.rs
@@ -57,9 +57,9 @@ fn main() -> anyhow::Result<()> {
             (app_config.window.opacity.clamp(0.0, 1.0) * 255.0).round() as u8,
         )))
         .insert_resource(app_config.clone())
-        .insert_non_send_resource(runtime)
-        .insert_non_send_resource(terminal)
-        .insert_non_send_resource(AppWindowIcon { icon: window_icon })
+        .insert_non_send(runtime)
+        .insert_non_send(terminal)
+        .insert_non_send(AppWindowIcon { icon: window_icon })
         .insert_resource(WinitSettings {
             focused_mode: UpdateMode::reactive_low_power(FOCUSED_UPDATE_INTERVAL),
             unfocused_mode: UpdateMode::Continuous,

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,6 +33,16 @@ struct AppWindowIcon {
     icon: Option<Icon>,
 }
 
+/// Builds the primary window resolution, overriding the display scale factor
+/// only when the config asks for it.
+fn window_resolution(app_config: &AppConfig) -> WindowResolution {
+    let resolution = WindowResolution::new(app_config.window.width, app_config.window.height);
+    match app_config.window.scale_factor {
+        Some(scale_factor) => resolution.with_scale_factor_override(scale_factor),
+        None => resolution,
+    }
+}
+
 fn main() -> anyhow::Result<()> {
     let cli = Cli::parse();
     let app_config = AppConfig::load_from_path(cli.config_file.as_deref())?;
@@ -70,11 +80,7 @@ fn main() -> anyhow::Result<()> {
                     primary_window: Some(Window {
                         title: window_title.clone(),
                         name: Some(window_title),
-                        resolution: WindowResolution::new(
-                            app_config.window.width,
-                            app_config.window.height,
-                        )
-                        .with_scale_factor_override(app_config.window.scale_factor),
+                        resolution: window_resolution(&app_config),
                         transparent: app_config.window.opacity < 1.0,
                         visible: false,
                         ..default()

--- a/src/model.rs
+++ b/src/model.rs
@@ -112,7 +112,7 @@ pub fn spawn_cursor_model(
         Ok((source, ObjectSource::Gltf(asset_path))) => {
             info!("loading cursor model from {}", source);
             commands.entity(root).with_children(|parent| {
-                parent.spawn(SceneRoot(
+                parent.spawn(WorldAssetRoot(
                     asset_server.load(GltfAssetLabel::Scene(0).from_asset(asset_path)),
                 ));
             });

--- a/src/mouse.rs
+++ b/src/mouse.rs
@@ -270,6 +270,7 @@ pub(crate) fn handle_mouse_input(
     let Ok((primary_window, window)) = primary_window.single() else {
         return;
     };
+    let window_size = window.resolution.size().max(Vec2::ONE);
     let mouse_mode = runtime.parser.screen().mouse_protocol_mode();
     let mouse_encoding = runtime.parser.screen().mouse_protocol_encoding();
     let mobius_animating =
@@ -309,7 +310,7 @@ pub(crate) fn handle_mouse_input(
                 plane_view.last_pan_cursor = Some(event.position);
             }
         } else if forward_mouse {
-            if let Some(cell) = position_to_cell(event.position, viewport, terminal)
+            if let Some(cell) = position_to_cell(event.position, window_size, viewport, terminal)
                 && forwarded_mouse.last_cell != Some(cell)
                 && match mouse_mode {
                     MouseProtocolMode::ButtonMotion => {
@@ -339,7 +340,7 @@ pub(crate) fn handle_mouse_input(
                 forwarded_mouse.last_cell = Some(cell);
             }
         } else if (selection.dragging || selection.pending_start.is_some())
-            && let Some(cell) = position_to_cell(event.position, viewport, terminal)
+            && let Some(cell) = position_to_cell(event.position, window_size, viewport, terminal)
             && selection.update_from_cursor(cell, event.position)
         {
             redraw.request();
@@ -362,7 +363,9 @@ pub(crate) fn handle_mouse_input(
                     if let Some(cell) = window
                         .cursor_position()
                         .or(selection.cursor_position())
-                        .and_then(|position| position_to_cell(position, viewport, terminal))
+                        .and_then(|position| {
+                            position_to_cell(position, window_size, viewport, terminal)
+                        })
                     {
                         runtime.write_input(&encode_mouse_event(cell, 0, false, mouse_encoding));
                         forwarded_mouse.last_cell = Some(cell);
@@ -374,7 +377,7 @@ pub(crate) fn handle_mouse_input(
                     plane_view.rotating = true;
                     plane_view.last_rotate_cursor = selection.cursor_position();
                 } else if let Some(pos) = selection.cursor_position()
-                    && let Some(cell) = position_to_cell(pos, viewport, terminal)
+                    && let Some(cell) = position_to_cell(pos, window_size, viewport, terminal)
                     && selection.begin_pending(cell, pos)
                 {
                     redraw.request();
@@ -386,7 +389,9 @@ pub(crate) fn handle_mouse_input(
                     if let Some(cell) = window
                         .cursor_position()
                         .or(selection.cursor_position())
-                        .and_then(|position| position_to_cell(position, viewport, terminal))
+                        .and_then(|position| {
+                            position_to_cell(position, window_size, viewport, terminal)
+                        })
                     {
                         runtime.write_input(&encode_mouse_event(cell, 0, true, mouse_encoding));
                         forwarded_mouse.last_cell = Some(cell);
@@ -406,7 +411,9 @@ pub(crate) fn handle_mouse_input(
                 if let Some(cell) = window
                     .cursor_position()
                     .or(selection.cursor_position())
-                    .and_then(|position| position_to_cell(position, viewport, terminal))
+                    .and_then(|position| {
+                        position_to_cell(position, window_size, viewport, terminal)
+                    })
                 {
                     runtime.write_input(&encode_mouse_event(cell, 1, false, mouse_encoding));
                     forwarded_mouse.last_cell = Some(cell);
@@ -417,7 +424,9 @@ pub(crate) fn handle_mouse_input(
                 if let Some(cell) = window
                     .cursor_position()
                     .or(selection.cursor_position())
-                    .and_then(|position| position_to_cell(position, viewport, terminal))
+                    .and_then(|position| {
+                        position_to_cell(position, window_size, viewport, terminal)
+                    })
                 {
                     runtime.write_input(&encode_mouse_event(cell, 1, true, mouse_encoding));
                     forwarded_mouse.last_cell = Some(cell);
@@ -428,7 +437,9 @@ pub(crate) fn handle_mouse_input(
                 if let Some(cell) = window
                     .cursor_position()
                     .or(selection.cursor_position())
-                    .and_then(|position| position_to_cell(position, viewport, terminal))
+                    .and_then(|position| {
+                        position_to_cell(position, window_size, viewport, terminal)
+                    })
                 {
                     runtime.write_input(&encode_mouse_event(cell, 2, false, mouse_encoding));
                     forwarded_mouse.last_cell = Some(cell);
@@ -439,7 +450,9 @@ pub(crate) fn handle_mouse_input(
                 if let Some(cell) = window
                     .cursor_position()
                     .or(selection.cursor_position())
-                    .and_then(|position| position_to_cell(position, viewport, terminal))
+                    .and_then(|position| {
+                        position_to_cell(position, window_size, viewport, terminal)
+                    })
                 {
                     runtime.write_input(&encode_mouse_event(cell, 2, true, mouse_encoding));
                     forwarded_mouse.last_cell = Some(cell);
@@ -481,7 +494,7 @@ pub(crate) fn handle_mouse_input(
             if let Some(cell) = window
                 .cursor_position()
                 .or(selection.cursor_position())
-                .and_then(|position| position_to_cell(position, viewport, terminal))
+                .and_then(|position| position_to_cell(position, window_size, viewport, terminal))
             {
                 runtime.write_input(&encode_mouse_event(
                     cell,
@@ -555,6 +568,7 @@ pub(crate) fn encode_mouse_wheel(
 
 fn position_to_cell(
     position: Vec2,
+    window_size: Vec2,
     viewport: &TerminalViewport,
     terminal: &TerminalSurface,
 ) -> Option<UVec2> {
@@ -570,8 +584,18 @@ fn position_to_cell(
         return None;
     }
 
-    let x = position.x.clamp(0.0, viewport.size.x - 1.0);
-    let y = position.y.clamp(0.0, viewport.size.y - 1.0);
+    let margin = (window_size - viewport.size).max(Vec2::ZERO) * 0.5;
+    let local_position = position - margin;
+    if local_position.x < 0.0
+        || local_position.y < 0.0
+        || local_position.x >= viewport.size.x
+        || local_position.y >= viewport.size.y
+    {
+        return None;
+    }
+
+    let x = local_position.x.clamp(0.0, viewport.size.x - 1.0);
+    let y = local_position.y.clamp(0.0, viewport.size.y - 1.0);
     let col = (x / cell_width).floor() as u32;
     let row = (y / cell_height).floor() as u32;
 

--- a/src/mouse.rs
+++ b/src/mouse.rs
@@ -237,8 +237,8 @@ impl TerminalSelection {
 #[derive(SystemParam)]
 pub struct MouseSystemParams<'w, 's> {
     primary_window: Query<'w, 's, (Entity, &'static Window), With<PrimaryWindow>>,
-    runtime: NonSendMut<'w, TerminalRuntime>,
-    terminal: NonSend<'w, TerminalSurface>,
+    runtime: ResMut<'w, TerminalRuntime>,
+    terminal: Res<'w, TerminalSurface>,
     viewport: Res<'w, TerminalViewport>,
     presentation: Res<'w, TerminalPresentation>,
     mobius_transition: Res<'w, MobiusTransition>,

--- a/src/mouse.rs
+++ b/src/mouse.rs
@@ -509,7 +509,7 @@ pub(crate) fn handle_mouse_input(
             let amount = match event.unit {
                 MouseScrollUnit::Line => event.y.round() as isize,
                 MouseScrollUnit::Pixel => {
-                    let char_height = terminal.char_dimensions().y.max(1) as f32;
+                    let char_height = terminal.char_dimensions().y;
                     local_scroll.pixel_remainder += event.y / char_height;
                     let amount = local_scroll.pixel_remainder.trunc() as isize;
                     local_scroll.pixel_remainder -= amount as f32;

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -2,11 +2,17 @@
 
 use bevy::prelude::*;
 
+use crate::config::AppConfig;
 use crate::direct_render::DirectTerminalRenderPlugin;
-use crate::inline::TerminalInlineObjects;
+use crate::inline::{
+    TerminalInlineObjectPlane, TerminalInlineObjectSprite, TerminalInlineObjects, TerminalRgpObject,
+};
 use crate::keyboard::{TerminalClipboard, TerminalKeyBindings, handle_keyboard_input};
 use crate::mouse::{TerminalSelection, handle_mouse_input};
-use crate::scene::{apply_terminal_presentation, setup_scene};
+use crate::scene::{
+    MobiusTransition, TerminalPlaneView, TerminalPresentation, TerminalPresentationMode,
+    apply_terminal_presentation, setup_scene,
+};
 use crate::systems::{
     TerminalFrameDirty, TerminalRedrawSet, animate_mobius_transition, animate_terminal_plane_warp,
     apply_inline_objects, apply_instance_brightness, finish_terminal_model_load,
@@ -15,6 +21,17 @@ use crate::systems::{
     sync_asset_to_terminal_cursor, sync_inline_objects, sync_rgp_objects, sync_terminal_materials,
 };
 use crate::terminal::TerminalRedrawState;
+
+/// Inline object entities spawned since the visibility pass last ran.
+type AddedInlineObjects<'w, 's> = Query<
+    'w,
+    's,
+    (),
+    Or<(
+        Added<TerminalInlineObjectSprite>,
+        Added<TerminalInlineObjectPlane>,
+    )>,
+>;
 
 /// Main terminal plugin.
 pub struct TerminalPlugin;
@@ -37,11 +54,26 @@ impl Plugin for TerminalPlugin {
                 Update,
                 apply_terminal_presentation
                     .after(handle_keyboard_input)
-                    .after(handle_mouse_input),
+                    .after(handle_mouse_input)
+                    .run_if(
+                        |presentation: Res<TerminalPresentation>,
+                         plane_view: Res<TerminalPlaneView>,
+                         mobius_transition: Res<MobiusTransition>| {
+                            presentation.is_changed()
+                                || plane_view.is_changed()
+                                || mobius_transition.is_changed()
+                        },
+                    ),
             )
             .add_systems(
                 Update,
-                apply_inline_objects.after(apply_terminal_presentation),
+                apply_inline_objects
+                    .after(apply_terminal_presentation)
+                    .run_if(
+                        |presentation: Res<TerminalPresentation>, added: AddedInlineObjects| {
+                            presentation.is_changed() || !added.is_empty()
+                        },
+                    ),
             )
             .configure_sets(
                 Update,
@@ -62,13 +94,34 @@ impl Plugin for TerminalPlugin {
                     .in_set(TerminalRedrawSet),
             )
             .add_systems(Update, sync_inline_objects.after(TerminalRedrawSet))
-            .add_systems(Update, sync_rgp_objects.after(sync_inline_objects))
-            .add_systems(Update, apply_instance_brightness.after(sync_rgp_objects))
-            .add_systems(Update, animate_mobius_transition)
-            .add_systems(Update, animate_terminal_plane_warp)
             .add_systems(
                 Update,
-                sync_asset_to_terminal_cursor.after(TerminalRedrawSet),
+                sync_rgp_objects
+                    .after(sync_inline_objects)
+                    .run_if(|objects: Query<(), With<TerminalRgpObject>>| !objects.is_empty()),
+            )
+            .add_systems(Update, apply_instance_brightness.after(sync_rgp_objects))
+            .add_systems(
+                Update,
+                animate_mobius_transition.run_if(
+                    |presentation: Res<TerminalPresentation>,
+                     mobius_transition: Res<MobiusTransition>| {
+                        presentation.mode == TerminalPresentationMode::Mobius3d
+                            || mobius_transition.active
+                    },
+                ),
+            )
+            .add_systems(
+                Update,
+                animate_terminal_plane_warp.run_if(|presentation: Res<TerminalPresentation>| {
+                    presentation.mode != TerminalPresentationMode::Flat2d
+                }),
+            )
+            .add_systems(
+                Update,
+                sync_asset_to_terminal_cursor
+                    .after(TerminalRedrawSet)
+                    .run_if(|config: Res<AppConfig>| config.cursor.model.visible),
             )
             .add_systems(Last, shutdown_terminal_runtime_on_exit)
             .add_plugins(DirectTerminalRenderPlugin);

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -45,6 +45,8 @@ impl Plugin for TerminalPlugin {
                 Update,
                 redraw_soft_terminal
                     .after(handle_mouse_input)
+                    .after(handle_keyboard_input)
+                    .after(handle_window_resize)
                     .after(pump_pty_output),
             )
             .add_systems(Update, sync_inline_objects.after(redraw_soft_terminal))

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -8,10 +8,11 @@ use crate::keyboard::{TerminalClipboard, TerminalKeyBindings, handle_keyboard_in
 use crate::mouse::{TerminalSelection, handle_mouse_input};
 use crate::scene::{apply_terminal_presentation, setup_scene};
 use crate::systems::{
-    animate_mobius_transition, animate_terminal_plane_warp, apply_inline_objects,
-    apply_instance_brightness, handle_window_resize, pump_pty_output, redraw_soft_terminal,
+    TerminalFrameDirty, TerminalRedrawSet, animate_mobius_transition, animate_terminal_plane_warp,
+    apply_inline_objects, apply_instance_brightness, finish_terminal_model_load,
+    handle_window_resize, pump_pty_output, render_terminal_widget,
     request_exit_on_primary_window_close, shutdown_terminal_runtime_on_exit,
-    sync_asset_to_terminal_cursor, sync_inline_objects, sync_rgp_objects,
+    sync_asset_to_terminal_cursor, sync_inline_objects, sync_rgp_objects, sync_terminal_materials,
 };
 use crate::terminal::TerminalRedrawState;
 
@@ -24,6 +25,7 @@ impl Plugin for TerminalPlugin {
             .init_resource::<TerminalInlineObjects>()
             .init_resource::<TerminalRedrawState>()
             .init_resource::<TerminalKeyBindings>()
+            .init_resource::<TerminalFrameDirty>()
             .init_non_send::<TerminalClipboard>()
             .add_systems(Startup, setup_scene)
             .add_systems(Update, request_exit_on_primary_window_close)
@@ -41,22 +43,32 @@ impl Plugin for TerminalPlugin {
                 Update,
                 apply_inline_objects.after(apply_terminal_presentation),
             )
-            .add_systems(
+            .configure_sets(
                 Update,
-                redraw_soft_terminal
+                TerminalRedrawSet
                     .after(handle_mouse_input)
                     .after(handle_keyboard_input)
                     .after(handle_window_resize)
                     .after(pump_pty_output),
             )
-            .add_systems(Update, sync_inline_objects.after(redraw_soft_terminal))
+            .add_systems(
+                Update,
+                (
+                    render_terminal_widget,
+                    sync_terminal_materials,
+                    finish_terminal_model_load,
+                )
+                    .chain()
+                    .in_set(TerminalRedrawSet),
+            )
+            .add_systems(Update, sync_inline_objects.after(TerminalRedrawSet))
             .add_systems(Update, sync_rgp_objects.after(sync_inline_objects))
             .add_systems(Update, apply_instance_brightness.after(sync_rgp_objects))
             .add_systems(Update, animate_mobius_transition)
             .add_systems(Update, animate_terminal_plane_warp)
             .add_systems(
                 Update,
-                sync_asset_to_terminal_cursor.after(redraw_soft_terminal),
+                sync_asset_to_terminal_cursor.after(TerminalRedrawSet),
             )
             .add_systems(Last, shutdown_terminal_runtime_on_exit)
             .add_plugins(DirectTerminalRenderPlugin);

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -2,6 +2,7 @@
 
 use bevy::prelude::*;
 
+use crate::direct_render::DirectTerminalRenderPlugin;
 use crate::inline::TerminalInlineObjects;
 use crate::keyboard::{TerminalClipboard, TerminalKeyBindings, handle_keyboard_input};
 use crate::mouse::{TerminalSelection, handle_mouse_input};
@@ -23,7 +24,7 @@ impl Plugin for TerminalPlugin {
             .init_resource::<TerminalInlineObjects>()
             .init_resource::<TerminalRedrawState>()
             .init_resource::<TerminalKeyBindings>()
-            .init_non_send_resource::<TerminalClipboard>()
+            .init_non_send::<TerminalClipboard>()
             .add_systems(Startup, setup_scene)
             .add_systems(Update, request_exit_on_primary_window_close)
             .add_systems(Update, pump_pty_output)
@@ -55,6 +56,7 @@ impl Plugin for TerminalPlugin {
                 Update,
                 sync_asset_to_terminal_cursor.after(redraw_soft_terminal),
             )
-            .add_systems(Last, shutdown_terminal_runtime_on_exit);
+            .add_systems(Last, shutdown_terminal_runtime_on_exit)
+            .add_plugins(DirectTerminalRenderPlugin);
     }
 }

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -9,6 +9,7 @@ use crate::inline::{
 };
 use crate::keyboard::{TerminalClipboard, TerminalKeyBindings, handle_keyboard_input};
 use crate::mouse::{TerminalSelection, handle_mouse_input};
+use crate::present::TerminalPresentPlugin;
 use crate::scene::{
     MobiusTransition, TerminalPlaneView, TerminalPresentation, TerminalPresentationMode,
     apply_terminal_presentation, setup_scene,
@@ -124,6 +125,7 @@ impl Plugin for TerminalPlugin {
                     .run_if(|config: Res<AppConfig>| config.cursor.model.visible),
             )
             .add_systems(Last, shutdown_terminal_runtime_on_exit)
-            .add_plugins(DirectTerminalRenderPlugin);
+            .add_plugins(DirectTerminalRenderPlugin)
+            .add_plugins(TerminalPresentPlugin);
     }
 }

--- a/src/present.rs
+++ b/src/present.rs
@@ -1,0 +1,94 @@
+//! 1:1 presentation of the terminal texture for flat 2D mode.
+//!
+//! Instead of drawing the terminal texture on a world-positioned sprite (whose
+//! interpolated UVs resample the texture and make text blurry/jagged unless the
+//! mapping happens to be exactly 1:1), this presents it with a fullscreen quad
+//! whose fragment shader fetches each texel by physical pixel coordinate
+//! (`textureLoad`). That is an identity sample — crisp at every font size and
+//! DPI — modeled on linebender/bevy_vello's render-target present.
+//!
+//! The 3D plane path is unchanged; it still samples the texture as a material on
+//! transformable geometry, where sampling is unavoidable.
+
+use bevy::asset::{load_internal_asset, uuid_handle};
+use bevy::mesh::{Indices, MeshVertexBufferLayoutRef, PrimitiveTopology, VertexBufferLayout};
+use bevy::prelude::*;
+use bevy::render::render_resource::{
+    AsBindGroup, BlendState, RenderPipelineDescriptor, SpecializedMeshPipelineError, VertexFormat,
+    VertexStepMode,
+};
+use bevy::shader::{Shader, ShaderRef};
+use bevy::sprite_render::{Material2d, Material2dKey, Material2dPlugin};
+
+/// Handle for the embedded terminal-present shader.
+const TERMINAL_PRESENT_SHADER: Handle<Shader> =
+    uuid_handle!("7e3b1c2a-5d6f-4a8b-9c0d-1e2f3a4b5c6d");
+
+/// Material that presents the terminal texture 1:1 with physical pixels.
+///
+/// Sampled via `textureLoad` in the shader, so no sampler binding is needed.
+#[derive(Asset, TypePath, AsBindGroup, Clone)]
+pub struct TerminalPresentMaterial {
+    /// The terminal present texture (an `Rgba8Unorm` texture with an sRGB view).
+    #[texture(0)]
+    pub texture: Handle<Image>,
+}
+
+impl Material2d for TerminalPresentMaterial {
+    fn vertex_shader() -> ShaderRef {
+        TERMINAL_PRESENT_SHADER.into()
+    }
+
+    fn fragment_shader() -> ShaderRef {
+        TERMINAL_PRESENT_SHADER.into()
+    }
+
+    fn specialize(
+        descriptor: &mut RenderPipelineDescriptor,
+        _layout: &MeshVertexBufferLayoutRef,
+        _key: Material2dKey<Self>,
+    ) -> Result<(), SpecializedMeshPipelineError> {
+        // Alpha-blend so the transparent area outside the terminal lets the
+        // camera clear color show through.
+        if let Some(fragment) = descriptor.fragment.as_mut()
+            && let Some(Some(target)) = fragment.targets.first_mut()
+        {
+            target.blend = Some(BlendState::ALPHA_BLENDING);
+        }
+        // The present quad carries only clip-space positions.
+        descriptor.vertex.buffers = vec![VertexBufferLayout::from_vertex_formats(
+            VertexStepMode::Vertex,
+            [VertexFormat::Float32x3],
+        )];
+        Ok(())
+    }
+}
+
+/// A clip-space quad covering the whole viewport (positions only).
+pub fn fullscreen_quad() -> Mesh {
+    let mut mesh = Mesh::new(
+        PrimitiveTopology::TriangleList,
+        bevy::asset::RenderAssetUsages::default(),
+    );
+    mesh.insert_attribute(
+        Mesh::ATTRIBUTE_POSITION,
+        vec![[-1.0, -1.0, 0.0], [3.0, -1.0, 0.0], [-1.0, 3.0, 0.0]],
+    );
+    mesh.insert_indices(Indices::U32(vec![0, 1, 2]));
+    mesh
+}
+
+/// Registers the terminal-present shader and material.
+pub struct TerminalPresentPlugin;
+
+impl Plugin for TerminalPresentPlugin {
+    fn build(&self, app: &mut App) {
+        load_internal_asset!(
+            app,
+            TERMINAL_PRESENT_SHADER,
+            "shaders/terminal_present.wgsl",
+            Shader::from_wgsl
+        );
+        app.add_plugins(Material2dPlugin::<TerminalPresentMaterial>::default());
+    }
+}

--- a/src/rendering.rs
+++ b/src/rendering.rs
@@ -46,6 +46,16 @@ pub fn sync_terminal_debug_image(
 }
 
 /// Synchronizes an image handle across plane materials.
+///
+/// Re-binds the texture on every call rather than only when the handle changes.
+/// The terminal plane textures are rebuilt on the GPU as the terminal updates:
+/// the back debug texture is re-uploaded each redraw, and the front present
+/// texture's GPU image is recreated whenever the terminal resizes. Either rebuild
+/// leaves a material's cached bind group pointing at a stale texture, so the plane
+/// freezes (front) or blanks (back) until the material is re-prepared.
+/// Unconditionally re-binding re-prepares the bind group so the planes always
+/// sample the current texture. The caller only runs this on redraw frames (gated
+/// by the frame-dirty flag), so it is not per-frame churn.
 pub fn sync_plane_texture<'a>(
     image_handle: Option<&Handle<Image>>,
     material_handles: impl IntoIterator<Item = &'a MeshMaterial3d<StandardMaterial>>,
@@ -56,12 +66,7 @@ pub fn sync_plane_texture<'a>(
     };
 
     for material_handle in material_handles {
-        // `get_mut` marks the material modified and re-prepares it on the GPU;
-        // only take it when the texture handle actually changes.
-        let needs_update = materials
-            .get(&material_handle.0)
-            .is_some_and(|material| material.base_color_texture.as_ref() != Some(image_handle));
-        if needs_update && let Some(mut material) = materials.get_mut(&material_handle.0) {
+        if let Some(mut material) = materials.get_mut(&material_handle.0) {
             material.base_color_texture = Some(image_handle.clone());
         }
     }

--- a/src/rendering.rs
+++ b/src/rendering.rs
@@ -56,7 +56,12 @@ pub fn sync_plane_texture<'a>(
     };
 
     for material_handle in material_handles {
-        if let Some(mut material) = materials.get_mut(&material_handle.0) {
+        // `get_mut` marks the material modified and re-prepares it on the GPU;
+        // only take it when the texture handle actually changes.
+        let needs_update = materials
+            .get(&material_handle.0)
+            .is_some_and(|material| material.base_color_texture.as_ref() != Some(image_handle));
+        if needs_update && let Some(mut material) = materials.get_mut(&material_handle.0) {
             material.base_color_texture = Some(image_handle.clone());
         }
     }

--- a/src/rendering.rs
+++ b/src/rendering.rs
@@ -22,7 +22,7 @@ pub fn sync_terminal_debug_image(
     let Some(handle) = terminal.back_image_handle.as_ref() else {
         return;
     };
-    let Some(image) = images.get_mut(handle) else {
+    let Some(mut image) = images.get_mut(handle) else {
         return;
     };
 
@@ -56,7 +56,7 @@ pub fn sync_plane_texture<'a>(
     };
 
     for material_handle in material_handles {
-        if let Some(material) = materials.get_mut(&material_handle.0) {
+        if let Some(mut material) = materials.get_mut(&material_handle.0) {
             material.base_color_texture = Some(image_handle.clone());
         }
     }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -4,11 +4,13 @@ use std::collections::HashSet;
 use std::env;
 use std::io::{ErrorKind, Read, Write};
 use std::path::PathBuf;
-use std::sync::mpsc::{self, Receiver};
+use std::sync::mpsc::{self, Receiver, TryRecvError};
 use std::sync::{Arc, Mutex};
 use std::thread::{self, JoinHandle};
 
 use anyhow::Context;
+use bevy::platform::cell::SyncCell;
+use bevy::prelude::Resource;
 use portable_pty::{CommandBuilder, MasterPty, PtySize, native_pty_system};
 use vt100::{Callbacks, Parser, Screen};
 
@@ -169,13 +171,18 @@ impl Callbacks for TerminalParserCallbacks {
 }
 
 /// Running PTY and parser state.
+///
+/// The `!Sync` PTY handles (the output channel receiver and the master) live
+/// in [`SyncCell`]s so the runtime qualifies as a regular [`Resource`] and
+/// systems using it are not pinned to the main thread.
+#[derive(Resource)]
 pub struct TerminalRuntime {
     /// PTY output channel.
-    pub rx: Receiver<Vec<u8>>,
+    rx: SyncCell<Receiver<Vec<u8>>>,
     /// PTY input writer.
     pub writer: Arc<Mutex<Option<Box<dyn Write + Send>>>>,
     /// PTY master handle.
-    master: Option<Box<dyn MasterPty + Send>>,
+    master: SyncCell<Option<Box<dyn MasterPty + Send>>>,
     /// Child process handle.
     child: Option<Box<dyn portable_pty::Child + Send + Sync>>,
     /// PTY reader thread.
@@ -339,9 +346,9 @@ impl TerminalRuntime {
         });
 
         Ok(Self {
-            rx,
+            rx: SyncCell::new(rx),
             writer: Arc::new(Mutex::new(Some(writer))),
-            master: Some(pair.master),
+            master: SyncCell::new(Some(pair.master)),
             child: Some(child),
             reader_thread: Some(reader_thread),
             parser: Parser::new_with_callbacks(
@@ -354,6 +361,11 @@ impl TerminalRuntime {
             pty_disconnected: false,
             shutdown_started: false,
         })
+    }
+
+    /// Receives pending PTY output without blocking.
+    pub fn try_recv(&mut self) -> Result<Vec<u8>, TryRecvError> {
+        self.rx.get().try_recv()
     }
 
     /// Writes input bytes to the PTY.
@@ -376,7 +388,7 @@ impl TerminalRuntime {
             return;
         }
 
-        if let Some(master) = self.master.as_ref() {
+        if let Some(master) = self.master.get().as_ref() {
             let _ = master.resize(PtySize {
                 rows,
                 cols,
@@ -423,7 +435,7 @@ impl TerminalRuntime {
             let _ = child.kill();
         }
         self.child.take();
-        self.master.take();
+        self.master.get().take();
 
         if self
             .reader_thread

--- a/src/scene/mod.rs
+++ b/src/scene/mod.rs
@@ -12,10 +12,14 @@ use bevy::image::ImageSampler;
 use bevy::mesh::{Indices, PrimitiveTopology};
 use bevy::prelude::*;
 use bevy::render::render_resource::{Extent3d, Face, TextureDimension, TextureFormat};
+use bevy::window::PrimaryWindow;
 
 use crate::config::AppConfig;
 use crate::direct_render::new_terminal_image;
-use crate::terminal::TerminalSurface;
+use crate::runtime::TerminalRuntime;
+use crate::terminal::{
+    TerminalLayout, TerminalSurface, render_scale_for_window, snapped_translation,
+};
 
 /// Marker for the 2D terminal sprite.
 #[derive(Component)]
@@ -173,6 +177,20 @@ type PlaneBackTransformQuery<'w, 's> =
     Query<'w, 's, &'static mut Transform, With<TerminalPlaneBack>>;
 type PlaneCameraQuery<'w, 's> =
     Query<'w, 's, (&'static mut Projection, &'static mut Transform), With<TerminalPlaneCamera>>;
+pub(crate) type TerminalSpriteLayoutQuery<'w, 's> =
+    Query<'w, 's, (&'static mut Sprite, &'static mut Transform), With<TerminalSprite>>;
+pub(crate) type TerminalPlaneLayoutQuery<'w, 's> =
+    Query<'w, 's, &'static mut Transform, (With<TerminalPlane>, Without<TerminalSprite>)>;
+pub(crate) type TerminalPlaneBackLayoutQuery<'w, 's> = Query<
+    'w,
+    's,
+    &'static mut Transform,
+    (
+        With<TerminalPlaneBack>,
+        Without<TerminalPlane>,
+        Without<TerminalSprite>,
+    ),
+>;
 
 #[derive(SystemParam)]
 pub(crate) struct PresentationParams<'w, 's> {
@@ -198,19 +216,45 @@ pub(crate) struct PresentationParams<'w, 's> {
     >,
 }
 
+#[derive(SystemParam)]
+pub(crate) struct SetupSceneParams<'w, 's> {
+    commands: Commands<'w, 's>,
+    app_config: Res<'w, AppConfig>,
+    meshes: ResMut<'w, Assets<Mesh>>,
+    materials: ResMut<'w, Assets<StandardMaterial>>,
+    images: ResMut<'w, Assets<Image>>,
+    primary_window: Query<'w, 's, &'static Window, With<PrimaryWindow>>,
+    runtime: NonSendMut<'w, TerminalRuntime>,
+    terminal: NonSendMut<'w, TerminalSurface>,
+}
+
 /// Sets up the terminal presentation scene.
 ///
 /// This startup system creates the 2D and 3D cameras, terminal sprite, terminal plane meshes,
 /// backing images, lighting and presentation resources used by later update systems.
-pub fn setup_scene(
-    mut commands: Commands,
-    app_config: Res<AppConfig>,
-    mut meshes: ResMut<Assets<Mesh>>,
-    mut materials: ResMut<Assets<StandardMaterial>>,
-    mut images: ResMut<Assets<Image>>,
-    mut terminal: NonSendMut<TerminalSurface>,
-) {
+pub(crate) fn setup_scene(mut params: SetupSceneParams) {
+    let SetupSceneParams {
+        commands,
+        app_config,
+        meshes,
+        materials,
+        images,
+        primary_window,
+        runtime,
+        terminal,
+    } = &mut params;
     let terminal_opacity = app_config.window.opacity.clamp(0.0, 1.0);
+    let window = primary_window.single().expect("primary window");
+    let window_size = window.resolution.size().max(Vec2::ONE);
+    let render_scale = render_scale_for_window(window);
+    let layout = terminal.resize_to_fit(window_size, render_scale);
+    let pty_pixels = layout.pty_pixels();
+    runtime.resize(
+        layout.cols,
+        layout.rows,
+        pty_pixels.x as u16,
+        pty_pixels.y as u16,
+    );
 
     commands.spawn((
         Camera2d,
@@ -237,22 +281,18 @@ pub fn setup_scene(
         Msaa::Off,
     ));
 
-    let pixmap = terminal.pixmap_dimensions();
-    let pixmap_width = pixmap.x;
-    let pixmap_height = pixmap.y;
-
     let terminal_alpha = (terminal_opacity * 255.0).round() as u8;
     let image_handle = images.add(new_terminal_image(
-        pixmap_width,
-        pixmap_height,
+        layout.texture_size.x,
+        layout.texture_size.y,
         crate::config::TERMINAL_TEXTURE_LABEL,
     ));
     terminal.image_handle = Some(image_handle.clone());
 
     let [r, g, b] = app_config.theme.background;
     let back_image = create_terminal_image(
-        pixmap_width,
-        pixmap_height,
+        layout.texture_size.x,
+        layout.texture_size.y,
         [
             r.saturating_sub(13),
             g.saturating_sub(11),
@@ -263,23 +303,19 @@ pub fn setup_scene(
     let back_image_handle = images.add(back_image);
     terminal.back_image_handle = Some(back_image_handle.clone());
 
-    let viewport_size = Vec2::new(
-        app_config.window.width as f32,
-        app_config.window.height as f32,
-    );
     let viewport_center = Vec2::ZERO;
     commands.insert_resource(TerminalViewport {
-        size: viewport_size,
+        size: layout.logical_size,
         center: viewport_center,
     });
 
     let mut sprite = Sprite::from_image(image_handle);
-    sprite.custom_size = Some(viewport_size);
+    sprite.custom_size = Some(layout.logical_size);
     sprite.color = Color::srgba(1.0, 1.0, 1.0, terminal_opacity);
     commands.spawn((
         TerminalSprite,
         sprite,
-        Transform::from_translation(Vec3::new(viewport_center.x, viewport_center.y, 0.0)),
+        Transform::from_translation(snapped_translation(viewport_center, render_scale).extend(0.0)),
     ));
 
     let front_mesh = meshes.add(terminal_plane_mesh(32, 20));
@@ -300,7 +336,7 @@ pub fn setup_scene(
             unlit: true,
             ..default()
         })),
-        Transform::from_scale(viewport_size.extend(1.0)),
+        Transform::from_scale(layout.logical_size.extend(1.0)),
         Visibility::Hidden,
     ));
 
@@ -317,7 +353,7 @@ pub fn setup_scene(
         Transform {
             translation: Vec3::new(0.0, 0.0, -2.0),
             rotation: Quat::from_rotation_y(std::f32::consts::PI),
-            scale: viewport_size.extend(1.0),
+            scale: layout.logical_size.extend(1.0),
         },
         Visibility::Hidden,
     ));
@@ -357,6 +393,32 @@ pub fn setup_scene(
         loaded: false,
         first_frame_uploaded: false,
     });
+}
+
+/// Synchronizes Bevy presentation entities to the terminal texture layout.
+pub(crate) fn sync_terminal_layout(
+    layout: TerminalLayout,
+    viewport: &mut TerminalViewport,
+    sprite_query: &mut TerminalSpriteLayoutQuery,
+    plane_query: &mut TerminalPlaneLayoutQuery,
+    plane_back_query: &mut TerminalPlaneBackLayoutQuery,
+) {
+    viewport.size = layout.logical_size;
+    viewport.center = Vec2::ZERO;
+
+    for (mut sprite, mut transform) in sprite_query.iter_mut() {
+        sprite.custom_size = Some(layout.logical_size);
+        transform.translation = snapped_translation(viewport.center, layout.render_scale)
+            .extend(transform.translation.z);
+    }
+
+    for mut transform in plane_query.iter_mut() {
+        transform.scale = layout.logical_size.extend(1.0);
+    }
+
+    for mut transform in plane_back_query.iter_mut() {
+        transform.scale = layout.logical_size.extend(1.0);
+    }
 }
 
 fn create_terminal_image(width: u32, height: u32, fill: [u8; 4]) -> Image {

--- a/src/scene/mod.rs
+++ b/src/scene/mod.rs
@@ -15,7 +15,7 @@ use bevy::render::render_resource::{Extent3d, Face, TextureDimension, TextureFor
 use bevy::window::PrimaryWindow;
 
 use crate::config::AppConfig;
-use crate::direct_render::new_terminal_image;
+use crate::direct_render::{new_terminal_image, new_terminal_render_image};
 use crate::runtime::TerminalRuntime;
 use crate::terminal::{
     TerminalLayout, TerminalSurface, render_scale_for_window, snapped_translation,
@@ -284,6 +284,13 @@ pub(crate) fn setup_scene(mut params: SetupSceneParams) {
     ));
 
     let terminal_alpha = (terminal_opacity * 255.0).round() as u8;
+    let render_image_handle = images.add(new_terminal_render_image(
+        layout.texture_size.x,
+        layout.texture_size.y,
+        crate::config::TERMINAL_RENDER_TEXTURE_LABEL,
+    ));
+    terminal.render_image_handle = Some(render_image_handle);
+
     let image_handle = images.add(new_terminal_image(
         layout.texture_size.x,
         layout.texture_size.y,

--- a/src/scene/mod.rs
+++ b/src/scene/mod.rs
@@ -20,9 +20,7 @@ use crate::config::AppConfig;
 use crate::direct_render::{new_terminal_image, new_terminal_render_image};
 use crate::present::{TerminalPresentMaterial, fullscreen_quad};
 use crate::runtime::TerminalRuntime;
-use crate::terminal::{
-    TerminalLayout, TerminalSurface, render_scale_for_window, snapped_translation,
-};
+use crate::terminal::{TerminalLayout, TerminalSurface, render_scale_for_window};
 
 /// Marker for the 2D terminal sprite.
 #[derive(Component)]
@@ -180,8 +178,6 @@ type PlaneBackTransformQuery<'w, 's> =
     Query<'w, 's, &'static mut Transform, With<TerminalPlaneBack>>;
 type PlaneCameraQuery<'w, 's> =
     Query<'w, 's, (&'static mut Projection, &'static mut Transform), With<TerminalPlaneCamera>>;
-pub(crate) type TerminalSpriteLayoutQuery<'w, 's> =
-    Query<'w, 's, (&'static mut Sprite, &'static mut Transform), With<TerminalSprite>>;
 pub(crate) type TerminalPlaneLayoutQuery<'w, 's> =
     Query<'w, 's, &'static mut Transform, (With<TerminalPlane>, Without<TerminalSprite>)>;
 pub(crate) type TerminalPlaneBackLayoutQuery<'w, 's> = Query<
@@ -419,18 +415,11 @@ pub(crate) fn setup_scene(mut params: SetupSceneParams) {
 pub(crate) fn sync_terminal_layout(
     layout: TerminalLayout,
     viewport: &mut TerminalViewport,
-    sprite_query: &mut TerminalSpriteLayoutQuery,
     plane_query: &mut TerminalPlaneLayoutQuery,
     plane_back_query: &mut TerminalPlaneBackLayoutQuery,
 ) {
     viewport.size = layout.logical_size;
     viewport.center = Vec2::ZERO;
-
-    for (mut sprite, mut transform) in sprite_query.iter_mut() {
-        sprite.custom_size = Some(layout.logical_size);
-        transform.translation = snapped_translation(viewport.center, layout.render_scale)
-            .extend(transform.translation.z);
-    }
 
     for mut transform in plane_query.iter_mut() {
         transform.scale = layout.logical_size.extend(1.0);

--- a/src/scene/mod.rs
+++ b/src/scene/mod.rs
@@ -224,8 +224,8 @@ pub(crate) struct SetupSceneParams<'w, 's> {
     materials: ResMut<'w, Assets<StandardMaterial>>,
     images: ResMut<'w, Assets<Image>>,
     primary_window: Query<'w, 's, &'static Window, With<PrimaryWindow>>,
-    runtime: NonSendMut<'w, TerminalRuntime>,
-    terminal: NonSendMut<'w, TerminalSurface>,
+    runtime: ResMut<'w, TerminalRuntime>,
+    terminal: ResMut<'w, TerminalSurface>,
 }
 
 /// Sets up the terminal presentation scene.

--- a/src/scene/mod.rs
+++ b/src/scene/mod.rs
@@ -214,6 +214,8 @@ pub(crate) struct PresentationParams<'w, 's> {
             PlaneCameraQuery<'w, 's>,
         ),
     >,
+    camera_2d: Query<'w, 's, &'static mut Camera, (With<Camera2d>, Without<TerminalPlaneCamera>)>,
+    camera_3d: Query<'w, 's, &'static mut Camera, (With<TerminalPlaneCamera>, Without<Camera2d>)>,
 }
 
 #[derive(SystemParam)]
@@ -449,6 +451,8 @@ pub(crate) fn apply_terminal_presentation(
         plane_materials,
         materials,
         plane_transforms,
+        camera_2d,
+        camera_3d,
     } = &mut params;
     let is_3d = presentation.mode.is_3d();
     let is_mobius = presentation.mode.is_mobius();
@@ -496,10 +500,35 @@ pub(crate) fn apply_terminal_presentation(
         };
     }
 
-    if let Ok(front_material) = plane_materials.single()
-        && let Some(mut material) = materials.get_mut(&front_material.0)
-    {
-        material.cull_mode = if is_mobius { None } else { Some(Face::Back) };
+    if let Ok(front_material) = plane_materials.single() {
+        let cull_mode = if is_mobius { None } else { Some(Face::Back) };
+        // `get_mut` marks the material modified and re-prepares it on the
+        // GPU; only take it when the cull mode actually changes.
+        let needs_update = materials
+            .get(&front_material.0)
+            .is_some_and(|material| material.cull_mode != cull_mode);
+        if needs_update && let Some(mut material) = materials.get_mut(&front_material.0) {
+            material.cull_mode = cull_mode;
+        }
+    }
+
+    // The 2D camera only contributes in flat mode; the 3D camera stays active
+    // everywhere because the cursor model and RGP objects render through it
+    // even in 2D mode. Whichever camera renders first owns the screen clear.
+    for mut camera in camera_2d.iter_mut() {
+        let active = !is_3d;
+        if camera.is_active != active {
+            camera.is_active = active;
+        }
+    }
+    // This system only runs when presentation state changes, so assigning
+    // unconditionally does not churn change detection every frame.
+    for mut camera in camera_3d.iter_mut() {
+        camera.clear_color = if is_3d {
+            ClearColorConfig::Default
+        } else {
+            ClearColorConfig::None
+        };
     }
 
     for mut transform in &mut plane_transforms.p0() {

--- a/src/scene/mod.rs
+++ b/src/scene/mod.rs
@@ -14,6 +14,7 @@ use bevy::prelude::*;
 use bevy::render::render_resource::{Extent3d, Face, TextureDimension, TextureFormat};
 
 use crate::config::AppConfig;
+use crate::direct_render::new_terminal_image;
 use crate::terminal::TerminalSurface;
 
 /// Marker for the 2D terminal sprite.
@@ -241,10 +242,11 @@ pub fn setup_scene(
     let pixmap_height = pixmap.y;
 
     let terminal_alpha = (terminal_opacity * 255.0).round() as u8;
-    let mut image = create_terminal_image(pixmap_width, pixmap_height, [0, 0, 0, 0]);
-    image.data = Some(vec![0; (pixmap_width * pixmap_height * 4) as usize]);
-
-    let image_handle = images.add(image);
+    let image_handle = images.add(new_terminal_image(
+        pixmap_width,
+        pixmap_height,
+        crate::config::TERMINAL_TEXTURE_LABEL,
+    ));
     terminal.image_handle = Some(image_handle.clone());
 
     let [r, g, b] = app_config.theme.background;
@@ -324,7 +326,7 @@ pub fn setup_scene(
         PointLight {
             intensity: 190_000.0,
             range: 2200.0,
-            shadows_enabled: false,
+            shadow_maps_enabled: false,
             ..default()
         },
         Transform::from_xyz(220.0, 320.0, 1000.0),
@@ -332,7 +334,7 @@ pub fn setup_scene(
     commands.spawn((
         DirectionalLight {
             illuminance: 15_000.0,
-            shadows_enabled: false,
+            shadow_maps_enabled: false,
             ..default()
         },
         Transform::from_rotation(Quat::from_euler(EulerRot::ZYX, 0.0, -0.9, -0.45)),
@@ -341,7 +343,7 @@ pub fn setup_scene(
         PointLight {
             intensity: 45_000.0,
             range: 1800.0,
-            shadows_enabled: false,
+            shadow_maps_enabled: false,
             ..default()
         },
         Transform::from_xyz(-280.0, -120.0, 700.0),
@@ -433,7 +435,7 @@ pub(crate) fn apply_terminal_presentation(
     }
 
     if let Ok(front_material) = plane_materials.single()
-        && let Some(material) = materials.get_mut(&front_material.0)
+        && let Some(mut material) = materials.get_mut(&front_material.0)
     {
         material.cull_mode = if is_mobius { None } else { Some(Face::Back) };
     }

--- a/src/scene/mod.rs
+++ b/src/scene/mod.rs
@@ -14,8 +14,11 @@ use bevy::prelude::*;
 use bevy::render::render_resource::{Extent3d, Face, TextureDimension, TextureFormat};
 use bevy::window::PrimaryWindow;
 
+use bevy::camera::visibility::NoFrustumCulling;
+
 use crate::config::AppConfig;
 use crate::direct_render::{new_terminal_image, new_terminal_render_image};
+use crate::present::{TerminalPresentMaterial, fullscreen_quad};
 use crate::runtime::TerminalRuntime;
 use crate::terminal::{
     TerminalLayout, TerminalSurface, render_scale_for_window, snapped_translation,
@@ -225,6 +228,7 @@ pub(crate) struct SetupSceneParams<'w, 's> {
     meshes: ResMut<'w, Assets<Mesh>>,
     materials: ResMut<'w, Assets<StandardMaterial>>,
     images: ResMut<'w, Assets<Image>>,
+    present_materials: ResMut<'w, Assets<TerminalPresentMaterial>>,
     primary_window: Query<'w, 's, &'static Window, With<PrimaryWindow>>,
     runtime: ResMut<'w, TerminalRuntime>,
     terminal: ResMut<'w, TerminalSurface>,
@@ -241,6 +245,7 @@ pub(crate) fn setup_scene(mut params: SetupSceneParams) {
         meshes,
         materials,
         images,
+        present_materials,
         primary_window,
         runtime,
         terminal,
@@ -318,13 +323,19 @@ pub(crate) fn setup_scene(mut params: SetupSceneParams) {
         center: viewport_center,
     });
 
-    let mut sprite = Sprite::from_image(image_handle);
-    sprite.custom_size = Some(layout.logical_size);
-    sprite.color = Color::srgba(1.0, 1.0, 1.0, terminal_opacity);
+    // Present the terminal texture 1:1 with physical pixels via a fullscreen quad
+    // whose shader fetches each texel by pixel coordinate (no resampling), rather
+    // than a world-positioned sprite whose interpolated UVs resample it. The
+    // `TerminalSprite` marker is kept so the flat/3D visibility toggle applies.
     commands.spawn((
         TerminalSprite,
-        sprite,
-        Transform::from_translation(snapped_translation(viewport_center, render_scale).extend(0.0)),
+        Mesh2d(meshes.add(fullscreen_quad())),
+        MeshMaterial2d(present_materials.add(TerminalPresentMaterial {
+            texture: image_handle,
+        })),
+        Transform::default(),
+        Visibility::Visible,
+        NoFrustumCulling,
     ));
 
     let front_mesh = meshes.add(terminal_plane_mesh(32, 20));

--- a/src/shaders/terminal_present.wgsl
+++ b/src/shaders/terminal_present.wgsl
@@ -1,0 +1,38 @@
+// Presents the terminal texture 1:1 with physical pixels.
+//
+// A fullscreen (clip-space) quad covers the viewport; each fragment samples the
+// terminal texture by its own physical pixel coordinate via `textureLoad`, so
+// every texel maps to exactly one screen pixel with no resampling — the crisp
+// presentation pattern from linebender/bevy_vello, specialized to a centered,
+// pixel-aligned sub-rect (the terminal grid does not always fill the window).
+#import bevy_render::view::View
+#import bevy_sprite::mesh2d_vertex_output::VertexOutput
+
+@group(0) @binding(0) var<uniform> view: View;
+@group(2) @binding(0) var terminal_texture: texture_2d<f32>;
+
+struct Vertex {
+    @location(0) position: vec3<f32>,
+};
+
+@vertex
+fn vertex(in: Vertex) -> VertexOutput {
+    var out: VertexOutput;
+    // `position` is already in clip space (the quad spans the whole viewport).
+    out.position = vec4<f32>(in.position, 1.0);
+    return out;
+}
+
+@fragment
+fn fragment(in: VertexOutput) -> @location(0) vec4<f32> {
+    let tex_size = vec2<f32>(textureDimensions(terminal_texture));
+    // Center the texture in the viewport, snapped to a whole physical pixel.
+    let origin = view.viewport.xy + floor((view.viewport.zw - tex_size) * 0.5);
+    let p = in.position.xy - origin;
+    if (p.x < 0.0 || p.y < 0.0 || p.x >= tex_size.x || p.y >= tex_size.y) {
+        // Outside the terminal: transparent, so the camera clear shows through.
+        return vec4<f32>(0.0, 0.0, 0.0, 0.0);
+    }
+    // Exact texel fetch (the texture's sRGB view decodes to linear on load).
+    return textureLoad(terminal_texture, vec2<i32>(p), 0);
+}

--- a/src/shaders/terminal_present.wgsl
+++ b/src/shaders/terminal_present.wgsl
@@ -26,8 +26,16 @@ fn vertex(in: Vertex) -> VertexOutput {
 @fragment
 fn fragment(in: VertexOutput) -> @location(0) vec4<f32> {
     let tex_size = vec2<f32>(textureDimensions(terminal_texture));
-    // Center the texture in the viewport, snapped to a whole physical pixel.
-    let origin = view.viewport.xy + floor((view.viewport.zw - tex_size) * 0.5);
+    // Normally center the texture in the viewport. But when it is taller than
+    // the viewport (only at the clamped 2-row minimum, when the window is too
+    // short to show both rows), anchor to the bottom edge instead so the last
+    // terminal row stays visible and the top row clips first. Snapped to a whole
+    // physical pixel.
+    let origin_x = view.viewport.x + floor((view.viewport.z - tex_size.x) * 0.5);
+    let centered_y = view.viewport.y + floor((view.viewport.w - tex_size.y) * 0.5);
+    let bottom_y = view.viewport.y + view.viewport.w - tex_size.y;
+    let origin_y = select(centered_y, bottom_y, tex_size.y > view.viewport.w);
+    let origin = vec2<f32>(origin_x, floor(origin_y));
     let p = in.position.xy - origin;
     if (p.x < 0.0 || p.y < 0.0 || p.x >= tex_size.x || p.y >= tex_size.y) {
         // Outside the terminal: transparent, so the camera clear shows through.

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -22,6 +22,7 @@ use std::collections::HashMap;
 use std::sync::mpsc::TryRecvError;
 
 use crate::config::{AppConfig, CURSOR_DEPTH};
+use crate::direct_render::DirectTerminalSceneExchange;
 use crate::inline::{
     InlineObject, TerminalInlineObjectPlane, TerminalInlineObjectSprite, TerminalInlineObjects,
     TerminalRgpObject,
@@ -38,6 +39,7 @@ use crate::scene::{
 };
 use crate::terminal::{TerminalRedrawState, TerminalSurface, TerminalWidget};
 use bevy::app::AppExit;
+use bevy::asset::AssetMut;
 use bevy::ecs::message::{MessageReader, MessageWriter};
 use bevy::ecs::system::SystemParam;
 use bevy::gltf::GltfAssetLabel;
@@ -233,6 +235,7 @@ pub(crate) struct ResizeParams<'w, 's> {
         Query<'w, 's, &'static mut Transform, (With<TerminalPlane>, Without<TerminalSprite>)>,
     plane_back_query: PlaneBackResizeQuery<'w, 's>,
     images: ResMut<'w, Assets<Image>>,
+    direct_render: Res<'w, DirectTerminalSceneExchange>,
 }
 
 /// Handles primary window resize events.
@@ -257,6 +260,7 @@ pub(crate) fn handle_window_resize(
         plane_query,
         plane_back_query,
         images,
+        direct_render,
     } = &mut params;
     let Ok(primary_window) = primary_window.single() else {
         return;
@@ -283,7 +287,7 @@ pub(crate) fn handle_window_resize(
 
     runtime.resize(cols, rows, viewport_size.x as u16, viewport_size.y as u16);
     terminal.resize(cols, rows);
-    let _ = terminal.sync_image(images, 0.0);
+    let _ = terminal.sync_image(images, direct_render, 0.0);
     redraw.request();
 
     for mut sprite in sprite_query.iter_mut() {
@@ -347,6 +351,7 @@ pub(crate) struct RedrawParams<'w, 's> {
     time: Res<'w, Time>,
     redraw: ResMut<'w, TerminalRedrawState>,
     images: ResMut<'w, Assets<Image>>,
+    direct_render: Res<'w, DirectTerminalSceneExchange>,
     model_load_state: ResMut<'w, ModelLoadState>,
     commands: Commands<'w, 's>,
     meshes: ResMut<'w, Assets<Mesh>>,
@@ -375,6 +380,7 @@ pub(crate) fn redraw_soft_terminal(mut params: RedrawParams) {
         time,
         redraw,
         images,
+        direct_render,
         model_load_state,
         commands,
         meshes,
@@ -410,7 +416,7 @@ pub(crate) fn redraw_soft_terminal(mut params: RedrawParams) {
         }
     });
 
-    let _ = terminal.sync_image(images, time.elapsed_secs());
+    let _ = terminal.sync_image(images, direct_render, time.elapsed_secs());
     if matches!(
         presentation.mode,
         TerminalPresentationMode::Plane3d | TerminalPresentationMode::Mobius3d
@@ -793,7 +799,7 @@ fn spawn_rgp_object(
                 TerminalRgpObject { object_id },
                 Transform::default(),
                 Visibility::Visible,
-                SceneRoot(handle),
+                WorldAssetRoot(handle),
             ));
         }
         crate::inline::RgpInlineObject::Stl { mesh, handle } => {
@@ -1273,14 +1279,14 @@ fn active_mobius_progress(
 }
 
 fn apply_plane_warp(
-    mesh: Option<&mut Mesh>,
+    mesh: Option<AssetMut<'_, Mesh>>,
     mode: TerminalPresentationMode,
     pulse: f32,
     elapsed_secs: f32,
     direction: f32,
     mobius_progress: f32,
 ) {
-    let Some(mesh) = mesh else {
+    let Some(mut mesh) = mesh else {
         return;
     };
     let Some(VertexAttributeValues::Float32x2(uvs)) = mesh.attribute(Mesh::ATTRIBUTE_UV_0) else {

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -264,6 +264,13 @@ pub(crate) fn handle_window_resize(
         return;
     };
 
+    // Minimizing the window reports a 0x0 size. Skip it so the terminal keeps
+    // its last good grid instead of collapsing to a degenerate size that the
+    // vt100 parser can't safely process.
+    if window_size.x < 1.0 || window_size.y < 1.0 {
+        return;
+    }
+
     let window_size = window_size.max(Vec2::ONE);
     let layout = terminal.resize_to_fit(window_size, render_scale_for_window(window));
     let pty_pixels = layout.pty_pixels();

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -8,7 +8,7 @@
 //! - [`handle_window_resize`]
 //! - [`crate::scene::apply_terminal_presentation`]
 //! - [`apply_inline_objects`]
-//! - [`redraw_soft_terminal`]
+//! - [`render_terminal_widget`]
 //! - [`sync_inline_objects`]
 //! - [`sync_rgp_objects`]
 //! - [`apply_instance_brightness`]
@@ -128,7 +128,7 @@ pub(crate) fn request_exit_on_primary_window_close(
 /// Shuts down the PTY runtime when Bevy begins exiting.
 pub(crate) fn shutdown_terminal_runtime_on_exit(
     mut app_exit: MessageReader<AppExit>,
-    mut runtime: NonSendMut<TerminalRuntime>,
+    mut runtime: ResMut<TerminalRuntime>,
     mut shutdown_started: Local<bool>,
 ) {
     if *shutdown_started {
@@ -144,14 +144,14 @@ pub(crate) fn shutdown_terminal_runtime_on_exit(
 
 /// Pumps PTY output into the terminal parser.
 ///
-/// This runs early in the update schedule, before [`redraw_soft_terminal`]. It drains PTY output
+/// This runs early in the update schedule, before [`render_terminal_widget`]. It drains PTY output
 /// from [`TerminalRuntime`], feeds it through [`TerminalInlineObjects::consume_pty_output`] and
 /// requests a redraw through [`TerminalRedrawState`] when terminal state changed.
 ///
 /// It also updates scroll-coupled inline anchors before the redraw and sync passes rebuild the
 /// scene.
 pub fn pump_pty_output(
-    mut runtime: NonSendMut<TerminalRuntime>,
+    mut runtime: ResMut<TerminalRuntime>,
     mut inline_objects: ResMut<TerminalInlineObjects>,
     mut app_exit: MessageWriter<AppExit>,
     mut redraw: ResMut<TerminalRedrawState>,
@@ -163,7 +163,7 @@ pub fn pump_pty_output(
 
     let mut processed_output = false;
     loop {
-        match runtime.rx.try_recv() {
+        match runtime.try_recv() {
             Ok(chunk) => {
                 let track_scroll = inline_objects.has_scroll_tracked_anchors();
                 let prev_rows: Option<Vec<String>> = if track_scroll {
@@ -219,8 +219,8 @@ fn infer_upward_scroll(prev_rows: &[String], next_rows: &[String]) -> u16 {
 #[derive(SystemParam)]
 pub(crate) struct ResizeParams<'w, 's> {
     primary_window: Query<'w, 's, (Entity, &'static Window), With<PrimaryWindow>>,
-    runtime: NonSendMut<'w, TerminalRuntime>,
-    terminal: NonSendMut<'w, TerminalSurface>,
+    runtime: ResMut<'w, TerminalRuntime>,
+    terminal: ResMut<'w, TerminalSurface>,
     redraw: ResMut<'w, TerminalRedrawState>,
     viewport: ResMut<'w, TerminalViewport>,
     sprite_query: TerminalSpriteLayoutQuery<'w, 's>,
@@ -281,7 +281,7 @@ pub(crate) fn handle_window_resize(
         plane_query,
         plane_back_query,
     );
-    redraw.request_immediate();
+    redraw.request();
 }
 
 /// Applies inline object visibility for the current presentation mode.
@@ -322,37 +322,38 @@ pub fn apply_inline_objects(
 }
 
 /// Redraw system parameters.
+/// Tracks whether the terminal frame was redrawn during the current update.
+#[derive(Resource, Default)]
+pub(crate) struct TerminalFrameDirty(pub bool);
+
+/// Ordered terminal redraw pipeline:
+/// [`render_terminal_widget`] → [`sync_terminal_materials`] →
+/// [`finish_terminal_model_load`].
+#[derive(SystemSet, Debug, Clone, PartialEq, Eq, Hash)]
+pub(crate) struct TerminalRedrawSet;
+
 #[derive(SystemParam)]
-pub(crate) struct RedrawParams<'w, 's> {
+pub(crate) struct RenderWidgetParams<'w> {
     app_config: Res<'w, AppConfig>,
-    runtime: NonSend<'w, TerminalRuntime>,
-    terminal: NonSendMut<'w, TerminalSurface>,
+    runtime: Res<'w, TerminalRuntime>,
+    terminal: ResMut<'w, TerminalSurface>,
     selection: Res<'w, TerminalSelection>,
     presentation: Res<'w, TerminalPresentation>,
     time: Res<'w, Time>,
     redraw: ResMut<'w, TerminalRedrawState>,
     images: ResMut<'w, Assets<Image>>,
     direct_render: Res<'w, DirectTerminalSceneExchange>,
-    model_load_state: ResMut<'w, ModelLoadState>,
-    commands: Commands<'w, 's>,
-    meshes: ResMut<'w, Assets<Mesh>>,
-    materials: ResMut<'w, Assets<StandardMaterial>>,
-    plane_materials: Query<'w, 's, &'static MeshMaterial3d<StandardMaterial>, With<TerminalPlane>>,
-    plane_back_materials:
-        Query<'w, 's, &'static MeshMaterial3d<StandardMaterial>, With<TerminalPlaneBack>>,
-    asset_server: Res<'w, AssetServer>,
+    model_load_state: Res<'w, ModelLoadState>,
+    frame_dirty: ResMut<'w, TerminalFrameDirty>,
 }
 
-/// Redraws the terminal surface.
+/// Redraws the Ratatui buffer and publishes the rendered terminal frame.
 ///
-/// This runs after [`pump_pty_output`] and [`crate::mouse::handle_mouse_input`]. It redraws the
-/// Ratatui buffer into [`TerminalSurface`], uploads the rendered image, refreshes the debug back
-/// texture and synchronizes the front and back plane materials to the latest terminal images.
-///
-/// On the first successful upload it defers cursor-model spawning to the next frame. After that,
-/// it ensures the cursor model exists so [`sync_asset_to_terminal_cursor`] can position it.
-pub(crate) fn redraw_soft_terminal(mut params: RedrawParams) {
-    let RedrawParams {
+/// This runs after [`pump_pty_output`] and [`crate::mouse::handle_mouse_input`]. It records
+/// whether the frame changed in [`TerminalFrameDirty`] so the rest of [`TerminalRedrawSet`]
+/// can skip its work on clean frames.
+pub(crate) fn render_terminal_widget(mut params: RenderWidgetParams) {
+    let RenderWidgetParams {
         app_config,
         runtime,
         terminal,
@@ -363,19 +364,15 @@ pub(crate) fn redraw_soft_terminal(mut params: RedrawParams) {
         images,
         direct_render,
         model_load_state,
-        commands,
-        meshes,
-        materials,
-        plane_materials,
-        plane_back_materials,
-        asset_server,
+        frame_dirty,
     } = &mut params;
     let needs_redraw = redraw.take();
     let force_live_redraw = matches!(
         presentation.mode,
         TerminalPresentationMode::Plane3d | TerminalPresentationMode::Mobius3d
     ) && !app_config.cursor.model.visible;
-    if !needs_redraw && !force_live_redraw && model_load_state.loaded {
+    frame_dirty.0 = needs_redraw || force_live_redraw || !model_load_state.loaded;
+    if !frame_dirty.0 {
         return;
     }
 
@@ -398,23 +395,84 @@ pub(crate) fn redraw_soft_terminal(mut params: RedrawParams) {
     });
 
     let _ = terminal.sync_image(images, direct_render, time.elapsed_secs());
-    if matches!(
+}
+
+#[derive(SystemParam)]
+pub(crate) struct SyncMaterialsParams<'w, 's> {
+    runtime: Res<'w, TerminalRuntime>,
+    terminal: Res<'w, TerminalSurface>,
+    presentation: Res<'w, TerminalPresentation>,
+    images: ResMut<'w, Assets<Image>>,
+    materials: ResMut<'w, Assets<StandardMaterial>>,
+    plane_materials: Query<'w, 's, &'static MeshMaterial3d<StandardMaterial>, With<TerminalPlane>>,
+    plane_back_materials:
+        Query<'w, 's, &'static MeshMaterial3d<StandardMaterial>, With<TerminalPlaneBack>>,
+    frame_dirty: Res<'w, TerminalFrameDirty>,
+}
+
+/// Refreshes the debug back texture and plane materials after a redraw.
+pub(crate) fn sync_terminal_materials(mut params: SyncMaterialsParams) {
+    let SyncMaterialsParams {
+        runtime,
+        terminal,
+        presentation,
+        images,
+        materials,
+        plane_materials,
+        plane_back_materials,
+        frame_dirty,
+    } = &mut params;
+    if !frame_dirty.0 {
+        return;
+    }
+
+    let in_3d = matches!(
         presentation.mode,
         TerminalPresentationMode::Plane3d | TerminalPresentationMode::Mobius3d
-    ) {
-        sync_terminal_debug_image(terminal, images, screen);
+    );
+    if in_3d {
+        sync_terminal_debug_image(terminal, images, runtime.parser.screen());
     }
 
     sync_plane_texture(terminal.image_handle.as_ref(), plane_materials, materials);
-    if matches!(
-        presentation.mode,
-        TerminalPresentationMode::Plane3d | TerminalPresentationMode::Mobius3d
-    ) {
+    if in_3d {
         sync_plane_texture(
             terminal.back_image_handle.as_ref(),
             plane_back_materials,
             materials,
         );
+    }
+}
+
+#[derive(SystemParam)]
+pub(crate) struct ModelLoadParams<'w, 's> {
+    app_config: Res<'w, AppConfig>,
+    model_load_state: ResMut<'w, ModelLoadState>,
+    redraw: ResMut<'w, TerminalRedrawState>,
+    commands: Commands<'w, 's>,
+    meshes: ResMut<'w, Assets<Mesh>>,
+    materials: ResMut<'w, Assets<StandardMaterial>>,
+    asset_server: Res<'w, AssetServer>,
+    frame_dirty: Res<'w, TerminalFrameDirty>,
+}
+
+/// Completes deferred cursor-model loading once the first frame is uploaded.
+///
+/// The first successful upload defers cursor-model spawning to the next frame. After that, it
+/// ensures the cursor model exists so [`sync_asset_to_terminal_cursor`] can position it.
+pub(crate) fn finish_terminal_model_load(mut params: ModelLoadParams) {
+    let ModelLoadParams {
+        app_config,
+        model_load_state,
+        redraw,
+        commands,
+        meshes,
+        materials,
+        asset_server,
+        frame_dirty,
+    } = &mut params;
+    if !frame_dirty.0 {
+        return;
     }
 
     if !model_load_state.first_frame_uploaded {
@@ -436,7 +494,7 @@ pub(crate) fn redraw_soft_terminal(mut params: RedrawParams) {
 pub(crate) struct SyncInlineParams<'w, 's> {
     commands: Commands<'w, 's>,
     inline_objects: ResMut<'w, TerminalInlineObjects>,
-    terminal: NonSend<'w, TerminalSurface>,
+    terminal: Res<'w, TerminalSurface>,
     viewport: Res<'w, TerminalViewport>,
     presentation: Res<'w, TerminalPresentation>,
     plane_warp: Res<'w, TerminalPlaneWarp>,
@@ -453,7 +511,7 @@ pub(crate) struct SyncInlineParams<'w, 's> {
 
 /// Synchronizes Kitty inline object entities.
 ///
-/// This runs after [`redraw_soft_terminal`]. It rebuilds the scene entities for registered
+/// This runs after [`render_terminal_widget`]. It rebuilds the scene entities for registered
 /// [`InlineObject::KittyImage`] values and clears stale inline entities first so the scene matches
 /// the latest terminal anchors exactly.
 ///
@@ -830,7 +888,7 @@ fn spawn_rgp_object(
 #[derive(SystemParam)]
 pub(crate) struct RgpSyncParams<'w, 's> {
     app_config: Res<'w, AppConfig>,
-    terminal: NonSend<'w, TerminalSurface>,
+    terminal: Res<'w, TerminalSurface>,
     viewport: Res<'w, TerminalViewport>,
     presentation: Res<'w, TerminalPresentation>,
     mobius_transition: Res<'w, MobiusTransition>,
@@ -1297,8 +1355,8 @@ fn apply_plane_warp(
 #[derive(SystemParam)]
 pub(crate) struct CursorSyncParams<'w, 's> {
     app_config: Res<'w, AppConfig>,
-    runtime: NonSend<'w, TerminalRuntime>,
-    terminal: NonSend<'w, TerminalSurface>,
+    runtime: Res<'w, TerminalRuntime>,
+    terminal: Res<'w, TerminalSurface>,
     viewport: Res<'w, TerminalViewport>,
     presentation: Res<'w, TerminalPresentation>,
     mobius_transition: Res<'w, MobiusTransition>,
@@ -1310,7 +1368,7 @@ pub(crate) struct CursorSyncParams<'w, 's> {
 
 /// Synchronizes the 3D cursor model with the terminal cursor.
 ///
-/// This runs after [`redraw_soft_terminal`], once the cursor model has been spawned and the latest
+/// This runs after [`render_terminal_widget`], once the cursor model has been spawned and the latest
 /// terminal cursor position is available from [`TerminalRuntime`]. It updates the [`CursorModel`]
 /// transform and visibility for both 2D and 3D presentation modes.
 ///

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -36,8 +36,8 @@ use crate::runtime::TerminalRuntime;
 use crate::scene::{
     MobiusTransition, ModelLoadState, TerminalPlane, TerminalPlaneBack,
     TerminalPlaneBackLayoutQuery, TerminalPlaneLayoutQuery, TerminalPlaneMeshes, TerminalPlaneView,
-    TerminalPlaneWarp, TerminalPresentation, TerminalPresentationMode, TerminalSpriteLayoutQuery,
-    TerminalViewport, sync_terminal_layout,
+    TerminalPlaneWarp, TerminalPresentation, TerminalPresentationMode, TerminalViewport,
+    sync_terminal_layout,
 };
 use crate::terminal::{
     TerminalRedrawState, TerminalSurface, TerminalWidget, render_scale_for_window,
@@ -224,7 +224,6 @@ pub(crate) struct ResizeParams<'w, 's> {
     terminal: ResMut<'w, TerminalSurface>,
     redraw: ResMut<'w, TerminalRedrawState>,
     viewport: ResMut<'w, TerminalViewport>,
-    sprite_query: TerminalSpriteLayoutQuery<'w, 's>,
     plane_query: TerminalPlaneLayoutQuery<'w, 's>,
     plane_back_query: TerminalPlaneBackLayoutQuery<'w, 's>,
 }
@@ -247,7 +246,6 @@ pub(crate) fn handle_window_resize(
         terminal,
         redraw,
         viewport,
-        sprite_query,
         plane_query,
         plane_back_query,
     } = &mut params;
@@ -275,13 +273,7 @@ pub(crate) fn handle_window_resize(
         pty_pixels.x as u16,
         pty_pixels.y as u16,
     );
-    sync_terminal_layout(
-        layout,
-        viewport,
-        sprite_query,
-        plane_query,
-        plane_back_query,
-    );
+    sync_terminal_layout(layout, viewport, plane_query, plane_back_query);
     redraw.request();
 }
 

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -33,11 +33,14 @@ use crate::mouse::TerminalSelection;
 use crate::rendering::{sync_plane_texture, sync_terminal_debug_image};
 use crate::runtime::TerminalRuntime;
 use crate::scene::{
-    MobiusTransition, ModelLoadState, TerminalPlane, TerminalPlaneBack, TerminalPlaneMeshes,
-    TerminalPlaneView, TerminalPlaneWarp, TerminalPresentation, TerminalPresentationMode,
-    TerminalSprite, TerminalViewport,
+    MobiusTransition, ModelLoadState, TerminalPlane, TerminalPlaneBack,
+    TerminalPlaneBackLayoutQuery, TerminalPlaneLayoutQuery, TerminalPlaneMeshes, TerminalPlaneView,
+    TerminalPlaneWarp, TerminalPresentation, TerminalPresentationMode, TerminalSpriteLayoutQuery,
+    TerminalViewport, sync_terminal_layout,
 };
-use crate::terminal::{TerminalRedrawState, TerminalSurface, TerminalWidget};
+use crate::terminal::{
+    TerminalRedrawState, TerminalSurface, TerminalWidget, render_scale_for_window,
+};
 use bevy::app::AppExit;
 use bevy::asset::AssetMut;
 use bevy::ecs::message::{MessageReader, MessageWriter};
@@ -48,7 +51,7 @@ use bevy::mesh::{Indices, VertexAttributeValues};
 use bevy::prelude::*;
 use bevy::render::render_resource::PrimitiveTopology;
 use bevy::render::render_resource::{Extent3d, TextureDimension, TextureFormat};
-use bevy::window::{PrimaryWindow, WindowCloseRequested, WindowResized};
+use bevy::window::{PrimaryWindow, Window, WindowCloseRequested, WindowResized};
 
 struct InlineLayout {
     columns: u32,
@@ -95,16 +98,6 @@ type CursorTransformQuery<'w, 's> = Query<
     's,
     (&'static mut Transform, &'static mut Visibility),
     (With<CursorModel>, Without<TerminalPlane>),
->;
-type PlaneBackResizeQuery<'w, 's> = Query<
-    'w,
-    's,
-    &'static mut Transform,
-    (
-        With<TerminalPlaneBack>,
-        Without<TerminalPlane>,
-        Without<TerminalSprite>,
-    ),
 >;
 
 /// Requests application exit as soon as the primary window is asked to close.
@@ -225,17 +218,14 @@ fn infer_upward_scroll(prev_rows: &[String], next_rows: &[String]) -> u16 {
 
 #[derive(SystemParam)]
 pub(crate) struct ResizeParams<'w, 's> {
-    primary_window: Query<'w, 's, Entity, With<PrimaryWindow>>,
+    primary_window: Query<'w, 's, (Entity, &'static Window), With<PrimaryWindow>>,
     runtime: NonSendMut<'w, TerminalRuntime>,
     terminal: NonSendMut<'w, TerminalSurface>,
     redraw: ResMut<'w, TerminalRedrawState>,
     viewport: ResMut<'w, TerminalViewport>,
-    sprite_query: Query<'w, 's, &'static mut Sprite, With<TerminalSprite>>,
-    plane_query:
-        Query<'w, 's, &'static mut Transform, (With<TerminalPlane>, Without<TerminalSprite>)>,
-    plane_back_query: PlaneBackResizeQuery<'w, 's>,
-    images: ResMut<'w, Assets<Image>>,
-    direct_render: Res<'w, DirectTerminalSceneExchange>,
+    sprite_query: TerminalSpriteLayoutQuery<'w, 's>,
+    plane_query: TerminalPlaneLayoutQuery<'w, 's>,
+    plane_back_query: TerminalPlaneBackLayoutQuery<'w, 's>,
 }
 
 /// Handles primary window resize events.
@@ -244,8 +234,8 @@ pub(crate) struct ResizeParams<'w, 's> {
 /// [`TerminalRuntime`], [`TerminalSurface`], [`TerminalViewport`], the 2D terminal sprite and the
 /// front and back terminal plane transforms.
 ///
-/// The updated terminal image is uploaded immediately so later systems in the same frame see the
-/// new geometry.
+/// The redraw system runs after this system and uploads the resized terminal image in the same
+/// frame.
 pub(crate) fn handle_window_resize(
     mut resize_events: MessageReader<WindowResized>,
     mut params: ResizeParams,
@@ -259,10 +249,8 @@ pub(crate) fn handle_window_resize(
         sprite_query,
         plane_query,
         plane_back_query,
-        images,
-        direct_render,
     } = &mut params;
-    let Ok(primary_window) = primary_window.single() else {
+    let Ok((primary_window, window)) = primary_window.single() else {
         return;
     };
 
@@ -277,30 +265,23 @@ pub(crate) fn handle_window_resize(
         return;
     };
 
-    let viewport_size = Vec2::new(window_size.x.max(1.0), window_size.y.max(1.0));
-    viewport.size = viewport_size;
-    viewport.center = Vec2::ZERO;
-
-    let char_dims = terminal.char_dimensions().max(UVec2::ONE);
-    let cols = ((viewport_size.x / char_dims.x as f32).floor() as u16).max(1);
-    let rows = ((viewport_size.y / char_dims.y as f32).floor() as u16).max(1);
-
-    runtime.resize(cols, rows, viewport_size.x as u16, viewport_size.y as u16);
-    terminal.resize(cols, rows);
-    let _ = terminal.sync_image(images, direct_render, 0.0);
-    redraw.request();
-
-    for mut sprite in sprite_query.iter_mut() {
-        sprite.custom_size = Some(viewport_size);
-    }
-
-    for mut transform in plane_query.iter_mut() {
-        transform.scale = viewport_size.extend(1.0);
-    }
-
-    for mut transform in plane_back_query.iter_mut() {
-        transform.scale = viewport_size.extend(1.0);
-    }
+    let window_size = window_size.max(Vec2::ONE);
+    let layout = terminal.resize_to_fit(window_size, render_scale_for_window(window));
+    let pty_pixels = layout.pty_pixels();
+    runtime.resize(
+        layout.cols,
+        layout.rows,
+        pty_pixels.x as u16,
+        pty_pixels.y as u16,
+    );
+    sync_terminal_layout(
+        layout,
+        viewport,
+        sprite_query,
+        plane_query,
+        plane_back_query,
+    );
+    redraw.request_immediate();
 }
 
 /// Applies inline object visibility for the current presentation mode.

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -332,19 +332,23 @@ pub(crate) struct TerminalFrameDirty(pub bool);
 #[derive(SystemSet, Debug, Clone, PartialEq, Eq, Hash)]
 pub(crate) struct TerminalRedrawSet;
 
+/// Half-period of the fastest blink cadence the renderer supports (rapid
+/// blink); slow blink (0.5s) is a multiple of it.
+const BLINK_TICK_SECS: f32 = 0.25;
+
 #[derive(SystemParam)]
-pub(crate) struct RenderWidgetParams<'w> {
+pub(crate) struct RenderWidgetParams<'w, 's> {
     app_config: Res<'w, AppConfig>,
     runtime: Res<'w, TerminalRuntime>,
     terminal: ResMut<'w, TerminalSurface>,
     selection: Res<'w, TerminalSelection>,
-    presentation: Res<'w, TerminalPresentation>,
     time: Res<'w, Time>,
     redraw: ResMut<'w, TerminalRedrawState>,
     images: ResMut<'w, Assets<Image>>,
     direct_render: Res<'w, DirectTerminalSceneExchange>,
     model_load_state: Res<'w, ModelLoadState>,
     frame_dirty: ResMut<'w, TerminalFrameDirty>,
+    blink_phase: Local<'s, u64>,
 }
 
 /// Redraws the Ratatui buffer and publishes the rendered terminal frame.
@@ -358,20 +362,22 @@ pub(crate) fn render_terminal_widget(mut params: RenderWidgetParams) {
         runtime,
         terminal,
         selection,
-        presentation,
         time,
         redraw,
         images,
         direct_render,
         model_load_state,
         frame_dirty,
+        blink_phase,
     } = &mut params;
     let needs_redraw = redraw.take();
-    let force_live_redraw = matches!(
-        presentation.mode,
-        TerminalPresentationMode::Plane3d | TerminalPresentationMode::Mobius3d
-    ) && !app_config.cursor.model.visible;
-    frame_dirty.0 = needs_redraw || force_live_redraw || !model_load_state.loaded;
+    // The texture content only changes with terminal state or blink phase;
+    // warp and camera animations are mesh- and camera-side. Rebuilding on
+    // blink ticks instead of every frame keeps idle scene builds at 4Hz.
+    let phase = (time.elapsed_secs() / BLINK_TICK_SECS) as u64;
+    let blink_ticked = **blink_phase != phase;
+    **blink_phase = phase;
+    frame_dirty.0 = needs_redraw || blink_ticked || !model_load_state.loaded;
     if !frame_dirty.0 {
         return;
     }

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -30,6 +30,7 @@ use crate::inline::{
 use crate::model::CursorModel;
 use crate::model::spawn_cursor_model;
 use crate::mouse::TerminalSelection;
+use crate::present::TerminalPresentMaterial;
 use crate::rendering::{sync_plane_texture, sync_terminal_debug_image};
 use crate::runtime::TerminalRuntime;
 use crate::scene::{
@@ -413,6 +414,8 @@ pub(crate) struct SyncMaterialsParams<'w, 's> {
     plane_materials: Query<'w, 's, &'static MeshMaterial3d<StandardMaterial>, With<TerminalPlane>>,
     plane_back_materials:
         Query<'w, 's, &'static MeshMaterial3d<StandardMaterial>, With<TerminalPlaneBack>>,
+    present_materials: ResMut<'w, Assets<TerminalPresentMaterial>>,
+    present_query: Query<'w, 's, &'static MeshMaterial2d<TerminalPresentMaterial>>,
     frame_dirty: Res<'w, TerminalFrameDirty>,
 }
 
@@ -426,10 +429,26 @@ pub(crate) fn sync_terminal_materials(mut params: SyncMaterialsParams) {
         materials,
         plane_materials,
         plane_back_materials,
+        present_materials,
+        present_query,
         frame_dirty,
     } = &mut params;
     if !frame_dirty.0 {
         return;
+    }
+
+    // The present texture's GpuImage is recreated when the terminal resizes (window
+    // resize / font zoom), which invalidates the 2D present material's cached bind
+    // group. Writing the texture handle — not merely touching the asset with
+    // `get_mut` — advances the material's change tick so Bevy re-prepares the bind
+    // group against the current GpuImage; a no-op touch leaves the quad sampling a
+    // stale texture and the flat view freezes. Matches the plane handling.
+    if let Some(present_image) = terminal.image_handle.as_ref() {
+        for present_handle in present_query.iter() {
+            if let Some(mut material) = present_materials.get_mut(&present_handle.0) {
+                material.texture = present_image.clone();
+            }
+        }
     }
 
     let in_3d = matches!(

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -1,7 +1,5 @@
 //! Terminal surface rendering and Ratatui integration.
 
-use std::time::{Duration, Instant};
-
 use bevy::prelude::*;
 use parley_ratatui::ratatui::Terminal;
 use parley_ratatui::ratatui::buffer::Buffer;
@@ -18,9 +16,6 @@ use crate::direct_render::{
     DirectTerminalSceneExchange, resize_terminal_image, update_direct_terminal_frame,
 };
 use crate::mouse::TerminalSelection;
-
-/// Minimum interval between terminal redraws.
-const REDRAW_THROTTLE: Duration = Duration::from_millis(16);
 
 /// Terminal grid and presentation dimensions.
 #[derive(Clone, Copy, Debug)]
@@ -58,15 +53,11 @@ impl TerminalLayout {
 #[derive(Resource)]
 pub struct TerminalRedrawState {
     needs_redraw: bool,
-    last_redraw: Instant,
 }
 
 impl Default for TerminalRedrawState {
     fn default() -> Self {
-        Self {
-            needs_redraw: true,
-            last_redraw: Instant::now() - REDRAW_THROTTLE,
-        }
+        Self { needs_redraw: true }
     }
 }
 
@@ -76,24 +67,14 @@ impl TerminalRedrawState {
         self.needs_redraw = true;
     }
 
-    /// Requests a redraw without waiting for the throttle interval.
-    pub fn request_immediate(&mut self) {
-        self.needs_redraw = true;
-        self.last_redraw = Instant::now() - REDRAW_THROTTLE;
-    }
-
     /// Returns whether a redraw was pending.
     pub fn take(&mut self) -> bool {
-        if !self.needs_redraw || self.last_redraw.elapsed() < REDRAW_THROTTLE {
-            return false;
-        }
-        self.needs_redraw = false;
-        self.last_redraw = Instant::now();
-        true
+        std::mem::take(&mut self.needs_redraw)
     }
 }
 
 /// Terminal surface and render state.
+#[derive(Resource)]
 pub struct TerminalSurface {
     /// Ratatui terminal backend.
     pub tui: Terminal<ParleyBackend>,

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -9,8 +9,8 @@ use parley_ratatui::ratatui::layout::Rect;
 use parley_ratatui::ratatui::style::{Color as TuiColor, Modifier, Style};
 use parley_ratatui::ratatui::widgets::Widget;
 use parley_ratatui::{
-    FontOptions, ParleyBackend, PresentationScale, TerminalRenderer, TexturePresentation,
-    snap_logical_position_to_physical_pixel,
+    CellQuantization, FontOptions, ParleyBackend, PresentationScale, TerminalRenderer,
+    TexturePresentation, snap_logical_position_to_physical_pixel,
 };
 
 use crate::config::{AppConfig, FontConfig, FontStyleConfig, ThemeConfig};
@@ -130,7 +130,9 @@ impl TerminalSurface {
         } else {
             tui.show_cursor()?;
         }
-        let render_scale = config.window.scale_factor.max(1.0);
+        // The real scale arrives with the first `resize_to_fit` once the
+        // window exists; an explicit override seeds it early.
+        let render_scale = config.window.scale_factor.unwrap_or(1.0).max(1.0);
         let renderer = build_terminal_renderer(
             &config.font,
             &config.theme,
@@ -219,13 +221,10 @@ impl TerminalSurface {
         self.rows = rows;
     }
 
-    /// Returns the rendered cell size in pixels.
-    pub fn char_dimensions(&self) -> UVec2 {
+    /// Returns the rendered cell size in logical pixels.
+    pub fn char_dimensions(&self) -> Vec2 {
         let metrics = self.renderer.logical_metrics(self.render_scale);
-        UVec2::new(
-            metrics.cell_width.ceil().max(1.0) as u32,
-            metrics.cell_height.ceil().max(1.0) as u32,
-        )
+        Vec2::new(metrics.cell_width.max(1.0), metrics.cell_height.max(1.0))
     }
 
     /// Returns the terminal pixmap dimensions in pixels.
@@ -358,10 +357,16 @@ fn build_terminal_renderer(
         ),
         palette,
     };
-    let font_options = FontOptions::default().with_family(font.family.clone());
+    // Config font sizes are points; Parley takes pixels (1pt = 4/3px at 96dpi).
+    const PT_TO_PX: f32 = 96.0 / 72.0;
+    let font_options = FontOptions::default()
+        .with_family(font.family.clone())
+        // Fractional cells keep font-size zoom proportional on both axes even
+        // when a single step moves the glyph advance by less than one pixel.
+        .with_cell_quantization(CellQuantization::Fractional);
     TerminalRenderer::new_scaled(
         FontOptions {
-            size: font.size as f32,
+            size: font.size as f32 * PT_TO_PX,
             ..font_options
         },
         theme,
@@ -483,6 +488,44 @@ fn ansi_index_to_tui(index: u8, theme_palette: &[TuiColor; 16]) -> TuiColor {
         232..=255 => {
             let shade = 8 + (index - 232) * 10;
             TuiColor::Rgb(shade, shade, shade)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Regression test for vertical-only zoom steps (#97): with fractional
+    /// cell quantization, every font-size step must grow both axes.
+    #[test]
+    fn font_size_steps_scale_cells_on_both_axes() {
+        for render_scale in [1.0, 2.0] {
+            let mut previous: Option<(f32, f32)> = None;
+            for size in 8..=24 {
+                let font = FontConfig {
+                    size,
+                    ..FontConfig::default()
+                };
+                let renderer =
+                    build_terminal_renderer(&font, &ThemeConfig::default(), 1.0, render_scale);
+                let metrics = renderer.logical_metrics(render_scale);
+                if let Some((width, height)) = previous {
+                    assert!(
+                        metrics.cell_width > width,
+                        "cell width must grow at size {size} (scale {render_scale}): \
+                         {width} -> {}",
+                        metrics.cell_width
+                    );
+                    assert!(
+                        metrics.cell_height > height,
+                        "cell height must grow at size {size} (scale {render_scale}): \
+                         {height} -> {}",
+                        metrics.cell_height
+                    );
+                }
+                previous = Some((metrics.cell_width, metrics.cell_height));
+            }
         }
     }
 }

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -8,12 +8,12 @@ use parley_ratatui::ratatui::buffer::Buffer;
 use parley_ratatui::ratatui::layout::Rect;
 use parley_ratatui::ratatui::style::{Color as TuiColor, Modifier, Style};
 use parley_ratatui::ratatui::widgets::Widget;
-use parley_ratatui::vello::wgpu;
-use parley_ratatui::{
-    FontOptions, GpuRenderer, ParleyBackend, TerminalRenderer, TextureReadback, TextureTarget,
-};
+use parley_ratatui::{FontOptions, ParleyBackend, TerminalRenderer};
 
-use crate::config::{AppConfig, FontConfig, FontStyleConfig, TERMINAL_TEXTURE_LABEL, ThemeConfig};
+use crate::config::{AppConfig, FontConfig, FontStyleConfig, ThemeConfig};
+use crate::direct_render::{
+    DirectTerminalSceneExchange, resize_terminal_image, update_direct_terminal_frame,
+};
 use crate::mouse::TerminalSelection;
 
 /// Minimum interval between terminal redraws.
@@ -69,59 +69,6 @@ pub struct TerminalSurface {
     font: FontConfig,
     theme: ThemeConfig,
     renderer: TerminalRenderer,
-    gpu: Option<OffscreenGpu>,
-}
-
-struct OffscreenGpu {
-    device: wgpu::Device,
-    queue: wgpu::Queue,
-    renderer: GpuRenderer,
-    target: TextureTarget,
-    readback: TextureReadback,
-    rgba: Vec<u8>,
-}
-
-impl OffscreenGpu {
-    async fn new(width: u32, height: u32) -> anyhow::Result<Self> {
-        let instance = wgpu::Instance::default();
-        let adapter = instance
-            .request_adapter(&wgpu::RequestAdapterOptions::default())
-            .await
-            .map_err(|_| anyhow::anyhow!("failed to request wgpu adapter for parley_ratatui"))?;
-        let (device, queue) = adapter
-            .request_device(&wgpu::DeviceDescriptor::default())
-            .await?;
-        let target = TextureTarget::new(
-            &device,
-            width,
-            height,
-            wgpu::TextureFormat::Rgba8Unorm,
-            Some(TERMINAL_TEXTURE_LABEL),
-        );
-        let renderer = GpuRenderer::new(&device)?;
-        Ok(Self {
-            device,
-            queue,
-            renderer,
-            target,
-            readback: TextureReadback::new(),
-            rgba: Vec::new(),
-        })
-    }
-
-    fn resize(&mut self, width: u32, height: u32) {
-        if self.target.width == width && self.target.height == height {
-            return;
-        }
-
-        self.target = TextureTarget::new(
-            &self.device,
-            width,
-            height,
-            self.target.format,
-            Some(TERMINAL_TEXTURE_LABEL),
-        );
-    }
 }
 
 impl TerminalSurface {
@@ -154,7 +101,6 @@ impl TerminalSurface {
             font: config.font.clone(),
             theme: config.theme.clone(),
             renderer,
-            gpu: None,
         })
     }
 
@@ -167,12 +113,6 @@ impl TerminalSurface {
 
         self.font.size = new_size;
         self.renderer = build_terminal_renderer(&self.font, &self.theme, self.window_opacity);
-        if let Some(gpu) = self.gpu.as_mut() {
-            let (width, height) = self
-                .renderer
-                .texture_size_for_buffer(self.tui.backend().buffer());
-            gpu.resize(width, height);
-        }
         true
     }
 
@@ -196,13 +136,6 @@ impl TerminalSurface {
         }
         self.cols = cols;
         self.rows = rows;
-
-        if let Some(gpu) = self.gpu.as_mut() {
-            let (width, height) = self
-                .renderer
-                .texture_size_for_buffer(self.tui.backend().buffer());
-            gpu.resize(width, height);
-        }
     }
 
     /// Returns the rendered cell size in pixels.
@@ -227,59 +160,36 @@ impl TerminalSurface {
     /// # Errors
     ///
     /// Returns an error if the offscreen renderer cannot be initialized or rendered.
-    pub fn sync_image(
+    pub(crate) fn sync_image(
         &mut self,
         images: &mut Assets<Image>,
+        exchange: &DirectTerminalSceneExchange,
         elapsed_secs: f32,
     ) -> anyhow::Result<()> {
         let Some(handle) = self.image_handle.as_ref() else {
             return Ok(());
         };
-        let Some(image) = images.get_mut(handle) else {
+        let Some(mut image) = images.get_mut(handle) else {
             return Ok(());
         };
 
         let (width, height) = self
             .renderer
             .texture_size_for_buffer(self.tui.backend().buffer());
-        if self.gpu.is_none() {
-            self.gpu = Some(pollster::block_on(OffscreenGpu::new(width, height))?);
-        }
-        let Some(gpu) = self.gpu.as_mut() else {
-            anyhow::bail!("offscreen GPU renderer should be initialized");
-        };
-        gpu.resize(width, height);
+        resize_terminal_image(&mut image, width, height);
 
         let buffer = self.tui.backend().buffer();
         let cursor = Some(self.tui.backend().cursor_position());
         let cursor_visible = self.tui.backend().cursor_visible();
-
-        gpu.renderer.render_to_rgba8_with_elapsed_into(
+        update_direct_terminal_frame(
+            exchange,
+            handle.clone(),
             &mut self.renderer,
-            &mut gpu.readback,
-            &gpu.device,
-            &gpu.queue,
-            &gpu.target,
             buffer,
             cursor,
             cursor_visible,
             elapsed_secs,
-            &mut gpu.rgba,
-        )?;
-
-        image.resize(bevy::render::render_resource::Extent3d {
-            width,
-            height,
-            depth_or_array_layers: 1,
-        });
-        let data = image.data.get_or_insert_with(Vec::new);
-        let target_len = width as usize * height as usize * 4;
-        if data.len() != target_len {
-            data.resize(target_len, 0);
-        }
-        if gpu.rgba.len() == target_len {
-            data.copy_from_slice(&gpu.rgba);
-        }
+        );
 
         Ok(())
     }

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -13,7 +13,8 @@ use parley_ratatui::{
 
 use crate::config::{AppConfig, FontConfig, FontStyleConfig, ThemeConfig};
 use crate::direct_render::{
-    DirectTerminalSceneExchange, TerminalImages, resize_terminal_image, update_direct_terminal_frame,
+    DirectTerminalSceneExchange, TerminalImages, resize_terminal_image,
+    update_direct_terminal_frame,
 };
 use crate::mouse::TerminalSelection;
 

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -13,7 +13,7 @@ use parley_ratatui::{
 
 use crate::config::{AppConfig, FontConfig, FontStyleConfig, ThemeConfig};
 use crate::direct_render::{
-    DirectTerminalSceneExchange, resize_terminal_image, update_direct_terminal_frame,
+    DirectTerminalSceneExchange, TerminalImages, resize_terminal_image, update_direct_terminal_frame,
 };
 use crate::mouse::TerminalSelection;
 
@@ -270,8 +270,10 @@ impl TerminalSurface {
         let cursor_visible = self.tui.backend().cursor_visible();
         update_direct_terminal_frame(
             exchange,
-            render_handle,
-            present_handle,
+            TerminalImages {
+                render: render_handle,
+                present: present_handle,
+            },
             &mut self.renderer,
             buffer,
             cursor,

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -175,12 +175,16 @@ impl TerminalSurface {
 
         let metrics = self.renderer.logical_metrics(self.render_scale);
         let logical_size = logical_size.max(Vec2::ONE);
+        // A single-column grid makes vt100's wide-character wrap logic
+        // underflow (`cols - width` for a 2-cell glyph), so keep at least two.
         let cols = (logical_size.x / metrics.cell_width)
             .floor()
-            .clamp(1.0, u16::MAX as f32) as u16;
+            .clamp(2.0, u16::MAX as f32) as u16;
+        // Likewise, a single-row grid makes vt100's wrap/scroll bookkeeping
+        // underflow (`prev_row - scrolled`), so keep at least two rows.
         let rows = (logical_size.y / metrics.cell_height)
             .floor()
-            .clamp(1.0, u16::MAX as f32) as u16;
+            .clamp(2.0, u16::MAX as f32) as u16;
 
         if cols != self.cols || rows != self.rows {
             self.resize(cols, rows);

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -78,8 +78,11 @@ impl TerminalRedrawState {
 pub struct TerminalSurface {
     /// Ratatui terminal backend.
     pub tui: Terminal<ParleyBackend>,
-    /// Front texture image handle.
+    /// Front texture image handle (sampled by the plane material and sprite).
     pub image_handle: Option<Handle<Image>>,
+    /// Vello render-target handle. Vello rasterizes into this storage texture
+    /// and it is copied into [`Self::image_handle`] each frame.
+    pub render_image_handle: Option<Handle<Image>>,
     /// Back texture image handle.
     pub back_image_handle: Option<Handle<Image>>,
     /// Terminal column count.
@@ -124,6 +127,7 @@ impl TerminalSurface {
         Ok(Self {
             tui,
             image_handle: None,
+            render_image_handle: None,
             back_image_handle: None,
             cols,
             rows,
@@ -237,22 +241,28 @@ impl TerminalSurface {
         exchange: &DirectTerminalSceneExchange,
         elapsed_secs: f32,
     ) -> anyhow::Result<()> {
-        let Some(handle) = self.image_handle.as_ref() else {
+        let (Some(render_handle), Some(present_handle)) =
+            (self.render_image_handle.clone(), self.image_handle.clone())
+        else {
             return Ok(());
         };
         let (width, height) = self
             .renderer
             .texture_size_for_buffer(self.tui.backend().buffer());
-        // `get_mut` marks the asset modified, which makes Bevy re-extract and
-        // re-upload the CPU-side buffer; only take it when the size changes.
-        let Some(image) = images.get(handle) else {
-            return Ok(());
-        };
-        let size = image.texture_descriptor.size;
-        if (size.width != width || size.height != height)
-            && let Some(mut image) = images.get_mut(handle)
-        {
-            resize_terminal_image(&mut image, width, height);
+        // The render and present textures are kept the same size so the copy is
+        // a plain texel copy. `get_mut` marks the asset modified, which makes
+        // Bevy re-extract and re-upload the CPU-side buffer; only take it when
+        // the size changes.
+        for handle in [&render_handle, &present_handle] {
+            let Some(image) = images.get(handle) else {
+                continue;
+            };
+            let size = image.texture_descriptor.size;
+            if (size.width != width || size.height != height)
+                && let Some(mut image) = images.get_mut(handle)
+            {
+                resize_terminal_image(&mut image, width, height);
+            }
         }
 
         let buffer = self.tui.backend().buffer();
@@ -260,7 +270,8 @@ impl TerminalSurface {
         let cursor_visible = self.tui.backend().cursor_visible();
         update_direct_terminal_frame(
             exchange,
-            handle.clone(),
+            render_handle,
+            present_handle,
             &mut self.renderer,
             buffer,
             cursor,

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -159,7 +159,7 @@ impl TerminalSurface {
     }
 
     /// Updates the physical render scale.
-    pub fn set_render_scale(&mut self, render_scale: f32) -> bool {
+    fn set_render_scale(&mut self, render_scale: f32) -> bool {
         let render_scale = render_scale.max(1.0);
         if (render_scale - self.render_scale).abs() < f32::EPSILON {
             return false;
@@ -222,7 +222,7 @@ impl TerminalSurface {
     }
 
     /// Returns the current terminal layout.
-    pub fn layout(&self) -> TerminalLayout {
+    fn layout(&self) -> TerminalLayout {
         TerminalLayout::new(
             self.cols,
             self.rows,

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -299,11 +299,20 @@ impl TerminalSurface {
 pub fn render_scale_for_window(window: &Window) -> f32 {
     let logical_size = window.resolution.size().max(Vec2::ONE);
     let physical_size = window.resolution.physical_size();
+    let scale_factor = window.scale_factor();
+    // A Bevy scale-factor override already defines the physical/logical ratio. Applying the
+    // backend scale factor on top of it over-sizes fullscreen terminal textures.
+    let base_scale_factor = if window.resolution.scale_factor_override().is_some() {
+        scale_factor
+    } else {
+        window.resolution.base_scale_factor()
+    };
+
     PresentationScale::new(
         [logical_size.x, logical_size.y],
         [physical_size.x, physical_size.y],
-        window.scale_factor(),
-        window.resolution.base_scale_factor(),
+        scale_factor,
+        base_scale_factor,
     )
     .render_scale()
 }

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -8,7 +8,10 @@ use parley_ratatui::ratatui::buffer::Buffer;
 use parley_ratatui::ratatui::layout::Rect;
 use parley_ratatui::ratatui::style::{Color as TuiColor, Modifier, Style};
 use parley_ratatui::ratatui::widgets::Widget;
-use parley_ratatui::{FontOptions, ParleyBackend, TerminalRenderer};
+use parley_ratatui::{
+    FontOptions, ParleyBackend, PresentationScale, TerminalRenderer, TexturePresentation,
+    snap_logical_position_to_physical_pixel,
+};
 
 use crate::config::{AppConfig, FontConfig, FontStyleConfig, ThemeConfig};
 use crate::direct_render::{
@@ -18,6 +21,38 @@ use crate::mouse::TerminalSelection;
 
 /// Minimum interval between terminal redraws.
 const REDRAW_THROTTLE: Duration = Duration::from_millis(16);
+
+/// Terminal grid and presentation dimensions.
+#[derive(Clone, Copy, Debug)]
+pub struct TerminalLayout {
+    /// Terminal column count.
+    pub cols: u16,
+    /// Terminal row count.
+    pub rows: u16,
+    /// Physical texture size in pixels.
+    pub texture_size: UVec2,
+    /// Logical presentation size in Bevy world units.
+    pub logical_size: Vec2,
+    /// Physical render scale used for the terminal texture.
+    pub render_scale: f32,
+}
+
+impl TerminalLayout {
+    fn new(cols: u16, rows: u16, texture_size: UVec2, render_scale: f32) -> Self {
+        Self {
+            cols,
+            rows,
+            texture_size,
+            logical_size: texture_logical_size(texture_size, render_scale),
+            render_scale,
+        }
+    }
+
+    /// Returns PTY pixel dimensions clamped to portable-pty's `u16` API.
+    pub fn pty_pixels(self) -> UVec2 {
+        self.texture_size.min(UVec2::splat(u16::MAX as u32))
+    }
+}
 
 /// Terminal redraw flag.
 #[derive(Resource)]
@@ -39,6 +74,12 @@ impl TerminalRedrawState {
     /// Requests a terminal redraw.
     pub fn request(&mut self) {
         self.needs_redraw = true;
+    }
+
+    /// Requests a redraw without waiting for the throttle interval.
+    pub fn request_immediate(&mut self) {
+        self.needs_redraw = true;
+        self.last_redraw = Instant::now() - REDRAW_THROTTLE;
     }
 
     /// Returns whether a redraw was pending.
@@ -68,6 +109,7 @@ pub struct TerminalSurface {
     window_opacity: f32,
     font: FontConfig,
     theme: ThemeConfig,
+    render_scale: f32,
     renderer: TerminalRenderer,
 }
 
@@ -88,7 +130,13 @@ impl TerminalSurface {
         } else {
             tui.show_cursor()?;
         }
-        let renderer = build_terminal_renderer(&config.font, &config.theme, config.window.opacity);
+        let render_scale = config.window.scale_factor.max(1.0);
+        let renderer = build_terminal_renderer(
+            &config.font,
+            &config.theme,
+            config.window.opacity,
+            render_scale,
+        );
 
         Ok(Self {
             tui,
@@ -100,6 +148,7 @@ impl TerminalSurface {
             window_opacity: config.window.opacity.clamp(0.0, 1.0),
             font: config.font.clone(),
             theme: config.theme.clone(),
+            render_scale,
             renderer,
         })
     }
@@ -112,13 +161,45 @@ impl TerminalSurface {
         }
 
         self.font.size = new_size;
-        self.renderer = build_terminal_renderer(&self.font, &self.theme, self.window_opacity);
+        self.rebuild_renderer();
         true
     }
 
     /// Returns the current font size.
     pub fn font_size(&self) -> i32 {
         self.font.size
+    }
+
+    /// Updates the physical render scale.
+    pub fn set_render_scale(&mut self, render_scale: f32) -> bool {
+        let render_scale = render_scale.max(1.0);
+        if (render_scale - self.render_scale).abs() < f32::EPSILON {
+            return false;
+        }
+
+        self.render_scale = render_scale;
+        self.rebuild_renderer();
+        true
+    }
+
+    /// Resizes the terminal grid to fit a logical window size.
+    pub fn resize_to_fit(&mut self, logical_size: Vec2, render_scale: f32) -> TerminalLayout {
+        self.set_render_scale(render_scale);
+
+        let metrics = self.renderer.logical_metrics(self.render_scale);
+        let logical_size = logical_size.max(Vec2::ONE);
+        let cols = (logical_size.x / metrics.cell_width)
+            .floor()
+            .clamp(1.0, u16::MAX as f32) as u16;
+        let rows = (logical_size.y / metrics.cell_height)
+            .floor()
+            .clamp(1.0, u16::MAX as f32) as u16;
+
+        if cols != self.cols || rows != self.rows {
+            self.resize(cols, rows);
+        }
+
+        self.layout()
     }
 
     /// Resizes the terminal grid.
@@ -140,7 +221,7 @@ impl TerminalSurface {
 
     /// Returns the rendered cell size in pixels.
     pub fn char_dimensions(&self) -> UVec2 {
-        let metrics = self.renderer.metrics();
+        let metrics = self.renderer.logical_metrics(self.render_scale);
         UVec2::new(
             metrics.cell_width.ceil().max(1.0) as u32,
             metrics.cell_height.ceil().max(1.0) as u32,
@@ -153,6 +234,16 @@ impl TerminalSurface {
             .renderer
             .texture_size_for_buffer(self.tui.backend().buffer());
         UVec2::new(width, height)
+    }
+
+    /// Returns the current terminal layout.
+    pub fn layout(&self) -> TerminalLayout {
+        TerminalLayout::new(
+            self.cols,
+            self.rows,
+            self.pixmap_dimensions(),
+            self.render_scale,
+        )
     }
 
     /// Synchronizes the rendered terminal image.
@@ -193,12 +284,48 @@ impl TerminalSurface {
 
         Ok(())
     }
+
+    fn rebuild_renderer(&mut self) {
+        self.renderer = build_terminal_renderer(
+            &self.font,
+            &self.theme,
+            self.window_opacity,
+            self.render_scale,
+        );
+    }
+}
+
+/// Computes the physical render scale for a Bevy window.
+pub fn render_scale_for_window(window: &Window) -> f32 {
+    let logical_size = window.resolution.size().max(Vec2::ONE);
+    let physical_size = window.resolution.physical_size();
+    PresentationScale::new(
+        [logical_size.x, logical_size.y],
+        [physical_size.x, physical_size.y],
+        window.scale_factor(),
+        window.resolution.base_scale_factor(),
+    )
+    .render_scale()
+}
+
+/// Returns the logical size for a physical terminal texture.
+pub fn texture_logical_size(texture_size: UVec2, render_scale: f32) -> Vec2 {
+    let [width, height] =
+        TexturePresentation::new([texture_size.x, texture_size.y], render_scale).logical_size();
+    Vec2::new(width, height)
+}
+
+/// Snaps a logical position to the physical pixel grid.
+pub fn snapped_translation(position: Vec2, render_scale: f32) -> Vec2 {
+    let [x, y] = snap_logical_position_to_physical_pixel([position.x, position.y], render_scale);
+    Vec2::new(x, y)
 }
 
 fn build_terminal_renderer(
     font: &FontConfig,
     theme_config: &ThemeConfig,
     window_opacity: f32,
+    render_scale: f32,
 ) -> TerminalRenderer {
     let palette = theme_config
         .palette()
@@ -223,12 +350,13 @@ fn build_terminal_renderer(
         palette,
     };
     let font_options = FontOptions::default().with_family(font.family.clone());
-    TerminalRenderer::new(
+    TerminalRenderer::new_scaled(
         FontOptions {
             size: font.size as f32,
             ..font_options
         },
         theme,
+        render_scale,
     )
 }
 

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -8,7 +8,6 @@ use parley_ratatui::ratatui::style::{Color as TuiColor, Modifier, Style};
 use parley_ratatui::ratatui::widgets::Widget;
 use parley_ratatui::{
     CellQuantization, FontOptions, ParleyBackend, TerminalRenderer, TexturePresentation,
-    snap_logical_position_to_physical_pixel,
 };
 
 use crate::config::{AppConfig, FontConfig, FontStyleConfig, ThemeConfig};
@@ -317,12 +316,6 @@ pub fn texture_logical_size(texture_size: UVec2, render_scale: f32) -> Vec2 {
     let [width, height] =
         TexturePresentation::new([texture_size.x, texture_size.y], render_scale).logical_size();
     Vec2::new(width, height)
-}
-
-/// Snaps a logical position to the physical pixel grid.
-pub fn snapped_translation(position: Vec2, render_scale: f32) -> Vec2 {
-    let [x, y] = snap_logical_position_to_physical_pixel([position.x, position.y], render_scale);
-    Vec2::new(x, y)
 }
 
 fn build_terminal_renderer(

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -240,14 +240,20 @@ impl TerminalSurface {
         let Some(handle) = self.image_handle.as_ref() else {
             return Ok(());
         };
-        let Some(mut image) = images.get_mut(handle) else {
-            return Ok(());
-        };
-
         let (width, height) = self
             .renderer
             .texture_size_for_buffer(self.tui.backend().buffer());
-        resize_terminal_image(&mut image, width, height);
+        // `get_mut` marks the asset modified, which makes Bevy re-extract and
+        // re-upload the CPU-side buffer; only take it when the size changes.
+        let Some(image) = images.get(handle) else {
+            return Ok(());
+        };
+        let size = image.texture_descriptor.size;
+        if (size.width != width || size.height != height)
+            && let Some(mut image) = images.get_mut(handle)
+        {
+            resize_terminal_image(&mut image, width, height);
+        }
 
         let buffer = self.tui.backend().buffer();
         let cursor = Some(self.tui.backend().cursor_position());

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -7,8 +7,8 @@ use parley_ratatui::ratatui::layout::Rect;
 use parley_ratatui::ratatui::style::{Color as TuiColor, Modifier, Style};
 use parley_ratatui::ratatui::widgets::Widget;
 use parley_ratatui::{
-    CellQuantization, FontOptions, ParleyBackend, PresentationScale, TerminalRenderer,
-    TexturePresentation, snap_logical_position_to_physical_pixel,
+    CellQuantization, FontOptions, ParleyBackend, TerminalRenderer, TexturePresentation,
+    snap_logical_position_to_physical_pixel,
 };
 
 use crate::config::{AppConfig, FontConfig, FontStyleConfig, ThemeConfig};
@@ -297,24 +297,19 @@ impl TerminalSurface {
 
 /// Computes the physical render scale for a Bevy window.
 pub fn render_scale_for_window(window: &Window) -> f32 {
-    let logical_size = window.resolution.size().max(Vec2::ONE);
-    let physical_size = window.resolution.physical_size();
-    let scale_factor = window.scale_factor();
-    // A Bevy scale-factor override already defines the physical/logical ratio. Applying the
-    // backend scale factor on top of it over-sizes fullscreen terminal textures.
-    let base_scale_factor = if window.resolution.scale_factor_override().is_some() {
-        scale_factor
-    } else {
-        window.resolution.base_scale_factor()
-    };
-
-    PresentationScale::new(
-        [logical_size.x, logical_size.y],
-        [physical_size.x, physical_size.y],
-        scale_factor,
-        base_scale_factor,
-    )
-    .render_scale()
+    // The presenting window's *actual* framebuffer ratio (physical / logical), so the
+    // terminal texture is rasterized at exactly the framebuffer resolution and can be
+    // presented 1:1 with physical pixels. Deriving it from the real physical size —
+    // rather than the reported scale factor — keeps it correct when they disagree.
+    //
+    // The previous version took the max with the backend's base scale factor; on a
+    // mixed-DPI multi-monitor setup that leaked a higher-DPI monitor's scale, over-sizing
+    // the texture so it had to be resampled onto the low-DPI window.
+    let logical = window.resolution.size().max(Vec2::ONE);
+    let physical = window.resolution.physical_size().as_vec2();
+    (physical.x / logical.x)
+        .min(physical.y / logical.y)
+        .max(1.0)
 }
 
 /// Returns the logical size for a physical terminal texture.


### PR DESCRIPTION
## Summary

This PR replaces Ratty's CPU-readback terminal rendering with a **direct Vello→Bevy GPU texture path**: `parley_ratatui` records a Vello scene, the scene is handed to Bevy's render world through a double-buffered exchange, and Vello rasterizes it straight into a Bevy-owned GPU texture with no CPU readback. On top of that core change it reworks the scale/zoom model to render at native display scale, makes the terminal systems `Send` so they run continuously and in parallel, gates per-frame work behind dirty/state checks, and fixes a series of color, scale, shutdown, and GPU-validation bugs.

Updates `parley_ratatui` to `0.3.1` and Bevy to `0.19.0-rc.2`.

Fixes #97.
FIxes #106
Fixes #115 

---

## 1. New direct Vello→Bevy render path (replaces CPU readback)

The old path rendered the terminal on a private offscreen `wgpu` device, read the pixels back to the CPU, and uploaded them into a Bevy `Image` every frame. That whole bridge is gone.

**`src/direct_render.rs` (new file) — `DirectTerminalRenderPlugin`:**
- **`DirectTerminalSceneExchange`** — an `Arc`-backed `Resource` shared between the main world and the `RenderApp`. Its inner state is two single-slot, mutex-guarded mailboxes: `pending: Mutex<Option<DirectTerminalFrame>>` (latest main→render frame, newest wins) and `recycled: Mutex<Option<Scene>>` (one spare Vello `Scene` flowing render→main). `publish_frame` replaces the pending slot and recycles any displaced frame's scene; `take_recycled_scene`/`recycle_scene` (which calls `scene.reset()` and keeps at most one) implement **double-buffered scene ownership** so neither side reallocates a scene per frame.
- **`update_direct_terminal_frame`** (main side) — does the double-buffer dance: take a recycled scene, swap it into the `TerminalRenderer`, build the scene from the Ratatui buffer (`build_scene_with_elapsed`), swap the spare back, and `publish_frame` with both image handles, size, and `base_color`.
- **`extract_terminal_frame`** (`ExtractSchedule`) — moves the pending frame into the render world's `ExtractedDirectTerminalFrame`, recycling any frame it supersedes.
- **`render_terminal_frame`** (RenderGraph, set `RenderGraphSystems::Begin`) — lazily builds the Vello `GpuRenderer`, rasterizes into the render texture, and copies into the present texture. Placed in `Begin` so Vello's submission is ordered **before** the camera passes that sample the terminal texture.
- **Shutdown fix** — the Vello renderer lives in `DirectTerminalRenderState { renderer: SyncCell<Option<GpuRenderer>> }`. `vello::Renderer` is `Send` but not `Sync`, so a plain resource is impossible; the previous non-send resource pinned `render_terminal_frame` to a thread and **deadlocked the pipelined render app's final update during shutdown** (`World::clear_all` waited forever). `SyncCell` makes it a normal `Send` resource.

**`src/terminal.rs`** — deletes the entire `OffscreenGpu` struct (its own `wgpu::Device`/`Queue`, `GpuRenderer`, `TextureTarget`, `TextureReadback`, CPU `rgba: Vec<u8>`), the `pollster::block_on` init, and the `render_to_rgba8…` → `image.data.copy_from_slice` readback. `TerminalSurface` becomes a regular `#[derive(Resource)]`.

**`Cargo.toml`** — removes `pollster` (no CPU readback to block on). **`README.md`** — rewrites the pipeline section: the terminal image is now "fully GPU-resident; the only data crossing from the main world to the render world each frame is the recorded scene, not pixels." **`src/lib.rs`** — adds `mod direct_render;`.

---

## 2. Color correctness & GPU-validation safety (sRGB / storage split)

Vello writes **sRGB-encoded, display-ready** bytes into its `Rgba8Unorm` storage target (confirmed by a readback probe). Two problems had to be solved, and the final design uses **two textures**:

- **`new_terminal_render_image`** — the texture Vello rasterizes into: `Rgba8Unorm`, `STORAGE_BINDING | COPY_SRC | COPY_DST`, **no sRGB view**. Vello binds it as a compute storage target, which requires a plain (non-sRGB) view.
- **`new_terminal_image`** — the **present** texture materials/sprite sample: `Rgba8Unorm`, `TEXTURE_BINDING | COPY_DST` (no storage), with `view_formats = [Rgba8UnormSrgb]` and a `texture_view_descriptor` so it is sampled through an **sRGB view** that decodes the bytes on read (rather than treating them as linear and re-encoding at the swapchain, which washed out colors).

`render_terminal_frame` rasterizes into the render texture, then `copy_texture_to_texture` (a plain same-format `Rgba8Unorm`→`Rgba8Unorm` texel copy) into the present texture each frame.

**Why two textures:** earlier the present texture *was* the storage texture with an sRGB view bolted on. wgpu rejects an sRGB view of a storage texture, so on stricter backends bind-group creation failed (`TextureView with '' label is invalid`) and the app quit. Splitting them keeps the sRGB view on a non-storage texture (Bevy's standard render-target pattern, valid on every backend); the storage texture has no sRGB view. Inspired by `linebender/bevy_vello`, which keeps sRGB off the storage texture.

**Frame retry & zero-fill** — frames that arrive before the GPU image is prepared, or while its size lags a resize, are now **retained and retried** on the next render frame (a newer published frame supersedes a retained one during extraction) instead of being silently dropped, and both textures are zero-filled so a frame sampled before the first copy reads transparent black rather than uninitialized memory.

**`src/rendering.rs`** — `sync_plane_texture` only takes `materials.get_mut(...)` when the `base_color_texture` handle actually differs (checked via an immutable `get`), because `get_mut` marks the material modified and forces a GPU re-prepare.

---

## 3. Scale & zoom model (fixes #97)

Previously cell metrics were floored to whole physical pixels at a forced scale factor of `1.0`, so a font-size step whose advance delta was under one pixel changed only the cell **height** — zoom collapsed into a vertical-only stretch.

- **Native scale by default.** `WindowConfig.scale_factor` (`src/config.rs`) changes from `f32` (default `1.0`) to `Option<f32>` (default `None` = "use the display's scale factor"). `src/main.rs`'s new `window_resolution()` helper applies `with_scale_factor_override(...)` **only** when the config sets it; otherwise the window renders at the display's real scale factor. `config/ratty.toml` comments out `scale_factor` with documentation.
- **Don't double-count the override.** `render_scale_for_window()` (`src/terminal.rs`) chooses its base scale factor as `scale_factor` when a Bevy override is set, else `base_scale_factor()` — "a scale-factor override already defines the physical/logical ratio; applying the backend factor on top of it over-sizes fullscreen terminal textures."
- **Fractional cell quantization.** `build_terminal_renderer` builds the `parley_ratatui` renderer with `CellQuantization::Fractional` and `new_scaled(..., render_scale)`, so both axes grow on every font-size step. A regression test (`font_size_steps_scale_cells_on_both_axes`) asserts `cell_width`/`cell_height` strictly increase across sizes 8..=24 at scales 1.0 and 2.0.
- **Font size in points.** `FontConfig.size` is now interpreted as **points**; the renderer applies `PT_TO_PX = 96.0/72.0` before handing the size to Parley (so the default `18` renders at 18pt). `config/ratty.toml` documents this.
- **`TerminalLayout`** (new) bundles `cols`, `rows`, `texture_size: UVec2` (physical px), `logical_size: Vec2` (Bevy world units), and `render_scale`; `pty_pixels()` clamps to portable-pty's `u16` API. `resize_to_fit(logical_size, render_scale)` recomputes the grid from `renderer.logical_metrics(render_scale)` (logical metrics keep the column/row count stable across HiDPI scales) and returns a layout that the resize/render/input systems all consume. `set_render_scale` rebuilds the renderer; `char_dimensions` now returns fractional `Vec2` logical metrics instead of a ceiled `UVec2`; `snapped_translation()` snaps the sprite to the physical pixel grid (the "align zoom resize layout" fix).

---

## 4. Scene & presentation

**`src/scene/mod.rs`:**
- **Two images in `setup_scene`** — creates `new_terminal_render_image` (storage, `terminal.render_image_handle`) and `new_terminal_image` (present, `terminal.image_handle`); the legacy `create_terminal_image` is kept only for the 3D "back" debug image.
- **Layout-driven sizing** — `setup_scene` becomes a `SetupSceneParams` system param that reads the real `PrimaryWindow` and `TerminalRuntime`, computes `layout = terminal.resize_to_fit(window_size, render_scale_for_window(window))`, resizes the PTY to `layout.pty_pixels()`, and derives all image sizes, the `TerminalViewport`, the sprite `custom_size`/snapped translation, and both plane transform scales from `layout` instead of `app_config.window.{width,height}`.
- **Presentation entities** — `TerminalSprite` (2D, samples the present texture), `TerminalPlane` + `TerminalPlaneBack` (3D meshes, `StandardMaterial { unlit: true, alpha_mode: Blend }`; front samples the present texture, back samples the debug image). Two cameras: `Camera2d` (`order: 0`) and `TerminalPlaneCamera` (`Camera3d`, `order: 1`, orthographic, `clear_color: None` by default).
- **`apply_terminal_presentation` only mutates GPU state when it changes** — front-material `cull_mode` (`None` for Mobius's double-sided ribbon, else `Some(Face::Back)`) is only taken via `get_mut` when it differs; the 2D camera's `is_active = !is_3d` and the 3D camera's `clear_color` (the 3D camera stays active everywhere — it renders the cursor model/RGP objects even in 2D — so "whichever camera renders first owns the screen clear") are only assigned when changed.
- **`sync_terminal_layout`** (new) re-applies a `TerminalLayout` to live entities (viewport, sprite size/translation, plane scales) on resize, backed by new `TerminalSpriteLayoutQuery` / `TerminalPlaneLayoutQuery` / `TerminalPlaneBackLayoutQuery` aliases.

**`src/config.rs`** — adds `TERMINAL_RENDER_TEXTURE_LABEL` for Vello's storage texture and clarifies `TERMINAL_TEXTURE_LABEL` as the sampled present texture.

---

## 5. Scheduling, parallelism & performance

- **`Send` resources.** `src/runtime.rs`: `TerminalRuntime` becomes `#[derive(Resource)]` by wrapping its `!Sync` PTY handles in `SyncCell` (`rx: SyncCell<Receiver<Vec<u8>>>`, `master: SyncCell<Option<Box<dyn MasterPty + Send>>>`) and exposing `try_recv(&mut self)`. With `TerminalRuntime` and `TerminalSurface` both `Send`, `src/main.rs` inserts them with `insert_resource` (was `insert_non_send_resource`) and every consuming system in `src/systems.rs` flips `NonSend*` → `Res*`, so Bevy can schedule them off the main thread / in parallel. `pump_pty_output` now calls `runtime.try_recv()`.
- **Continuous updates.** `src/main.rs` replaces the per-focus reactive throttle (`UpdateMode::reactive_low_power(FOCUSED_UPDATE_INTERVAL)`) with `WinitSettings::continuous()` — Bevy's default switches unfocused windows to reactive mode, which would delay background PTY output. The `Instant`-based redraw throttle in `TerminalRedrawState` is removed.
- **`TerminalRedrawSet` pipeline.** The old `redraw_soft_terminal` god-system (which redrew, uploaded, refreshed the back texture, synced materials, *and* drove cursor-model loading) is split into three `.chain()`-ed systems in a new `TerminalRedrawSet`: `render_terminal_widget` → `sync_terminal_materials` → `finish_terminal_model_load`, ordered `.after()` input/resize/PTY systems.
- **Frame-dirty + blink-tick gating.** `render_terminal_widget` computes a shared `TerminalFrameDirty` from `needs_redraw || blink_ticked || !model_loaded`, where `blink_ticked` uses a `Local<u64>` bucket over `BLINK_TICK_SECS = 0.25` (rapid blink half-period; slow blink is a multiple). Texture content only changes with terminal state or blink phase (warp/camera motion is mesh-/camera-side), so an idle terminal re-rasterizes only ~4×/s instead of every frame, and the downstream pipeline systems early-return on clean frames. `sync_image` likewise only takes `get_mut` on each image when its size changes.
- **Run conditions** (`src/plugin.rs`) so continuous mode doesn't burn work: `apply_terminal_presentation` runs only when presentation/plane-view/Mobius state `is_changed()`; `apply_inline_objects` only when presentation changed or inline-object entities were `Added`; `sync_rgp_objects` only when RGP objects exist; `animate_mobius_transition` only in Mobius mode or during a transition; `animate_terminal_plane_warp` only when not `Flat2d`; `sync_asset_to_terminal_cursor` only when the cursor model is visible.
- `src/systems.rs` `handle_window_resize` is simplified to call `terminal.resize_to_fit(...)` + `sync_terminal_layout(...)` instead of inlining grid/viewport math, and the redraw pipeline (not the resize system) uploads the resized image.

---

## 6. Input handling under the new layout

- **`src/keyboard.rs`** — font-zoom bindings now resize through the window-based layout model: instead of computing the grid from the viewport and integer char dimensions, it calls `terminal.resize_to_fit(window_size, render_scale_for_window(window))`, resizes the PTY from `layout.pty_pixels()`, and propagates geometry with `sync_terminal_layout(...)`. This keeps zoom proportional under fractional cell metrics. Params switch `NonSendMut` → `ResMut` and gain the window + layout queries.
- **`src/mouse.rs`** — mouse-to-cell mapping is corrected for a viewport that is smaller than and centered in the window (letterbox/pillarbox under the new scale model). `position_to_cell` gains a `window_size` parameter, subtracts the half-margin (`(window_size - viewport.size) * 0.5`), returns `None` when the cursor is outside the terminal area, and then clamps within the viewport — previously it clamped raw window coordinates, assuming the viewport filled the window from the origin. The wheel `Pixel` branch drops a now-unneeded `.max(1) as f32` since `char_dimensions()` returns fractional `Vec2`.

---

## 7. Dependency & Bevy 0.19 migration

- **`Cargo.toml`** — `bevy` `0.18.1` → `0.19.0-rc.2`; adds the `bevy_scene` feature; `parley_ratatui` `0.2.1` → `0.3.1`; removes `pollster`.
- **`parley_ratatui` 0.3.1** also fixes terminal-cell rendering upstream: it snaps cell background fills to the pixel grid (no base-color bleed between cells with fractional cell sizes) and renders block elements such as the half block (`▀`) as exact geometric fills instead of font glyphs (which only filled the em box and left gaps in the taller line-height cell). The present texture keeps **linear** filtering because it is mapped onto transformable/scaled 3D geometry where point sampling would pixelate it; the seam fixes are made at authoring time in `parley_ratatui`, not by the sampler.
- **Scene type rename** — Bevy 0.19 renamed `Scene`→`WorldAsset` / `SceneRoot`→`WorldAssetRoot`: `src/inline.rs` (`Handle<Scene>` → `Handle<WorldAsset>`) and `src/model.rs` (`SceneRoot` → `WorldAssetRoot`) are mechanical migrations.
- **Other API renames** — `insert_non_send_resource`/`init_non_send_resource` → `insert_non_send`/`init_non_send` (`AppWindowIcon`, `TerminalClipboard`); `StandardMaterial.shadows_enabled` → `shadow_maps_enabled`; `apply_plane_warp` takes `Option<AssetMut<'_, Mesh>>`.

---

## Bug fixes in this PR (by commit)

- **font zoom proportional with fractional cell metrics** (#97) — vertical-only zoom stretch.
- **avoid double-counting fullscreen scale** — explicit scale override was multiplied by the backend factor, oversizing fullscreen textures.
- **align zoom resize layout** — sprite/plane sizing and pixel-snapped translation on resize.
- **unblock shutdown by making render state a Send resource** — non-send Vello renderer deadlocked shutdown.
- **decode terminal texture as sRGB and retry dropped frames** — washed-out colors and stale/uninitialized frames.
- **give Vello a storage texture and copy into an sRGB present texture** — `TextureView … is invalid` crash on strict backends (sRGB view on a storage texture).
- **update parley_ratatui to 0.3.1** — inter-cell seams and block-glyph gaps.
