### PR TITLE
Add Rubik's Cube example

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,14 @@ Split-pane drawing demo with a 2D canvas on the left and a live 3D preview on th
   <video width="80%" src="https://github.com/user-attachments/assets/8b53515b-b887-4d03-a54c-7e7aa7ea128c"/>
 </div>
 
+#### [Rubik's cube](widget/examples/rubiks_cube.rs)
+
+Interactive 3D Rubik's cube demo:
+
+<div>
+  <video width="80%" src="https://github.com/user-attachments/assets/9c5828d5-890a-45ac-80f6-cbc0b22384e6"/>
+</div>
+
 ### Apps
 
 Here are some applications explicitly built around Ratty's Graphics Protocol:

--- a/protocols/graphics.md
+++ b/protocols/graphics.md
@@ -65,7 +65,7 @@ ESC _ ratty;g;s ESC \
 Ratty replies:
 
 ```text
-ESC _ ratty;g;s;v=1;fmt=obj|glb;path=1;payload=1;chunk=1;anim=1;depth=1;color=1;brightness=1;transform=1;update=1 ESC \
+ESC _ ratty;g;s;v=1;fmt=obj|glb;path=1;payload=1;chunk=1;anim=1;depth=1;color=1;brightness=1;transform=1;update=1;normalize=1 ESC \
 ```
 
 Fields:
@@ -81,6 +81,7 @@ Fields:
 - `brightness=1`: `brightness=<f32>` placement is supported
 - `transform=1`: transform fields such as rotation and offsets are supported
 - `update=1`: `u` object updates are supported
+- `normalize=1`: `normalize=<0|1>` registration is supported for OBJ assets
 
 If no reply arrives, the terminal does not support the protocol.
 
@@ -101,6 +102,13 @@ The required fields are:
 - `id`: object id chosen by the application
 - `fmt`: payload format, `obj` or `glb` in v1
 - `path`: object path known to Ratty
+
+Optional registration fields:
+
+- `normalize`: OBJ normalization flag, defaults to `1`
+  - `1`: center each OBJ mesh around its bounding-box center and scale it by
+    the largest bounding-box axis
+  - `0`: preserve the OBJ's authored vertex coordinates
 
 #### Payload-based registration
 
@@ -136,6 +144,7 @@ Fields:
   - `1`: more register chunks follow for this object id
   - `0`: this is the final chunk and registration can be finalized
 - `name`: optional source name for diagnostics and temporary asset naming
+- `normalize`: optional OBJ normalization flag on the first payload chunk, defaults to `1`
 
 The terminal accumulates chunks for the same `id` until it receives the final
 `more=0` chunk. At that point, the object becomes registered and can be placed

--- a/src/inline.rs
+++ b/src/inline.rs
@@ -8,7 +8,10 @@ use bevy::prelude::*;
 use vt100::Callbacks;
 
 use crate::kitty::{KittyOperation, KittyParserState, refresh_kitty_placeholder_anchors};
-use crate::model::{ObjectSource, load_object_source, load_object_source_from_bytes};
+use crate::model::{
+    ObjectLoadOptions, ObjectSource, load_object_source_from_bytes_with_options,
+    load_object_source_with_options,
+};
 use crate::rgp::{
     RgpOperation, RgpPlacementStyle, RgpPlacementUpdate, RgpRegisterSource,
     consume_sequence as consume_rgp_sequence, support_reply,
@@ -246,8 +249,12 @@ impl TerminalInlineObjects {
             RgpOperation::Register {
                 object_id,
                 format,
+                options,
                 source,
             } => {
+                let load_options = ObjectLoadOptions {
+                    normalize: options.normalize,
+                };
                 if format != "obj" && format != "glb" {
                     warn!("unsupported RGP object format `{format}` for object {object_id}");
                     None
@@ -255,7 +262,7 @@ impl TerminalInlineObjects {
                     match source {
                         RgpRegisterSource::Path { path } => {
                             self.pending_rgp_payloads.remove(&object_id);
-                            match load_object_source(Path::new(&path)) {
+                            match load_object_source_with_options(Path::new(&path), load_options) {
                                 Ok((source, source_data)) => {
                                     info!("registered RGP object {} from {}", object_id, source);
                                     self.objects.insert(
@@ -282,9 +289,15 @@ impl TerminalInlineObjects {
                                 }
                             }
                         }
-                        RgpRegisterSource::Payload { name, more, data } => {
-                            self.handle_rgp_payload_chunk(object_id, &format, name, more, data)
-                        }
+                        RgpRegisterSource::Payload { name, more, data } => self
+                            .handle_rgp_payload_chunk(
+                                object_id,
+                                &format,
+                                name,
+                                more,
+                                data,
+                                load_options,
+                            ),
                     }
                 }
             }
@@ -370,6 +383,7 @@ impl TerminalInlineObjects {
         name: Option<String>,
         more: bool,
         data: Vec<u8>,
+        options: ObjectLoadOptions,
     ) -> Option<Vec<u8>> {
         let pending = self
             .pending_rgp_payloads
@@ -378,6 +392,7 @@ impl TerminalInlineObjects {
                 format: format.to_string(),
                 name: name.clone(),
                 data: Vec::new(),
+                options,
             });
         if pending.format != format {
             warn!(
@@ -408,8 +423,12 @@ impl TerminalInlineObjects {
             pending.format,
             pending.data.len()
         );
-        match load_object_source_from_bytes(&pending.format, pending.name.as_deref(), &pending.data)
-        {
+        match load_object_source_from_bytes_with_options(
+            &pending.format,
+            pending.name.as_deref(),
+            &pending.data,
+            pending.options,
+        ) {
             Ok((source, source_data)) => {
                 info!("registered RGP object {} from {}", object_id, source);
                 self.objects.insert(
@@ -440,6 +459,7 @@ struct PendingRgpPayload {
     format: String,
     name: Option<String>,
     data: Vec<u8>,
+    options: ObjectLoadOptions,
 }
 
 fn normalize_hvp_sequences(bytes: &[u8]) -> Cow<'_, [u8]> {

--- a/src/inline.rs
+++ b/src/inline.rs
@@ -311,8 +311,13 @@ impl TerminalInlineObjects {
             }
             RgpOperation::Update { object_id, update } => {
                 if let Some(anchor) = self.anchors.get_mut(&object_id) {
+                    let needs_respawn = update.depth.is_some()
+                        || update.color.is_some()
+                        || update.brightness.is_some();
                     apply_rgp_update(&mut anchor.style, update);
-                    self.dirty = true;
+                    if needs_respawn {
+                        self.dirty = true;
+                    }
                 }
                 None
             }

--- a/src/model.rs
+++ b/src/model.rs
@@ -356,6 +356,17 @@ fn build_meshes(models: Vec<tobj::Model>, source: String) -> anyhow::Result<Vec<
         );
         mesh.insert_attribute(Mesh::ATTRIBUTE_POSITION, positions);
 
+        if !source_mesh.vertex_color.is_empty() {
+            let colors = source_mesh
+                .vertex_color
+                .chunks_exact(3)
+                .map(|color| [color[0], color[1], color[2], 1.0])
+                .collect::<Vec<[f32; 4]>>();
+            if colors.len() == source_mesh.positions.len() / 3 {
+                mesh.insert_attribute(Mesh::ATTRIBUTE_COLOR, colors);
+            }
+        }
+
         if !source_mesh.normals.is_empty() {
             let normals = source_mesh
                 .normals

--- a/src/model.rs
+++ b/src/model.rs
@@ -1,6 +1,6 @@
 //! Cursor and object asset loading.
 
-use std::io::Cursor;
+use std::io::{Cursor, Read};
 use std::path::{Component, Path, PathBuf};
 
 use anyhow::{Context, bail, ensure};
@@ -298,6 +298,7 @@ fn object_asset_path(path: &Path) -> anyhow::Result<String> {
 }
 
 fn load_obj_meshes_from_path(path: &Path) -> anyhow::Result<Vec<Mesh>> {
+    let preserve_transform = obj_preserves_transform_from_path(path).unwrap_or(false);
     let options = tobj::LoadOptions {
         triangulate: true,
         single_index: true,
@@ -306,10 +307,11 @@ fn load_obj_meshes_from_path(path: &Path) -> anyhow::Result<Vec<Mesh>> {
     };
     let (models, _) = tobj::load_obj(path, &options)
         .with_context(|| format!("failed to read {}", path.display()))?;
-    build_meshes(models, path.display().to_string())
+    build_meshes(models, path.display().to_string(), !preserve_transform)
 }
 
 fn load_obj_meshes_from_bytes(name: &str, bytes: &[u8]) -> anyhow::Result<Vec<Mesh>> {
+    let preserve_transform = obj_preserves_transform(bytes);
     let options = tobj::LoadOptions {
         triangulate: true,
         single_index: true,
@@ -320,10 +322,28 @@ fn load_obj_meshes_from_bytes(name: &str, bytes: &[u8]) -> anyhow::Result<Vec<Me
         Ok((Vec::new(), Default::default()))
     })
     .with_context(|| format!("failed to read embedded {name}"))?;
-    build_meshes(models, format!("embedded:{name}"))
+    build_meshes(models, format!("embedded:{name}"), !preserve_transform)
 }
 
-fn build_meshes(models: Vec<tobj::Model>, source: String) -> anyhow::Result<Vec<Mesh>> {
+fn obj_preserves_transform_from_path(path: &Path) -> anyhow::Result<bool> {
+    let mut file = std::fs::File::open(path)
+        .with_context(|| format!("failed to inspect {}", path.display()))?;
+    let mut prefix = [0; 256];
+    let read = file
+        .read(&mut prefix)
+        .with_context(|| format!("failed to inspect {}", path.display()))?;
+    Ok(obj_preserves_transform(&prefix[..read]))
+}
+
+fn obj_preserves_transform(bytes: &[u8]) -> bool {
+    std::str::from_utf8(bytes).is_ok_and(|prefix| prefix.contains("ratty:preserve-transform"))
+}
+
+fn build_meshes(
+    models: Vec<tobj::Model>,
+    source: String,
+    normalize: bool,
+) -> anyhow::Result<Vec<Mesh>> {
     let mut output = Vec::new();
     for model in models {
         let source_mesh = model.mesh;
@@ -341,13 +361,15 @@ fn build_meshes(models: Vec<tobj::Model>, source: String) -> anyhow::Result<Vec<
             positions.push([point.x, point.y, point.z]);
         }
 
-        let center = (min + max) * 0.5;
-        let extent = max - min;
-        let max_extent = extent.max_element().max(1e-6);
-        for p in &mut positions {
-            p[0] = (p[0] - center.x) / max_extent;
-            p[1] = (p[1] - center.y) / max_extent;
-            p[2] = (p[2] - center.z) / max_extent;
+        if normalize {
+            let center = (min + max) * 0.5;
+            let extent = max - min;
+            let max_extent = extent.max_element().max(1e-6);
+            for p in &mut positions {
+                p[0] = (p[0] - center.x) / max_extent;
+                p[1] = (p[1] - center.y) / max_extent;
+                p[2] = (p[2] - center.z) / max_extent;
+            }
         }
 
         let mut mesh = Mesh::new(

--- a/src/model.rs
+++ b/src/model.rs
@@ -1,6 +1,6 @@
 //! Cursor and object asset loading.
 
-use std::io::{Cursor, Read};
+use std::io::Cursor;
 use std::path::{Component, Path, PathBuf};
 
 use anyhow::{Context, bail, ensure};
@@ -27,6 +27,23 @@ pub enum ObjectSource {
     Obj(Vec<Mesh>),
     /// glTF scene asset path.
     Gltf(String),
+}
+
+/// Options that control object source loading.
+#[derive(Clone, Copy, Debug)]
+pub struct ObjectLoadOptions {
+    /// Controls whether OBJ meshes are centered and scaled at load time.
+    ///
+    /// When enabled, each OBJ mesh is centered around its bounding-box center
+    /// and scaled by the largest bounding-box axis. Disable this for generated
+    /// or assembled OBJ assets whose source coordinates should be preserved.
+    pub normalize: bool,
+}
+
+impl Default for ObjectLoadOptions {
+    fn default() -> Self {
+        Self { normalize: true }
+    }
 }
 
 /// Spawns the configured cursor model.
@@ -108,6 +125,18 @@ pub fn spawn_cursor_model(
 ///
 /// Returns an error if the asset cannot be resolved or parsed.
 pub fn load_object_source(path: &Path) -> anyhow::Result<(String, ObjectSource)> {
+    load_object_source_with_options(path, ObjectLoadOptions::default())
+}
+
+/// Loads an object source from a path with explicit load options.
+///
+/// # Errors
+///
+/// Returns an error if the asset cannot be resolved or parsed.
+pub fn load_object_source_with_options(
+    path: &Path,
+    options: ObjectLoadOptions,
+) -> anyhow::Result<(String, ObjectSource)> {
     let expanded_path = expand_path(path);
     let path = expanded_path.as_path();
     if path.exists() {
@@ -118,7 +147,7 @@ pub fn load_object_source(path: &Path) -> anyhow::Result<(String, ObjectSource)>
             .unwrap_or_default();
 
         return match extension.as_str() {
-            "obj" => load_obj_meshes_from_path(path)
+            "obj" => load_obj_meshes_from_path(path, options.normalize)
                 .map(|meshes| (path.display().to_string(), ObjectSource::Obj(meshes))),
             "glb" | "gltf" => {
                 let bytes = std::fs::read(path)
@@ -163,7 +192,7 @@ pub fn load_object_source(path: &Path) -> anyhow::Result<(String, ObjectSource)>
         && let Some(file) = EmbeddedObjects::get(file_name)
     {
         return match extension.as_str() {
-            "obj" => load_obj_meshes_from_bytes(file_name, &file.data)
+            "obj" => load_obj_meshes_from_bytes(file_name, &file.data, options.normalize)
                 .map(|meshes| (format!("embedded:{file_name}"), ObjectSource::Obj(meshes))),
             "glb" | "gltf" => {
                 let asset_path =
@@ -178,9 +207,12 @@ pub fn load_object_source(path: &Path) -> anyhow::Result<(String, ObjectSource)>
     }
 
     match extension.as_str() {
-        "obj" => load_obj_meshes_from_path(runtime_asset_root().join(&candidate).as_path())
-            .or_else(|_| load_obj_meshes_from_path(path))
-            .map(|meshes| (candidate.clone(), ObjectSource::Obj(meshes))),
+        "obj" => load_obj_meshes_from_path(
+            runtime_asset_root().join(&candidate).as_path(),
+            options.normalize,
+        )
+        .or_else(|_| load_obj_meshes_from_path(path, options.normalize))
+        .map(|meshes| (candidate.clone(), ObjectSource::Obj(meshes))),
         "glb" | "gltf" => {
             let asset_path = ensure_scene_asset_path(&candidate, None)?;
             Ok((candidate, ObjectSource::Gltf(asset_path)))
@@ -199,6 +231,20 @@ pub fn load_object_source_from_bytes(
     name: Option<&str>,
     bytes: &[u8],
 ) -> anyhow::Result<(String, ObjectSource)> {
+    load_object_source_from_bytes_with_options(format, name, bytes, ObjectLoadOptions::default())
+}
+
+/// Loads an object source from inline bytes with explicit load options.
+///
+/// # Errors
+///
+/// Returns an error if the payload cannot be parsed or materialized.
+pub fn load_object_source_from_bytes_with_options(
+    format: &str,
+    name: Option<&str>,
+    bytes: &[u8],
+    options: ObjectLoadOptions,
+) -> anyhow::Result<(String, ObjectSource)> {
     let display_name = name.unwrap_or(match format {
         "obj" => "payload.obj",
         "glb" | "gltf" => "payload.glb",
@@ -206,7 +252,7 @@ pub fn load_object_source_from_bytes(
     });
 
     match format {
-        "obj" => load_obj_meshes_from_bytes(display_name, bytes)
+        "obj" => load_obj_meshes_from_bytes(display_name, bytes, options.normalize)
             .map(|meshes| (format!("payload:{display_name}"), ObjectSource::Obj(meshes))),
         "glb" | "gltf" => {
             // Bevy scene loading still goes through the asset server, so payload-backed GLB/GLTF
@@ -297,8 +343,7 @@ fn object_asset_path(path: &Path) -> anyhow::Result<String> {
         .to_string())
 }
 
-fn load_obj_meshes_from_path(path: &Path) -> anyhow::Result<Vec<Mesh>> {
-    let preserve_transform = obj_preserves_transform_from_path(path).unwrap_or(false);
+fn load_obj_meshes_from_path(path: &Path, normalize: bool) -> anyhow::Result<Vec<Mesh>> {
     let options = tobj::LoadOptions {
         triangulate: true,
         single_index: true,
@@ -307,11 +352,14 @@ fn load_obj_meshes_from_path(path: &Path) -> anyhow::Result<Vec<Mesh>> {
     };
     let (models, _) = tobj::load_obj(path, &options)
         .with_context(|| format!("failed to read {}", path.display()))?;
-    build_meshes(models, path.display().to_string(), !preserve_transform)
+    build_meshes(models, path.display().to_string(), normalize)
 }
 
-fn load_obj_meshes_from_bytes(name: &str, bytes: &[u8]) -> anyhow::Result<Vec<Mesh>> {
-    let preserve_transform = obj_preserves_transform(bytes);
+fn load_obj_meshes_from_bytes(
+    name: &str,
+    bytes: &[u8],
+    normalize: bool,
+) -> anyhow::Result<Vec<Mesh>> {
     let options = tobj::LoadOptions {
         triangulate: true,
         single_index: true,
@@ -322,21 +370,7 @@ fn load_obj_meshes_from_bytes(name: &str, bytes: &[u8]) -> anyhow::Result<Vec<Me
         Ok((Vec::new(), Default::default()))
     })
     .with_context(|| format!("failed to read embedded {name}"))?;
-    build_meshes(models, format!("embedded:{name}"), !preserve_transform)
-}
-
-fn obj_preserves_transform_from_path(path: &Path) -> anyhow::Result<bool> {
-    let mut file = std::fs::File::open(path)
-        .with_context(|| format!("failed to inspect {}", path.display()))?;
-    let mut prefix = [0; 256];
-    let read = file
-        .read(&mut prefix)
-        .with_context(|| format!("failed to inspect {}", path.display()))?;
-    Ok(obj_preserves_transform(&prefix[..read]))
-}
-
-fn obj_preserves_transform(bytes: &[u8]) -> bool {
-    std::str::from_utf8(bytes).is_ok_and(|prefix| prefix.contains("ratty:preserve-transform"))
+    build_meshes(models, format!("embedded:{name}"), normalize)
 }
 
 fn build_meshes(

--- a/src/rgp.rs
+++ b/src/rgp.rs
@@ -67,6 +67,19 @@ pub enum RgpRegisterSource {
     },
 }
 
+/// Registration-time object loading options.
+#[derive(Clone, Copy)]
+pub struct RgpRegisterOptions {
+    /// Normalizes OBJ meshes into a centered unit-size coordinate space.
+    pub normalize: bool,
+}
+
+impl Default for RgpRegisterOptions {
+    fn default() -> Self {
+        Self { normalize: true }
+    }
+}
+
 /// Consumes an RGP APC sequence.
 pub fn consume_sequence(sequence: &[u8]) -> Option<RgpOperation> {
     if !sequence.starts_with(RGP_APC_START) {
@@ -107,6 +120,7 @@ pub fn consume_sequence(sequence: &[u8]) -> Option<RgpOperation> {
     let mut sx = None;
     let mut sy = None;
     let mut sz = None;
+    let mut normalize = None;
     let mut payload = None;
     for part in parts.filter(|part| !part.is_empty()) {
         let Some((key, value)) = part.split_once('=') else {
@@ -141,6 +155,7 @@ pub fn consume_sequence(sequence: &[u8]) -> Option<RgpOperation> {
             "sx" => sx = value.parse().ok(),
             "sy" => sy = value.parse().ok(),
             "sz" => sz = value.parse().ok(),
+            "normalize" => normalize = parse_bool(value),
             _ if verb == "r" && source.as_deref() == Some("payload") => {
                 payload = Some(part.to_string());
                 break;
@@ -154,6 +169,9 @@ pub fn consume_sequence(sequence: &[u8]) -> Option<RgpOperation> {
         "r" => Some(RgpOperation::Register {
             object_id: id?,
             format: format?,
+            options: RgpRegisterOptions {
+                normalize: normalize.unwrap_or(true),
+            },
             source: if let Some(path) = path {
                 RgpRegisterSource::Path { path }
             } else {
@@ -232,6 +250,8 @@ pub enum RgpOperation {
         object_id: u32,
         /// Declared object format.
         format: String,
+        /// Registration-time object loading options.
+        options: RgpRegisterOptions,
         /// Register source.
         source: RgpRegisterSource,
     },
@@ -260,7 +280,7 @@ pub enum RgpOperation {
 
 /// Returns the RGP support reply sequence.
 pub fn support_reply() -> Vec<u8> {
-    b"\x1b_ratty;g;s;v=1;fmt=obj|glb;path=1;payload=1;chunk=1;anim=1;depth=1;color=1;brightness=1;transform=1;update=1\x1b\\".to_vec()
+    b"\x1b_ratty;g;s;v=1;fmt=obj|glb;path=1;payload=1;chunk=1;anim=1;depth=1;color=1;brightness=1;transform=1;update=1;normalize=1\x1b\\".to_vec()
 }
 
 fn parse_color(value: &str) -> Option<[u8; 3]> {

--- a/widget/README.md
+++ b/widget/README.md
@@ -70,7 +70,7 @@ fn main() -> io::Result<()> {
 - [`examples/big_rat.rs`](https://github.com/orhun/ratty/tree/main/widget/examples/big_rat.rs): minimal inline object demo
 - [`examples/document.rs`](https://github.com/orhun/ratty/tree/main/widget/examples/document.rs): TempleOS-inspired editor with embedded objects
 - [`examples/draw.rs`](https://github.com/orhun/ratty/tree/main/widget/examples/draw.rs): 2D drawing pane with live 3D preview
-- [`examples/rubiks_cube.rs`](https://github.com/orhun/ratty/tree/main/widget/examples/rubiks_cube.rs): interactive 3D Rubik's cube built from RGP objects
+- [`examples/rubiks_cube.rs`](https://github.com/orhun/ratty/tree/main/widget/examples/rubiks_cube.rs): interactive 3D Rubik's cube
 
 ## License
 

--- a/widget/README.md
+++ b/widget/README.md
@@ -70,6 +70,7 @@ fn main() -> io::Result<()> {
 - [`examples/big_rat.rs`](https://github.com/orhun/ratty/tree/main/widget/examples/big_rat.rs): minimal inline object demo
 - [`examples/document.rs`](https://github.com/orhun/ratty/tree/main/widget/examples/document.rs): TempleOS-inspired editor with embedded objects
 - [`examples/draw.rs`](https://github.com/orhun/ratty/tree/main/widget/examples/draw.rs): 2D drawing pane with live 3D preview
+- [`examples/rubiks_cube.rs`](https://github.com/orhun/ratty/tree/main/widget/examples/rubiks_cube.rs): interactive 3D Rubik's cube built from RGP objects
 
 ## License
 

--- a/widget/examples/rubiks_cube.rs
+++ b/widget/examples/rubiks_cube.rs
@@ -474,6 +474,7 @@ impl SceneObject {
         let settings = RattyGraphicSettings::new(format!("rubiks-{id}.obj"))
             .id(id)
             .format(ObjectFormat::Obj)
+            .normalize(false)
             .animate(false)
             .brightness(1.0)
             .depth(0.0);
@@ -1027,7 +1028,7 @@ fn cuboid_primitive(center: Vec3, half: Vec3, color: [u8; 3], rotation: Mat3) ->
 }
 
 fn build_obj(primitives: &[MeshPrimitive]) -> String {
-    let mut obj = String::from("# ratty:preserve-transform\n# ratty-rubiks-cube\n");
+    let mut obj = String::from("# ratty-rubiks-cube\n");
     let mut vertex_offset = 1usize;
     let mut normal_offset = 1usize;
     for primitive in primitives {

--- a/widget/examples/rubiks_cube.rs
+++ b/widget/examples/rubiks_cube.rs
@@ -1,8 +1,7 @@
 use std::{
     borrow::Cow,
     collections::VecDeque,
-    fs,
-    io,
+    fs, io,
     path::PathBuf,
     time::{Duration, Instant},
 };
@@ -171,7 +170,12 @@ impl RubiksApp {
         let place_objects = self.view.placed_area != Some(area);
         emit_sequence(buf, area.x, area.y, &self.object.graphic.update_sequence());
         if place_objects {
-            emit_sequence(buf, area.x, area.y, &self.object.graphic.place_sequence(area));
+            emit_sequence(
+                buf,
+                area.x,
+                area.y,
+                &self.object.graphic.place_sequence(area),
+            );
         }
 
         if place_objects {
@@ -180,8 +184,10 @@ impl RubiksApp {
     }
 
     fn sync_scene_objects(&mut self, area: Rect) {
-        self.object
-            .apply(self.view.rotation(), &SceneMetrics::new(area, self.view.zoom));
+        self.object.apply(
+            self.view.rotation(),
+            &SceneMetrics::new(area, self.view.zoom),
+        );
     }
 
     fn handle_event(&mut self, event: Event) -> io::Result<()> {
@@ -341,16 +347,16 @@ impl RubiksCube {
 
     fn tick(&mut self, delta: f32) -> bool {
         let mut changed = false;
-        if self.active_turn.is_none() {
-            if let Some(queued) = self.queued_turns.pop_front() {
-                self.active_turn = Some(ActiveTurn {
-                    spec: queued.spec,
-                    record: queued.record,
-                    elapsed: 0.0,
-                    duration: TURN_DURATION,
-                });
-                changed = true;
-            }
+        if self.active_turn.is_none()
+            && let Some(queued) = self.queued_turns.pop_front()
+        {
+            self.active_turn = Some(ActiveTurn {
+                spec: queued.spec,
+                record: queued.record,
+                elapsed: 0.0,
+                duration: TURN_DURATION,
+            });
+            changed = true;
         }
 
         let Some(turn) = self.active_turn.as_mut() else {
@@ -468,8 +474,8 @@ impl SceneView {
         if viewport.is_empty() {
             return viewport;
         }
-        let width = viewport.width.saturating_sub(2).min(56).max(1);
-        let height = viewport.height.saturating_sub(2).min(24).max(1);
+        let width = viewport.width.saturating_sub(2).clamp(1, 56);
+        let height = viewport.height.saturating_sub(2).clamp(1, 24);
         viewport.centered(Constraint::Length(width), Constraint::Length(height))
     }
 }
@@ -507,11 +513,7 @@ impl SceneObject {
         settings.animate = false;
         settings.depth = 0.0;
         settings.rotation = rotation.to_euler_degrees();
-        settings.offset = [
-            0.0,
-            0.0,
-            metrics.unit * BASE_Z_UNITS,
-        ];
+        settings.offset = [0.0, 0.0, metrics.unit * BASE_Z_UNITS];
         settings.color = None;
         settings.brightness = 1.0;
         settings.scale = metrics.object_scale;
@@ -636,30 +638,12 @@ impl Sticker {
         let thickness = 0.018;
         let lift = 0.516;
         match (self.normal.x, self.normal.y, self.normal.z) {
-            (1, 0, 0) => (
-                Vec3::new(lift, 0.0, 0.0),
-                Vec3::new(thickness, face, face),
-            ),
-            (-1, 0, 0) => (
-                Vec3::new(-lift, 0.0, 0.0),
-                Vec3::new(thickness, face, face),
-            ),
-            (0, 1, 0) => (
-                Vec3::new(0.0, lift, 0.0),
-                Vec3::new(face, thickness, face),
-            ),
-            (0, -1, 0) => (
-                Vec3::new(0.0, -lift, 0.0),
-                Vec3::new(face, thickness, face),
-            ),
-            (0, 0, -1) => (
-                Vec3::new(0.0, 0.0, -lift),
-                Vec3::new(face, face, thickness),
-            ),
-            _ => (
-                Vec3::new(0.0, 0.0, lift),
-                Vec3::new(face, face, thickness),
-            ),
+            (1, 0, 0) => (Vec3::new(lift, 0.0, 0.0), Vec3::new(thickness, face, face)),
+            (-1, 0, 0) => (Vec3::new(-lift, 0.0, 0.0), Vec3::new(thickness, face, face)),
+            (0, 1, 0) => (Vec3::new(0.0, lift, 0.0), Vec3::new(face, thickness, face)),
+            (0, -1, 0) => (Vec3::new(0.0, -lift, 0.0), Vec3::new(face, thickness, face)),
+            (0, 0, -1) => (Vec3::new(0.0, 0.0, -lift), Vec3::new(face, face, thickness)),
+            _ => (Vec3::new(0.0, 0.0, lift), Vec3::new(face, face, thickness)),
         }
     }
 }
@@ -762,7 +746,6 @@ impl MoveSpec {
             Axis::Z => pos.z == self.layer,
         }
     }
-
 }
 
 #[derive(Clone, Copy, PartialEq, Eq)]

--- a/widget/examples/rubiks_cube.rs
+++ b/widget/examples/rubiks_cube.rs
@@ -1,0 +1,1378 @@
+use std::{
+    borrow::Cow,
+    collections::VecDeque,
+    fs,
+    io::{self, Write},
+    path::PathBuf,
+    time::{Duration, Instant},
+};
+
+use crossterm::{
+    event::{
+        self, DisableMouseCapture, EnableMouseCapture, Event, KeyCode, KeyEvent, MouseEvent,
+        MouseEventKind,
+    },
+    execute,
+    terminal::window_size,
+};
+use ratatui::{
+    DefaultTerminal, Frame,
+    buffer::Buffer,
+    layout::{Constraint, Position, Rect},
+    style::{Color, Style},
+    text::{Line, Span},
+    widgets::{Block, Paragraph, Widget},
+};
+use ratatui_ratty::{ObjectFormat, RattyGraphic, RattyGraphicSettings};
+
+const TICK: Duration = Duration::from_millis(33);
+const TURN_DURATION: f32 = 0.26;
+const BODY_SCALE: f32 = 0.15;
+const CUBIE_SPACING: f32 = 1.04;
+const BASE_Z_UNITS: f32 = 2.7;
+const GLB_JSON_CHUNK: u32 = 0x4e4f_534a;
+const GLB_BIN_CHUNK: u32 = 0x004e_4942;
+const ARRAY_BUFFER: u32 = 34_962;
+const ELEMENT_ARRAY_BUFFER: u32 = 34_963;
+const COMPONENT_F32: u32 = 5_126;
+const COMPONENT_U16: u32 = 5_123;
+
+fn main() -> io::Result<()> {
+    let mut terminal = ratatui::init();
+    let result = run(&mut terminal);
+    ratatui::restore();
+    result
+}
+
+fn run(terminal: &mut DefaultTerminal) -> io::Result<()> {
+    let mut app = RubiksApp::new()?;
+    execute!(io::stdout(), EnableMouseCapture)?;
+    let result = app.run(terminal);
+    let _ = app.clear();
+    execute!(io::stdout(), DisableMouseCapture)?;
+    result
+}
+
+struct RubiksApp {
+    cubies: Vec<Cubie>,
+    cube: SceneObject,
+    active_turn: Option<ActiveTurn>,
+    queued_turns: VecDeque<QueuedTurn>,
+    history: Vec<MoveSpec>,
+    rng: u32,
+    model_revision: u32,
+    palette: Palette,
+    yaw: f32,
+    pitch: f32,
+    roll: f32,
+    zoom: f32,
+    spread: f32,
+    viewport: Rect,
+    placed_area: Option<Rect>,
+    drag_start: Option<Position>,
+    should_quit: bool,
+}
+
+impl RubiksApp {
+    fn new() -> io::Result<Self> {
+        clear_demo_objects()?;
+        let mut app = Self {
+            cubies: Vec::new(),
+            cube: SceneObject::new_cube(900),
+            active_turn: None,
+            queued_turns: VecDeque::new(),
+            history: Vec::new(),
+            rng: 0x516f_6f74,
+            model_revision: 0,
+            palette: Palette::Classic,
+            yaw: -0.58,
+            pitch: -0.42,
+            roll: 0.0,
+            zoom: 1.0,
+            spread: 1.0,
+            viewport: Rect::default(),
+            placed_area: None,
+            drag_start: None,
+            should_quit: false,
+        };
+        app.reset_cube();
+        app.register_objects()?;
+        Ok(app)
+    }
+
+    fn run(&mut self, terminal: &mut DefaultTerminal) -> io::Result<()> {
+        let mut last_tick = Instant::now();
+
+        while !self.should_quit {
+            terminal.draw(|frame| self.render(frame))?;
+
+            let timeout = TICK.saturating_sub(last_tick.elapsed());
+            if event::poll(timeout)? {
+                self.handle_event(event::read()?)?;
+            }
+
+            let now = Instant::now();
+            let delta = now.duration_since(last_tick);
+            last_tick = now;
+            self.tick(delta.as_secs_f32());
+        }
+
+        Ok(())
+    }
+
+    fn reset_cube(&mut self) {
+        self.cubies.clear();
+        self.cube = SceneObject::new_cube(900);
+        self.active_turn = None;
+        self.queued_turns.clear();
+        self.history.clear();
+        self.placed_area = None;
+
+        for x in -1..=1 {
+            for y in -1..=1 {
+                for z in -1..=1 {
+                    if x == 0 && y == 0 && z == 0 {
+                        continue;
+                    }
+
+                    let pos = Vec3i::new(x, y, z);
+                    let mut stickers = Vec::new();
+                    for (normal, face) in exposed_faces(pos) {
+                        stickers.push(Sticker { normal, face });
+                    }
+
+                    self.cubies.push(Cubie::new(pos, stickers));
+                }
+            }
+        }
+    }
+
+    fn register_objects(&mut self) -> io::Result<()> {
+        self.register_cube_model()
+    }
+
+    fn register_cube_model(&mut self) -> io::Result<()> {
+        self.model_revision = self.model_revision.wrapping_add(1);
+        let active = self.active_turn.as_ref().map(|turn| {
+            let progress = smoothstep((turn.elapsed / turn.duration).clamp(0.0, 1.0));
+            (
+                turn.spec,
+                Mat3::from_axis(
+                    turn.spec.axis,
+                    turn.spec.dir as f32 * progress * std::f32::consts::FRAC_PI_2,
+                ),
+            )
+        });
+        let payload = cube_glb(&self.cubies, self.palette, active);
+        let path = cube_asset_path(self.model_revision, self.palette)?;
+        fs::write(&path, payload)?;
+        self.cube.graphic.settings_mut().path = Cow::Owned(path.to_string_lossy().into_owned());
+        self.cube.graphic.register()?;
+        Ok(())
+    }
+
+    fn clear(&self) -> io::Result<()> {
+        let mut stdout = io::stdout();
+        stdout.write_all(self.cube.graphic.delete_sequence().as_bytes())?;
+        stdout.flush()
+    }
+
+    fn render(&mut self, frame: &mut Frame<'_>) {
+        let area = frame.area();
+        let header = Rect::new(area.x, area.y, area.width, 3);
+        let body = Rect::new(
+            area.x,
+            area.y.saturating_add(3),
+            area.width,
+            area.height.saturating_sub(3),
+        );
+
+        Paragraph::new(Line::from(vec![
+            Span::styled("mouse", Style::default().fg(Color::Cyan)),
+            Span::raw(": orbit  "),
+            Span::styled("u d l r f b", Style::default().fg(Color::Cyan)),
+            Span::raw(": turn  "),
+            Span::styled("shift", Style::default().fg(Color::Cyan)),
+            Span::raw(": inverse  "),
+            Span::styled("space", Style::default().fg(Color::Cyan)),
+            Span::raw(": scramble  "),
+            Span::styled("enter", Style::default().fg(Color::Cyan)),
+            Span::raw(": solve  "),
+            Span::styled("p", Style::default().fg(Color::Cyan)),
+            Span::raw(format!(": palette {}  ", self.palette.name())),
+            Span::styled("q", Style::default().fg(Color::Cyan)),
+            Span::raw(": quit"),
+        ]))
+        .block(Block::bordered().title(Span::styled(
+            "RGP Rubik's Cube",
+            Style::default().fg(Color::Yellow),
+        )))
+        .render(header, frame.buffer_mut());
+
+        let block = Block::bordered()
+            .title(self.status())
+            .border_style(Style::default().fg(Color::White));
+        self.viewport = block.inner(body);
+        block.render(body, frame.buffer_mut());
+        self.paint_backdrop(frame.buffer_mut());
+
+        let cube_area = centered_cube_area(self.viewport);
+        self.sync_scene_objects(cube_area);
+        self.emit_rgp_sequences(frame.buffer_mut(), cube_area);
+    }
+
+    fn status(&self) -> String {
+        let active = self
+            .active_turn
+            .as_ref()
+            .map(|turn| turn.spec.label())
+            .unwrap_or("idle");
+        format!(
+            "3D cube | cubies: {} | move: {active} | queued: {} | zoom: {:.2} | spread: {:.2}",
+            self.cubies.len(),
+            self.queued_turns.len(),
+            self.zoom,
+            self.spread
+        )
+    }
+
+    fn paint_backdrop(&self, buf: &mut Buffer) {
+        let style = Style::default().fg(Color::Indexed(8));
+        for y in self.viewport.y..self.viewport.y.saturating_add(self.viewport.height) {
+            for x in self.viewport.x..self.viewport.x.saturating_add(self.viewport.width) {
+                if let Some(cell) = buf.cell_mut((x, y)) {
+                    let shade = if (u32::from(x) + u32::from(y) * 2) % 7 == 0 {
+                        '.'
+                    } else {
+                        ' '
+                    };
+                    cell.set_char(shade).set_style(style);
+                }
+            }
+        }
+    }
+
+    fn emit_rgp_sequences(&mut self, buf: &mut Buffer, area: Rect) {
+        if area.is_empty() {
+            return;
+        }
+
+        let place_objects = self.placed_area != Some(area);
+        emit_sequence(buf, area.x, area.y, &self.cube.transform_update_sequence());
+        if place_objects {
+            emit_sequence(buf, area.x, area.y, &self.cube.graphic.place_sequence(area));
+        }
+
+        if place_objects {
+            self.placed_area = Some(area);
+        }
+    }
+
+    fn sync_scene_objects(&mut self, area: Rect) {
+        let metrics = SceneMetrics::new(area, self.zoom);
+        let view =
+            Mat3::rotation_x(self.pitch) * Mat3::rotation_y(self.yaw) * Mat3::rotation_z(self.roll);
+        self.cube
+            .apply(SceneUpdate::new(Vec3::new(0.0, 0.0, 0.0), view), &metrics);
+    }
+
+    fn handle_event(&mut self, event: Event) -> io::Result<()> {
+        match event {
+            Event::Key(key) => self.handle_key(key),
+            Event::Mouse(mouse) => self.handle_mouse(mouse),
+            Event::Resize(_, _) => {
+                self.placed_area = None;
+                self.drag_start = None;
+            }
+            _ => {}
+        }
+        Ok(())
+    }
+
+    fn handle_key(&mut self, key: KeyEvent) {
+        if !key.is_press() {
+            return;
+        }
+
+        match key.code {
+            KeyCode::Esc | KeyCode::Char('q') => self.should_quit = true,
+            KeyCode::Char(' ') => self.queue_scramble(),
+            KeyCode::Enter => self.queue_solve(),
+            KeyCode::Backspace => self.queue_undo(),
+            KeyCode::Char('0') => {
+                self.reset_cube();
+                let _ = self.register_objects();
+            }
+            KeyCode::Char('p') => {
+                self.palette = self.palette.next();
+                let _ = self.register_objects();
+            }
+            KeyCode::Char('+') | KeyCode::Char('=') => {
+                self.zoom = (self.zoom + 0.06).min(1.6);
+            }
+            KeyCode::Char('-') => {
+                self.zoom = (self.zoom - 0.06).max(0.55);
+            }
+            KeyCode::Char(']') => {
+                self.spread = (self.spread + 0.03).min(1.22);
+            }
+            KeyCode::Char('[') => {
+                self.spread = (self.spread - 0.03).max(0.86);
+            }
+            KeyCode::Left => self.yaw -= 0.12,
+            KeyCode::Right => self.yaw += 0.12,
+            KeyCode::Up => self.pitch = (self.pitch - 0.10).max(-1.35),
+            KeyCode::Down => self.pitch = (self.pitch + 0.10).min(1.35),
+            KeyCode::Char(ch) => {
+                if let Some(spec) = MoveSpec::from_char(ch) {
+                    self.queue_turn(spec, true);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    fn handle_mouse(&mut self, mouse: MouseEvent) {
+        let pos = Position::new(mouse.column, mouse.row);
+        let inside = contains(self.viewport, pos);
+        match mouse.kind {
+            MouseEventKind::Down(crossterm::event::MouseButton::Left) if inside => {
+                self.drag_start = Some(pos);
+            }
+            MouseEventKind::Drag(crossterm::event::MouseButton::Left) => {
+                let Some(previous) = self.drag_start else {
+                    self.drag_start = Some(pos);
+                    return;
+                };
+                let dx = pos.x as i32 - previous.x as i32;
+                let dy = pos.y as i32 - previous.y as i32;
+                self.yaw += dx as f32 * 0.035;
+                self.pitch = (self.pitch + dy as f32 * 0.035).clamp(-1.35, 1.35);
+                self.drag_start = Some(pos);
+            }
+            MouseEventKind::Up(crossterm::event::MouseButton::Left) => {
+                self.drag_start = None;
+            }
+            MouseEventKind::ScrollUp if inside => {
+                self.zoom = (self.zoom + 0.05).min(1.6);
+            }
+            MouseEventKind::ScrollDown if inside => {
+                self.zoom = (self.zoom - 0.05).max(0.55);
+            }
+            _ => {}
+        }
+    }
+
+    fn tick(&mut self, delta: f32) {
+        if self.active_turn.is_none() {
+            if let Some(queued) = self.queued_turns.pop_front() {
+                self.active_turn = Some(ActiveTurn {
+                    spec: queued.spec,
+                    record: queued.record,
+                    elapsed: 0.0,
+                    duration: TURN_DURATION,
+                });
+                let _ = self.register_cube_model();
+            }
+        }
+
+        let Some(turn) = self.active_turn.as_mut() else {
+            return;
+        };
+        turn.elapsed += delta;
+        let completed = if turn.elapsed < turn.duration {
+            None
+        } else {
+            Some(*turn)
+        };
+
+        if completed.is_none() {
+            let _ = self.register_cube_model();
+            return;
+        };
+
+        let completed = completed.expect("checked above");
+        self.apply_move(completed.spec);
+        if completed.record {
+            self.history.push(completed.spec);
+        }
+        self.active_turn = None;
+        let _ = self.register_cube_model();
+    }
+
+    fn queue_turn(&mut self, spec: MoveSpec, record: bool) {
+        self.queued_turns.push_back(QueuedTurn { spec, record });
+    }
+
+    fn queue_scramble(&mut self) {
+        let mut previous_axis = None;
+        let mut count = 0;
+        while count < 24 {
+            let spec = self.random_move();
+            if previous_axis == Some(spec.axis) {
+                continue;
+            }
+            previous_axis = Some(spec.axis);
+            self.queue_turn(spec, true);
+            count += 1;
+        }
+    }
+
+    fn queue_solve(&mut self) {
+        if self.history.is_empty() {
+            return;
+        }
+        let solution = self
+            .history
+            .iter()
+            .rev()
+            .map(|spec| spec.inverse())
+            .collect::<Vec<_>>();
+        self.history.clear();
+        for spec in solution {
+            self.queue_turn(spec, false);
+        }
+    }
+
+    fn queue_undo(&mut self) {
+        let Some(spec) = self.history.pop() else {
+            return;
+        };
+        self.queue_turn(spec.inverse(), false);
+    }
+
+    fn random_move(&mut self) -> MoveSpec {
+        const MOVES: [MoveSpec; 6] = [
+            MoveSpec::new(Axis::Y, 1, -1, "U"),
+            MoveSpec::new(Axis::Y, -1, 1, "D"),
+            MoveSpec::new(Axis::X, 1, -1, "R"),
+            MoveSpec::new(Axis::X, -1, 1, "L"),
+            MoveSpec::new(Axis::Z, 1, -1, "F"),
+            MoveSpec::new(Axis::Z, -1, 1, "B"),
+        ];
+        self.rng = self.rng.wrapping_mul(1_664_525).wrapping_add(1_013_904_223);
+        let mut spec = MOVES[(self.rng as usize >> 16) % MOVES.len()];
+        if self.rng & 1 == 1 {
+            spec = spec.inverse();
+        }
+        spec
+    }
+
+    fn apply_move(&mut self, spec: MoveSpec) {
+        for cubie in &mut self.cubies {
+            if !spec.includes(cubie.pos) {
+                continue;
+            }
+            cubie.pos = cubie.pos.rotate(spec.axis, spec.dir);
+            cubie.orientation =
+                Mat3::from_axis(spec.axis, spec.dir as f32 * std::f32::consts::FRAC_PI_2)
+                    * cubie.orientation;
+        }
+    }
+}
+
+struct SceneObject {
+    graphic: RattyGraphic<'static>,
+}
+
+impl SceneObject {
+    fn new_cube(id: u32) -> Self {
+        let settings = RattyGraphicSettings::new(format!("rubiks-{id}.glb"))
+            .id(id)
+            .format(ObjectFormat::Glb)
+            .animate(false)
+            .brightness(1.0)
+            .depth(0.0);
+        Self {
+            graphic: RattyGraphic::new(settings),
+        }
+    }
+
+    fn apply(&mut self, update: SceneUpdate, metrics: &SceneMetrics) {
+        let settings = self.graphic.settings_mut();
+        settings.animate = false;
+        settings.depth = 0.0;
+        settings.rotation = update.rotation.to_euler_degrees();
+        settings.offset = [
+            update.position.x * metrics.unit,
+            update.position.y * metrics.unit,
+            metrics.unit * BASE_Z_UNITS + update.position.z * metrics.unit,
+        ];
+        settings.color = None;
+        settings.brightness = 1.0;
+        settings.scale = metrics.object_scale;
+        settings.scale3 = [1.0, 1.0, 1.0];
+    }
+
+    fn transform_update_sequence(&self) -> String {
+        let settings = self.graphic.settings();
+        format!(
+            "\x1b_ratty;g;u;id={};animate={};scale={};px={};py={};pz={};rx={};ry={};rz={};sx={};sy={};sz={}\x1b\\",
+            settings.id,
+            u8::from(settings.animate),
+            settings.scale,
+            settings.offset[0],
+            settings.offset[1],
+            settings.offset[2],
+            settings.rotation[0],
+            settings.rotation[1],
+            settings.rotation[2],
+            settings.scale3[0],
+            settings.scale3[1],
+            settings.scale3[2],
+        )
+    }
+}
+
+struct SceneMetrics {
+    unit: f32,
+    object_scale: f32,
+}
+
+impl SceneMetrics {
+    fn new(area: Rect, zoom: f32) -> Self {
+        let (cell_width, cell_height) = terminal_cell_pixels();
+        let base_scale = (area.width.max(1) as f32 * cell_width)
+            .max(area.height.max(1) as f32 * cell_height)
+            * 0.9;
+        let object_scale = BODY_SCALE * zoom;
+        Self {
+            unit: base_scale * object_scale,
+            object_scale,
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+struct SceneUpdate {
+    position: Vec3,
+    rotation: Mat3,
+}
+
+impl SceneUpdate {
+    fn new(position: Vec3, rotation: Mat3) -> Self {
+        Self { position, rotation }
+    }
+}
+
+#[derive(Clone)]
+struct Cubie {
+    pos: Vec3i,
+    orientation: Mat3,
+    stickers: Vec<Sticker>,
+}
+
+impl Cubie {
+    fn new(pos: Vec3i, stickers: Vec<Sticker>) -> Self {
+        Self {
+            pos,
+            orientation: Mat3::IDENTITY,
+            stickers,
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+struct Sticker {
+    normal: Vec3i,
+    face: Face,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Face {
+    Up,
+    Down,
+    Front,
+    Back,
+    Right,
+    Left,
+}
+
+#[derive(Clone, Copy)]
+enum Palette {
+    Classic,
+    Pastel,
+}
+
+impl Palette {
+    fn next(self) -> Self {
+        match self {
+            Self::Classic => Self::Pastel,
+            Self::Pastel => Self::Classic,
+        }
+    }
+
+    fn name(self) -> &'static str {
+        match self {
+            Self::Classic => "classic",
+            Self::Pastel => "pastel",
+        }
+    }
+
+    fn color(self, face: Face) -> [u8; 3] {
+        match self {
+            Self::Classic => match face {
+                Face::Up => [242, 242, 242],
+                Face::Down => [255, 213, 0],
+                Face::Front => [0, 155, 72],
+                Face::Back => [0, 70, 173],
+                Face::Right => [183, 18, 52],
+                Face::Left => [255, 88, 0],
+            },
+            Self::Pastel => match face {
+                Face::Up => [245, 236, 226],
+                Face::Down => [231, 201, 103],
+                Face::Front => [142, 204, 161],
+                Face::Back => [135, 161, 213],
+                Face::Right => [211, 128, 87],
+                Face::Left => [190, 139, 183],
+            },
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+struct ActiveTurn {
+    spec: MoveSpec,
+    record: bool,
+    elapsed: f32,
+    duration: f32,
+}
+
+#[derive(Clone, Copy)]
+struct QueuedTurn {
+    spec: MoveSpec,
+    record: bool,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+struct MoveSpec {
+    axis: Axis,
+    layer: i8,
+    dir: i8,
+    label: &'static str,
+}
+
+impl MoveSpec {
+    const fn new(axis: Axis, layer: i8, dir: i8, label: &'static str) -> Self {
+        Self {
+            axis,
+            layer,
+            dir,
+            label,
+        }
+    }
+
+    fn from_char(ch: char) -> Option<Self> {
+        let inverse = ch.is_ascii_uppercase();
+        let base = match ch.to_ascii_lowercase() {
+            'u' => Self::new(Axis::Y, 1, -1, "U"),
+            'd' => Self::new(Axis::Y, -1, 1, "D"),
+            'r' => Self::new(Axis::X, 1, -1, "R"),
+            'l' => Self::new(Axis::X, -1, 1, "L"),
+            'f' => Self::new(Axis::Z, 1, -1, "F"),
+            'b' => Self::new(Axis::Z, -1, 1, "B"),
+            _ => return None,
+        };
+        Some(if inverse { base.inverse() } else { base })
+    }
+
+    fn inverse(self) -> Self {
+        Self {
+            dir: -self.dir,
+            label: match self.label {
+                "U" => "U'",
+                "D" => "D'",
+                "R" => "R'",
+                "L" => "L'",
+                "F" => "F'",
+                "B" => "B'",
+                "U'" => "U",
+                "D'" => "D",
+                "R'" => "R",
+                "L'" => "L",
+                "F'" => "F",
+                "B'" => "B",
+                _ => self.label,
+            },
+            ..self
+        }
+    }
+
+    fn includes(self, pos: Vec3i) -> bool {
+        match self.axis {
+            Axis::X => pos.x == self.layer,
+            Axis::Y => pos.y == self.layer,
+            Axis::Z => pos.z == self.layer,
+        }
+    }
+
+    fn label(self) -> &'static str {
+        self.label
+    }
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Axis {
+    X,
+    Y,
+    Z,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+struct Vec3i {
+    x: i8,
+    y: i8,
+    z: i8,
+}
+
+impl Vec3i {
+    const fn new(x: i8, y: i8, z: i8) -> Self {
+        Self { x, y, z }
+    }
+
+    fn rotate(self, axis: Axis, dir: i8) -> Self {
+        match (axis, dir.signum()) {
+            (Axis::X, 1) => Self::new(self.x, -self.z, self.y),
+            (Axis::X, -1) => Self::new(self.x, self.z, -self.y),
+            (Axis::Y, 1) => Self::new(self.z, self.y, -self.x),
+            (Axis::Y, -1) => Self::new(-self.z, self.y, self.x),
+            (Axis::Z, 1) => Self::new(-self.y, self.x, self.z),
+            (Axis::Z, -1) => Self::new(self.y, -self.x, self.z),
+            _ => self,
+        }
+    }
+
+    fn to_vec3(self) -> Vec3 {
+        Vec3::new(self.x as f32, self.y as f32, self.z as f32)
+    }
+}
+
+#[derive(Clone, Copy, Default)]
+struct Vec3 {
+    x: f32,
+    y: f32,
+    z: f32,
+}
+
+impl Vec3 {
+    const fn new(x: f32, y: f32, z: f32) -> Self {
+        Self { x, y, z }
+    }
+
+    fn to_array(self) -> [f32; 3] {
+        [self.x, self.y, self.z]
+    }
+}
+
+impl std::ops::Add for Vec3 {
+    type Output = Self;
+
+    fn add(self, rhs: Self) -> Self::Output {
+        Self::new(self.x + rhs.x, self.y + rhs.y, self.z + rhs.z)
+    }
+}
+
+impl std::ops::Mul<f32> for Vec3 {
+    type Output = Self;
+
+    fn mul(self, rhs: f32) -> Self::Output {
+        Self::new(self.x * rhs, self.y * rhs, self.z * rhs)
+    }
+}
+
+#[derive(Clone, Copy)]
+struct Mat3 {
+    m: [[f32; 3]; 3],
+}
+
+impl Mat3 {
+    const IDENTITY: Self = Self {
+        m: [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]],
+    };
+
+    fn rotation_x(angle: f32) -> Self {
+        let (sin, cos) = angle.sin_cos();
+        Self {
+            m: [[1.0, 0.0, 0.0], [0.0, cos, -sin], [0.0, sin, cos]],
+        }
+    }
+
+    fn rotation_y(angle: f32) -> Self {
+        let (sin, cos) = angle.sin_cos();
+        Self {
+            m: [[cos, 0.0, sin], [0.0, 1.0, 0.0], [-sin, 0.0, cos]],
+        }
+    }
+
+    fn rotation_z(angle: f32) -> Self {
+        let (sin, cos) = angle.sin_cos();
+        Self {
+            m: [[cos, -sin, 0.0], [sin, cos, 0.0], [0.0, 0.0, 1.0]],
+        }
+    }
+
+    fn from_axis(axis: Axis, angle: f32) -> Self {
+        match axis {
+            Axis::X => Self::rotation_x(angle),
+            Axis::Y => Self::rotation_y(angle),
+            Axis::Z => Self::rotation_z(angle),
+        }
+    }
+
+    fn transform_vec(self, vec: Vec3) -> Vec3 {
+        Vec3::new(
+            self.m[0][0] * vec.x + self.m[0][1] * vec.y + self.m[0][2] * vec.z,
+            self.m[1][0] * vec.x + self.m[1][1] * vec.y + self.m[1][2] * vec.z,
+            self.m[2][0] * vec.x + self.m[2][1] * vec.y + self.m[2][2] * vec.z,
+        )
+    }
+
+    fn to_euler_degrees(self) -> [f32; 3] {
+        let cy = (self.m[0][0] * self.m[0][0] + self.m[0][1] * self.m[0][1]).sqrt();
+        let (x, y, z) = if cy > 16.0 * f32::EPSILON {
+            (
+                -self.m[1][2].atan2(self.m[2][2]),
+                self.m[0][2].atan2(cy),
+                -self.m[0][1].atan2(self.m[0][0]),
+            )
+        } else {
+            (
+                self.m[1][0].atan2(self.m[1][1]),
+                self.m[0][2].atan2(cy),
+                0.0,
+            )
+        };
+        [x.to_degrees(), y.to_degrees(), z.to_degrees()]
+    }
+}
+
+impl std::ops::Mul for Mat3 {
+    type Output = Self;
+
+    fn mul(self, rhs: Self) -> Self::Output {
+        let mut m = [[0.0; 3]; 3];
+        for (row, values) in m.iter_mut().enumerate() {
+            for (col, value) in values.iter_mut().enumerate() {
+                *value = self.m[row][0] * rhs.m[0][col]
+                    + self.m[row][1] * rhs.m[1][col]
+                    + self.m[row][2] * rhs.m[2][col];
+            }
+        }
+        Self { m }
+    }
+}
+
+fn exposed_faces(pos: Vec3i) -> Vec<(Vec3i, Face)> {
+    let mut faces = Vec::new();
+    if pos.y == 1 {
+        faces.push((Vec3i::new(0, 1, 0), Face::Up));
+    }
+    if pos.y == -1 {
+        faces.push((Vec3i::new(0, -1, 0), Face::Down));
+    }
+    if pos.z == 1 {
+        faces.push((Vec3i::new(0, 0, 1), Face::Front));
+    }
+    if pos.z == -1 {
+        faces.push((Vec3i::new(0, 0, -1), Face::Back));
+    }
+    if pos.x == 1 {
+        faces.push((Vec3i::new(1, 0, 0), Face::Right));
+    }
+    if pos.x == -1 {
+        faces.push((Vec3i::new(-1, 0, 0), Face::Left));
+    }
+    faces
+}
+
+fn cube_glb(cubies: &[Cubie], palette: Palette, active: Option<(MoveSpec, Mat3)>) -> Vec<u8> {
+    let sticker_count = cubies.iter().map(|cubie| cubie.stickers.len()).sum::<usize>();
+    let mut primitives = Vec::with_capacity(cubies.len() + sticker_count);
+
+    for cubie in cubies {
+        let turn_matrix = active
+            .filter(|(spec, _)| spec.includes(cubie.pos))
+            .map(|(_, matrix)| matrix)
+            .unwrap_or(Mat3::IDENTITY);
+        let center = turn_matrix.transform_vec(cubie.pos.to_vec3() * CUBIE_SPACING);
+        let rotation = turn_matrix * cubie.orientation;
+        primitives.push(cuboid_primitive(
+            center,
+            Vec3::new(0.49, 0.49, 0.49),
+            0,
+            rotation,
+        ));
+
+        for sticker in &cubie.stickers {
+            let (local_center, half) = sticker_box(sticker.normal);
+            primitives.push(cuboid_primitive(
+                center + rotation.transform_vec(local_center),
+                half,
+                sticker.face.material_index(),
+                rotation,
+            ));
+        }
+    }
+
+    build_glb(&primitives, palette)
+}
+
+fn cube_asset_path(revision: u32, palette: Palette) -> io::Result<PathBuf> {
+    let dir = std::env::temp_dir().join("ratty-rubiks-cube");
+    fs::create_dir_all(&dir)?;
+    Ok(dir.join(format!(
+        "rubiks-cube-v4-{}-{revision}.glb",
+        palette.name()
+    )))
+}
+
+#[derive(Clone)]
+struct MeshPrimitive {
+    positions: Vec<[f32; 3]>,
+    normals: Vec<[f32; 3]>,
+    indices: Vec<u16>,
+    material: usize,
+}
+
+#[derive(Clone, Copy)]
+struct PrimitiveAccessors {
+    position: usize,
+    normal: usize,
+    indices: usize,
+    material: usize,
+}
+
+#[derive(Clone, Copy)]
+struct BufferViewInfo {
+    offset: usize,
+    length: usize,
+    target: u32,
+}
+
+enum AccessorInfo {
+    Positions {
+        view: usize,
+        count: usize,
+        min: [f32; 3],
+        max: [f32; 3],
+    },
+    Normals {
+        view: usize,
+        count: usize,
+    },
+    Indices {
+        view: usize,
+        count: usize,
+    },
+}
+
+impl Face {
+    fn material_index(self) -> usize {
+        match self {
+            Self::Up => 1,
+            Self::Down => 2,
+            Self::Front => 3,
+            Self::Back => 4,
+            Self::Right => 5,
+            Self::Left => 6,
+        }
+    }
+
+    fn name(self) -> &'static str {
+        match self {
+            Self::Up => "up",
+            Self::Down => "down",
+            Self::Front => "front",
+            Self::Back => "back",
+            Self::Right => "right",
+            Self::Left => "left",
+        }
+    }
+}
+
+fn sticker_box(normal: Vec3i) -> (Vec3, Vec3) {
+    let face = 0.34;
+    let thickness = 0.018;
+    let lift = 0.516;
+    match (normal.x, normal.y, normal.z) {
+        (1, 0, 0) => (Vec3::new(lift, 0.0, 0.0), Vec3::new(thickness, face, face)),
+        (-1, 0, 0) => (Vec3::new(-lift, 0.0, 0.0), Vec3::new(thickness, face, face)),
+        (0, 1, 0) => (Vec3::new(0.0, lift, 0.0), Vec3::new(face, thickness, face)),
+        (0, -1, 0) => (Vec3::new(0.0, -lift, 0.0), Vec3::new(face, thickness, face)),
+        (0, 0, -1) => (Vec3::new(0.0, 0.0, -lift), Vec3::new(face, face, thickness)),
+        _ => (Vec3::new(0.0, 0.0, lift), Vec3::new(face, face, thickness)),
+    }
+}
+
+fn cuboid_primitive(center: Vec3, half: Vec3, material: usize, rotation: Mat3) -> MeshPrimitive {
+    let faces = [
+        (
+            Vec3::new(0.0, 0.0, 1.0),
+            [
+                Vec3::new(-half.x, -half.y, half.z),
+                Vec3::new(half.x, -half.y, half.z),
+                Vec3::new(half.x, half.y, half.z),
+                Vec3::new(-half.x, half.y, half.z),
+            ],
+        ),
+        (
+            Vec3::new(0.0, 0.0, -1.0),
+            [
+                Vec3::new(half.x, -half.y, -half.z),
+                Vec3::new(-half.x, -half.y, -half.z),
+                Vec3::new(-half.x, half.y, -half.z),
+                Vec3::new(half.x, half.y, -half.z),
+            ],
+        ),
+        (
+            Vec3::new(1.0, 0.0, 0.0),
+            [
+                Vec3::new(half.x, -half.y, half.z),
+                Vec3::new(half.x, -half.y, -half.z),
+                Vec3::new(half.x, half.y, -half.z),
+                Vec3::new(half.x, half.y, half.z),
+            ],
+        ),
+        (
+            Vec3::new(-1.0, 0.0, 0.0),
+            [
+                Vec3::new(-half.x, -half.y, -half.z),
+                Vec3::new(-half.x, -half.y, half.z),
+                Vec3::new(-half.x, half.y, half.z),
+                Vec3::new(-half.x, half.y, -half.z),
+            ],
+        ),
+        (
+            Vec3::new(0.0, 1.0, 0.0),
+            [
+                Vec3::new(-half.x, half.y, half.z),
+                Vec3::new(half.x, half.y, half.z),
+                Vec3::new(half.x, half.y, -half.z),
+                Vec3::new(-half.x, half.y, -half.z),
+            ],
+        ),
+        (
+            Vec3::new(0.0, -1.0, 0.0),
+            [
+                Vec3::new(-half.x, -half.y, -half.z),
+                Vec3::new(half.x, -half.y, -half.z),
+                Vec3::new(half.x, -half.y, half.z),
+                Vec3::new(-half.x, -half.y, half.z),
+            ],
+        ),
+    ];
+
+    let mut positions = Vec::with_capacity(24);
+    let mut normals = Vec::with_capacity(24);
+    let mut indices = Vec::with_capacity(36);
+    for (normal, corners) in faces {
+        let base = positions.len() as u16;
+        for corner in corners {
+            positions.push((center + rotation.transform_vec(corner)).to_array());
+        }
+        let normal = rotation.transform_vec(normal).to_array();
+        for _ in 0..4 {
+            normals.push(normal);
+        }
+        indices.extend_from_slice(&[base, base + 1, base + 2, base, base + 2, base + 3]);
+    }
+
+    MeshPrimitive {
+        positions,
+        normals,
+        indices,
+        material,
+    }
+}
+
+fn build_glb(primitives: &[MeshPrimitive], palette: Palette) -> Vec<u8> {
+    let mut bin = Vec::new();
+    let mut views = Vec::new();
+    let mut accessors = Vec::new();
+    let mut primitive_accessors = Vec::new();
+
+    for primitive in primitives {
+        let (position_view, min, max) =
+            push_vec3_buffer(&mut bin, &mut views, &primitive.positions, ARRAY_BUFFER);
+        let position_accessor = accessors.len();
+        accessors.push(AccessorInfo::Positions {
+            view: position_view,
+            count: primitive.positions.len(),
+            min,
+            max,
+        });
+
+        let (normal_view, _, _) =
+            push_vec3_buffer(&mut bin, &mut views, &primitive.normals, ARRAY_BUFFER);
+        let normal_accessor = accessors.len();
+        accessors.push(AccessorInfo::Normals {
+            view: normal_view,
+            count: primitive.normals.len(),
+        });
+
+        let index_view = push_u16_buffer(
+            &mut bin,
+            &mut views,
+            &primitive.indices,
+            ELEMENT_ARRAY_BUFFER,
+        );
+        let index_accessor = accessors.len();
+        accessors.push(AccessorInfo::Indices {
+            view: index_view,
+            count: primitive.indices.len(),
+        });
+
+        primitive_accessors.push(PrimitiveAccessors {
+            position: position_accessor,
+            normal: normal_accessor,
+            indices: index_accessor,
+            material: primitive.material,
+        });
+    }
+
+    align4(&mut bin, 0);
+    let mut json = gltf_json(&views, &accessors, &primitive_accessors, palette).into_bytes();
+    align4(&mut json, b' ');
+
+    let total_len = 12 + 8 + json.len() + 8 + bin.len();
+    let mut glb = Vec::with_capacity(total_len);
+    glb.extend_from_slice(b"glTF");
+    glb.extend_from_slice(&2u32.to_le_bytes());
+    glb.extend_from_slice(&(total_len as u32).to_le_bytes());
+    glb.extend_from_slice(&(json.len() as u32).to_le_bytes());
+    glb.extend_from_slice(&GLB_JSON_CHUNK.to_le_bytes());
+    glb.extend_from_slice(&json);
+    glb.extend_from_slice(&(bin.len() as u32).to_le_bytes());
+    glb.extend_from_slice(&GLB_BIN_CHUNK.to_le_bytes());
+    glb.extend_from_slice(&bin);
+    glb
+}
+
+fn push_vec3_buffer(
+    bin: &mut Vec<u8>,
+    views: &mut Vec<BufferViewInfo>,
+    values: &[[f32; 3]],
+    target: u32,
+) -> (usize, [f32; 3], [f32; 3]) {
+    align4(bin, 0);
+    let offset = bin.len();
+    let mut min = [f32::INFINITY; 3];
+    let mut max = [f32::NEG_INFINITY; 3];
+    for value in values {
+        for index in 0..3 {
+            min[index] = min[index].min(value[index]);
+            max[index] = max[index].max(value[index]);
+            bin.extend_from_slice(&value[index].to_le_bytes());
+        }
+    }
+    let length = bin.len() - offset;
+    let view = views.len();
+    views.push(BufferViewInfo {
+        offset,
+        length,
+        target,
+    });
+    (view, min, max)
+}
+
+fn push_u16_buffer(
+    bin: &mut Vec<u8>,
+    views: &mut Vec<BufferViewInfo>,
+    values: &[u16],
+    target: u32,
+) -> usize {
+    align4(bin, 0);
+    let offset = bin.len();
+    for value in values {
+        bin.extend_from_slice(&value.to_le_bytes());
+    }
+    let length = bin.len() - offset;
+    let view = views.len();
+    views.push(BufferViewInfo {
+        offset,
+        length,
+        target,
+    });
+    view
+}
+
+fn gltf_json(
+    views: &[BufferViewInfo],
+    accessors: &[AccessorInfo],
+    primitives: &[PrimitiveAccessors],
+    palette: Palette,
+) -> String {
+    let bin_len = views
+        .iter()
+        .map(|view| view.offset + view.length)
+        .max()
+        .unwrap_or(0);
+    let mut json = String::new();
+    json.push_str("{\"asset\":{\"version\":\"2.0\",\"generator\":\"ratty-rubiks-cube\"},");
+    json.push_str("\"scene\":0,\"scenes\":[{\"nodes\":[0]}],\"nodes\":[{\"mesh\":0}],");
+    json.push_str("\"meshes\":[{\"primitives\":[");
+    for (index, primitive) in primitives.iter().enumerate() {
+        if index > 0 {
+            json.push(',');
+        }
+        json.push_str(&format!(
+            "{{\"attributes\":{{\"POSITION\":{},\"NORMAL\":{}}},\"indices\":{},\"material\":{}}}",
+            primitive.position, primitive.normal, primitive.indices, primitive.material
+        ));
+    }
+    json.push_str("]}],\"materials\":[");
+    for (index, material) in material_defs(palette).iter().enumerate() {
+        if index > 0 {
+            json.push(',');
+        }
+        json.push_str(&material_json(material));
+    }
+    json.push_str("],\"buffers\":[{\"byteLength\":");
+    json.push_str(&bin_len.to_string());
+    json.push_str("}],\"bufferViews\":[");
+    for (index, view) in views.iter().enumerate() {
+        if index > 0 {
+            json.push(',');
+        }
+        json.push_str(&format!(
+            "{{\"buffer\":0,\"byteOffset\":{},\"byteLength\":{},\"target\":{}}}",
+            view.offset, view.length, view.target
+        ));
+    }
+    json.push_str("],\"accessors\":[");
+    for (index, accessor) in accessors.iter().enumerate() {
+        if index > 0 {
+            json.push(',');
+        }
+        json.push_str(&accessor_json(accessor));
+    }
+    json.push_str("]}");
+    json
+}
+
+struct MaterialDef {
+    name: &'static str,
+    color: [u8; 3],
+    roughness: f32,
+}
+
+fn material_defs(palette: Palette) -> [MaterialDef; 7] {
+    [
+        MaterialDef {
+            name: "body",
+            color: [14, 15, 18],
+            roughness: 0.68,
+        },
+        face_material(Face::Up, palette),
+        face_material(Face::Down, palette),
+        face_material(Face::Front, palette),
+        face_material(Face::Back, palette),
+        face_material(Face::Right, palette),
+        face_material(Face::Left, palette),
+    ]
+}
+
+fn face_material(face: Face, palette: Palette) -> MaterialDef {
+    MaterialDef {
+        name: face.name(),
+        color: palette.color(face),
+        roughness: 0.46,
+    }
+}
+
+fn material_json(material: &MaterialDef) -> String {
+    let [r, g, b] = material.color;
+    format!(
+        "{{\"name\":\"{}\",\"doubleSided\":true,\"pbrMetallicRoughness\":{{\"baseColorFactor\":[{:.4},{:.4},{:.4},1.0],\"metallicFactor\":0.0,\"roughnessFactor\":{:.3}}}}}",
+        material.name,
+        f32::from(r) / 255.0,
+        f32::from(g) / 255.0,
+        f32::from(b) / 255.0,
+        material.roughness,
+    )
+}
+
+fn accessor_json(accessor: &AccessorInfo) -> String {
+    match accessor {
+        AccessorInfo::Positions {
+            view,
+            count,
+            min,
+            max,
+        } => format!(
+            "{{\"bufferView\":{},\"componentType\":{},\"count\":{},\"type\":\"VEC3\",\"min\":[{:.4},{:.4},{:.4}],\"max\":[{:.4},{:.4},{:.4}]}}",
+            view, COMPONENT_F32, count, min[0], min[1], min[2], max[0], max[1], max[2],
+        ),
+        AccessorInfo::Normals { view, count } => format!(
+            "{{\"bufferView\":{},\"componentType\":{},\"count\":{},\"type\":\"VEC3\"}}",
+            view, COMPONENT_F32, count
+        ),
+        AccessorInfo::Indices { view, count } => format!(
+            "{{\"bufferView\":{},\"componentType\":{},\"count\":{},\"type\":\"SCALAR\"}}",
+            view, COMPONENT_U16, count
+        ),
+    }
+}
+
+fn align4(bytes: &mut Vec<u8>, fill: u8) {
+    while bytes.len() % 4 != 0 {
+        bytes.push(fill);
+    }
+}
+
+fn terminal_cell_pixels() -> (f32, f32) {
+    let Ok(size) = window_size() else {
+        return (9.0, 18.0);
+    };
+    let width = if size.columns > 0 && size.width > 0 {
+        f32::from(size.width) / f32::from(size.columns)
+    } else {
+        9.0
+    };
+    let height = if size.rows > 0 && size.height > 0 {
+        f32::from(size.height) / f32::from(size.rows)
+    } else {
+        18.0
+    };
+    (width.max(1.0), height.max(1.0))
+}
+
+fn centered_cube_area(bounds: Rect) -> Rect {
+    if bounds.is_empty() {
+        return bounds;
+    }
+    let width = bounds.width.saturating_sub(2).min(56).max(1);
+    let height = bounds.height.saturating_sub(2).min(24).max(1);
+    bounds.centered(Constraint::Length(width), Constraint::Length(height))
+}
+
+fn contains(area: Rect, position: Position) -> bool {
+    position.x >= area.x
+        && position.x < area.x.saturating_add(area.width)
+        && position.y >= area.y
+        && position.y < area.y.saturating_add(area.height)
+}
+
+fn emit_sequence(buf: &mut Buffer, x: u16, y: u16, sequence: &str) {
+    let Some(cell) = buf.cell_mut((x, y)) else {
+        return;
+    };
+    let existing = cell.symbol();
+    let mut symbol = String::with_capacity(sequence.len() + existing.len());
+    symbol.push_str(sequence);
+    symbol.push_str(existing);
+    cell.set_symbol(&symbol);
+}
+
+fn clear_demo_objects() -> io::Result<()> {
+    let mut stdout = io::stdout();
+    for id in 900..980 {
+        stdout.write_all(format!("\x1b_ratty;g;d;id={id}\x1b\\").as_bytes())?;
+    }
+    stdout.flush()
+}
+
+fn smoothstep(t: f32) -> f32 {
+    t * t * (3.0 - 2.0 * t)
+}

--- a/widget/examples/rubiks_cube.rs
+++ b/widget/examples/rubiks_cube.rs
@@ -2,7 +2,7 @@ use std::{
     borrow::Cow,
     collections::VecDeque,
     fs,
-    io::{self, Write},
+    io,
     path::PathBuf,
     time::{Duration, Instant},
 };
@@ -58,7 +58,7 @@ struct RubiksApp {
 
 impl RubiksApp {
     fn new() -> io::Result<Self> {
-        clear_demo_objects()?;
+        RattyGraphic::clear_all()?;
         let mut app = Self {
             cube: RubiksCube::new(),
             object: SceneObject::new_cube(900),
@@ -528,9 +528,7 @@ impl SceneObject {
     }
 
     fn clear(&self) -> io::Result<()> {
-        let mut stdout = io::stdout();
-        stdout.write_all(self.graphic.delete_sequence().as_bytes())?;
-        stdout.flush()
+        self.graphic.clear()
     }
 
     fn asset_path(&self) -> io::Result<PathBuf> {
@@ -1116,12 +1114,4 @@ fn emit_sequence(buf: &mut Buffer, x: u16, y: u16, sequence: &str) {
     symbol.push_str(sequence);
     symbol.push_str(existing);
     cell.set_symbol(&symbol);
-}
-
-fn clear_demo_objects() -> io::Result<()> {
-    let mut stdout = io::stdout();
-    for id in 900..980 {
-        stdout.write_all(format!("\x1b_ratty;g;d;id={id}\x1b\\").as_bytes())?;
-    }
-    stdout.flush()
 }

--- a/widget/examples/rubiks_cube.rs
+++ b/widget/examples/rubiks_cube.rs
@@ -27,7 +27,7 @@ use ratatui_ratty::{ObjectFormat, RattyGraphic, RattyGraphicSettings};
 
 const TICK: Duration = Duration::from_millis(33);
 const TURN_DURATION: f32 = 0.26;
-const BODY_SCALE: f32 = 0.46;
+const BODY_SCALE: f32 = 0.10;
 const CUBIE_SPACING: f32 = 1.04;
 const BASE_Z_UNITS: f32 = 2.7;
 
@@ -1027,7 +1027,7 @@ fn cuboid_primitive(center: Vec3, half: Vec3, color: [u8; 3], rotation: Mat3) ->
 }
 
 fn build_obj(primitives: &[MeshPrimitive]) -> String {
-    let mut obj = String::from("# ratty-rubiks-cube\n");
+    let mut obj = String::from("# ratty:preserve-transform\n# ratty-rubiks-cube\n");
     let mut vertex_offset = 1usize;
     let mut normal_offset = 1usize;
     for primitive in primitives {

--- a/widget/examples/rubiks_cube.rs
+++ b/widget/examples/rubiks_cube.rs
@@ -139,11 +139,10 @@ impl RubiksApp {
 
     fn status(&self) -> String {
         format!(
-            "3D cube | cubies: {} | move: {active} | queued: {} | zoom: {:.2} | spread: {:.2}",
+            "3D cube | cubies: {} | move: {active} | queued: {} | zoom: {:.2}",
             self.cube.cubie_count(),
             self.cube.queued_count(),
             self.view.zoom,
-            self.view.spread,
             active = self.cube.active_label(),
         )
     }
@@ -214,16 +213,10 @@ impl RubiksApp {
                 let _ = self.object.register_cube(&self.cube);
             }
             KeyCode::Char('+') | KeyCode::Char('=') => {
-                self.view.zoom = (self.view.zoom + 0.06).min(1.6);
+                self.view.zoom += 0.06;
             }
             KeyCode::Char('-') => {
-                self.view.zoom = (self.view.zoom - 0.06).max(0.55);
-            }
-            KeyCode::Char(']') => {
-                self.view.spread = (self.view.spread + 0.03).min(1.22);
-            }
-            KeyCode::Char('[') => {
-                self.view.spread = (self.view.spread - 0.03).max(0.86);
+                self.view.zoom -= 0.06;
             }
             KeyCode::Left => self.view.yaw -= 0.12,
             KeyCode::Right => self.view.yaw += 0.12,
@@ -263,10 +256,10 @@ impl RubiksApp {
                 self.drag_start = None;
             }
             MouseEventKind::ScrollUp if inside => {
-                self.view.zoom = (self.view.zoom + 0.05).min(1.6);
+                self.view.zoom += 0.05;
             }
             MouseEventKind::ScrollDown if inside => {
-                self.view.zoom = (self.view.zoom - 0.05).max(0.55);
+                self.view.zoom -= 0.05;
             }
             _ => {}
         }
@@ -453,7 +446,6 @@ struct SceneView {
     pitch: f32,
     roll: f32,
     zoom: f32,
-    spread: f32,
     placed_area: Option<Rect>,
 }
 
@@ -464,7 +456,6 @@ impl SceneView {
             pitch: -0.42,
             roll: 0.0,
             zoom: 1.0,
-            spread: 1.0,
             placed_area: None,
         }
     }

--- a/widget/examples/rubiks_cube.rs
+++ b/widget/examples/rubiks_cube.rs
@@ -48,21 +48,10 @@ fn run(terminal: &mut DefaultTerminal) -> io::Result<()> {
 }
 
 struct RubiksApp {
-    cubies: Vec<Cubie>,
-    cube: SceneObject,
-    active_turn: Option<ActiveTurn>,
-    queued_turns: VecDeque<QueuedTurn>,
-    history: Vec<MoveSpec>,
-    rng: u32,
-    model_revision: u32,
-    palette: Palette,
-    yaw: f32,
-    pitch: f32,
-    roll: f32,
-    zoom: f32,
-    spread: f32,
+    cube: RubiksCube,
+    object: SceneObject,
+    view: SceneView,
     viewport: Rect,
-    placed_area: Option<Rect>,
     drag_start: Option<Position>,
     should_quit: bool,
 }
@@ -71,26 +60,14 @@ impl RubiksApp {
     fn new() -> io::Result<Self> {
         clear_demo_objects()?;
         let mut app = Self {
-            cubies: Vec::new(),
-            cube: SceneObject::new_cube(900),
-            active_turn: None,
-            queued_turns: VecDeque::new(),
-            history: Vec::new(),
-            rng: 0x516f_6f74,
-            model_revision: 0,
-            palette: Palette::Classic,
-            yaw: -0.58,
-            pitch: -0.42,
-            roll: 0.0,
-            zoom: 1.0,
-            spread: 1.0,
+            cube: RubiksCube::new(),
+            object: SceneObject::new_cube(900),
+            view: SceneView::new(),
             viewport: Rect::default(),
-            placed_area: None,
             drag_start: None,
             should_quit: false,
         };
-        app.reset_cube();
-        app.register_objects()?;
+        app.object.register_cube(&app.cube)?;
         Ok(app)
     }
 
@@ -114,61 +91,8 @@ impl RubiksApp {
         Ok(())
     }
 
-    fn reset_cube(&mut self) {
-        self.cubies.clear();
-        self.cube = SceneObject::new_cube(900);
-        self.active_turn = None;
-        self.queued_turns.clear();
-        self.history.clear();
-        self.placed_area = None;
-
-        for x in -1..=1 {
-            for y in -1..=1 {
-                for z in -1..=1 {
-                    if x == 0 && y == 0 && z == 0 {
-                        continue;
-                    }
-
-                    let pos = Vec3i::new(x, y, z);
-                    let mut stickers = Vec::new();
-                    for (normal, face) in exposed_faces(pos) {
-                        stickers.push(Sticker { normal, face });
-                    }
-
-                    self.cubies.push(Cubie::new(pos, stickers));
-                }
-            }
-        }
-    }
-
-    fn register_objects(&mut self) -> io::Result<()> {
-        self.register_cube_model()
-    }
-
-    fn register_cube_model(&mut self) -> io::Result<()> {
-        self.model_revision = self.model_revision.wrapping_add(1);
-        let active = self.active_turn.as_ref().map(|turn| {
-            let progress = smoothstep((turn.elapsed / turn.duration).clamp(0.0, 1.0));
-            (
-                turn.spec,
-                Mat3::from_axis(
-                    turn.spec.axis,
-                    turn.spec.dir as f32 * progress * std::f32::consts::FRAC_PI_2,
-                ),
-            )
-        });
-        let payload = cube_obj(&self.cubies, self.palette, active);
-        let path = cube_asset_path(self.model_revision, self.palette)?;
-        fs::write(&path, payload)?;
-        self.cube.graphic.settings_mut().path = Cow::Owned(path.to_string_lossy().into_owned());
-        self.cube.graphic.register()?;
-        Ok(())
-    }
-
     fn clear(&self) -> io::Result<()> {
-        let mut stdout = io::stdout();
-        stdout.write_all(self.cube.graphic.delete_sequence().as_bytes())?;
-        stdout.flush()
+        self.object.clear()
     }
 
     fn render(&mut self, frame: &mut Frame<'_>) {
@@ -192,13 +116,11 @@ impl RubiksApp {
             Span::raw(": scramble  "),
             Span::styled("enter", Style::default().fg(Color::Cyan)),
             Span::raw(": solve  "),
-            Span::styled("p", Style::default().fg(Color::Cyan)),
-            Span::raw(format!(": palette {}  ", self.palette.name())),
             Span::styled("q", Style::default().fg(Color::Cyan)),
             Span::raw(": quit"),
         ]))
         .block(Block::bordered().title(Span::styled(
-            "RGP Rubik's Cube",
+            "Ratty Rubik's Cube",
             Style::default().fg(Color::Yellow),
         )))
         .render(header, frame.buffer_mut());
@@ -210,23 +132,19 @@ impl RubiksApp {
         block.render(body, frame.buffer_mut());
         self.paint_backdrop(frame.buffer_mut());
 
-        let cube_area = centered_cube_area(self.viewport);
+        let cube_area = self.view.cube_area(self.viewport);
         self.sync_scene_objects(cube_area);
         self.emit_rgp_sequences(frame.buffer_mut(), cube_area);
     }
 
     fn status(&self) -> String {
-        let active = self
-            .active_turn
-            .as_ref()
-            .map(|turn| turn.spec.label())
-            .unwrap_or("idle");
         format!(
             "3D cube | cubies: {} | move: {active} | queued: {} | zoom: {:.2} | spread: {:.2}",
-            self.cubies.len(),
-            self.queued_turns.len(),
-            self.zoom,
-            self.spread
+            self.cube.cubie_count(),
+            self.cube.queued_count(),
+            self.view.zoom,
+            self.view.spread,
+            active = self.cube.active_label(),
         )
     }
 
@@ -251,23 +169,20 @@ impl RubiksApp {
             return;
         }
 
-        let place_objects = self.placed_area != Some(area);
-        emit_sequence(buf, area.x, area.y, &self.cube.transform_update_sequence());
+        let place_objects = self.view.placed_area != Some(area);
+        emit_sequence(buf, area.x, area.y, &self.object.graphic.update_sequence());
         if place_objects {
-            emit_sequence(buf, area.x, area.y, &self.cube.graphic.place_sequence(area));
+            emit_sequence(buf, area.x, area.y, &self.object.graphic.place_sequence(area));
         }
 
         if place_objects {
-            self.placed_area = Some(area);
+            self.view.placed_area = Some(area);
         }
     }
 
     fn sync_scene_objects(&mut self, area: Rect) {
-        let metrics = SceneMetrics::new(area, self.zoom);
-        let view =
-            Mat3::rotation_x(self.pitch) * Mat3::rotation_y(self.yaw) * Mat3::rotation_z(self.roll);
-        self.cube
-            .apply(SceneUpdate::new(Vec3::new(0.0, 0.0, 0.0), view), &metrics);
+        self.object
+            .apply(self.view.rotation(), &SceneMetrics::new(area, self.view.zoom));
     }
 
     fn handle_event(&mut self, event: Event) -> io::Result<()> {
@@ -275,7 +190,7 @@ impl RubiksApp {
             Event::Key(key) => self.handle_key(key),
             Event::Mouse(mouse) => self.handle_mouse(mouse),
             Event::Resize(_, _) => {
-                self.placed_area = None;
+                self.view.placed_area = None;
                 self.drag_start = None;
             }
             _ => {}
@@ -290,36 +205,33 @@ impl RubiksApp {
 
         match key.code {
             KeyCode::Esc | KeyCode::Char('q') => self.should_quit = true,
-            KeyCode::Char(' ') => self.queue_scramble(),
-            KeyCode::Enter => self.queue_solve(),
-            KeyCode::Backspace => self.queue_undo(),
+            KeyCode::Char(' ') => self.cube.queue_scramble(),
+            KeyCode::Enter => self.cube.queue_solve(),
+            KeyCode::Backspace => self.cube.queue_undo(),
             KeyCode::Char('0') => {
-                self.reset_cube();
-                let _ = self.register_objects();
-            }
-            KeyCode::Char('p') => {
-                self.palette = self.palette.next();
-                let _ = self.register_objects();
+                self.cube.reset();
+                self.view.placed_area = None;
+                let _ = self.object.register_cube(&self.cube);
             }
             KeyCode::Char('+') | KeyCode::Char('=') => {
-                self.zoom = (self.zoom + 0.06).min(1.6);
+                self.view.zoom = (self.view.zoom + 0.06).min(1.6);
             }
             KeyCode::Char('-') => {
-                self.zoom = (self.zoom - 0.06).max(0.55);
+                self.view.zoom = (self.view.zoom - 0.06).max(0.55);
             }
             KeyCode::Char(']') => {
-                self.spread = (self.spread + 0.03).min(1.22);
+                self.view.spread = (self.view.spread + 0.03).min(1.22);
             }
             KeyCode::Char('[') => {
-                self.spread = (self.spread - 0.03).max(0.86);
+                self.view.spread = (self.view.spread - 0.03).max(0.86);
             }
-            KeyCode::Left => self.yaw -= 0.12,
-            KeyCode::Right => self.yaw += 0.12,
-            KeyCode::Up => self.pitch = (self.pitch - 0.10).max(-1.35),
-            KeyCode::Down => self.pitch = (self.pitch + 0.10).min(1.35),
+            KeyCode::Left => self.view.yaw -= 0.12,
+            KeyCode::Right => self.view.yaw += 0.12,
+            KeyCode::Up => self.view.pitch = (self.view.pitch - 0.10).max(-1.35),
+            KeyCode::Down => self.view.pitch = (self.view.pitch + 0.10).min(1.35),
             KeyCode::Char(ch) => {
                 if let Some(spec) = MoveSpec::from_char(ch) {
-                    self.queue_turn(spec, true);
+                    self.cube.queue_turn(spec, true);
                 }
             }
             _ => {}
@@ -328,7 +240,10 @@ impl RubiksApp {
 
     fn handle_mouse(&mut self, mouse: MouseEvent) {
         let pos = Position::new(mouse.column, mouse.row);
-        let inside = contains(self.viewport, pos);
+        let inside = pos.x >= self.viewport.x
+            && pos.x < self.viewport.right()
+            && pos.y >= self.viewport.y
+            && pos.y < self.viewport.bottom();
         match mouse.kind {
             MouseEventKind::Down(crossterm::event::MouseButton::Left) if inside => {
                 self.drag_start = Some(pos);
@@ -340,24 +255,99 @@ impl RubiksApp {
                 };
                 let dx = pos.x as i32 - previous.x as i32;
                 let dy = pos.y as i32 - previous.y as i32;
-                self.yaw += dx as f32 * 0.035;
-                self.pitch = (self.pitch + dy as f32 * 0.035).clamp(-1.35, 1.35);
+                self.view.yaw += dx as f32 * 0.035;
+                self.view.pitch = (self.view.pitch + dy as f32 * 0.035).clamp(-1.35, 1.35);
                 self.drag_start = Some(pos);
             }
             MouseEventKind::Up(crossterm::event::MouseButton::Left) => {
                 self.drag_start = None;
             }
             MouseEventKind::ScrollUp if inside => {
-                self.zoom = (self.zoom + 0.05).min(1.6);
+                self.view.zoom = (self.view.zoom + 0.05).min(1.6);
             }
             MouseEventKind::ScrollDown if inside => {
-                self.zoom = (self.zoom - 0.05).max(0.55);
+                self.view.zoom = (self.view.zoom - 0.05).max(0.55);
             }
             _ => {}
         }
     }
 
     fn tick(&mut self, delta: f32) {
+        if self.cube.tick(delta) {
+            let _ = self.object.register_cube(&self.cube);
+        }
+    }
+}
+
+struct RubiksCube {
+    cubies: Vec<Cubie>,
+    active_turn: Option<ActiveTurn>,
+    queued_turns: VecDeque<QueuedTurn>,
+    history: Vec<MoveSpec>,
+    rng: u32,
+}
+
+impl RubiksCube {
+    fn new() -> Self {
+        let mut cube = Self {
+            cubies: Vec::new(),
+            active_turn: None,
+            queued_turns: VecDeque::new(),
+            history: Vec::new(),
+            rng: 0x516f_6f74,
+        };
+        cube.reset();
+        cube
+    }
+
+    fn reset(&mut self) {
+        self.cubies.clear();
+        self.active_turn = None;
+        self.queued_turns.clear();
+        self.history.clear();
+
+        for x in -1..=1 {
+            for y in -1..=1 {
+                for z in -1..=1 {
+                    if x != 0 || y != 0 || z != 0 {
+                        self.cubies.push(Cubie::new(Vec3i::new(x, y, z)));
+                    }
+                }
+            }
+        }
+    }
+
+    fn cubie_count(&self) -> usize {
+        self.cubies.len()
+    }
+
+    fn queued_count(&self) -> usize {
+        self.queued_turns.len()
+    }
+
+    fn active_label(&self) -> &'static str {
+        self.active_turn
+            .as_ref()
+            .map(|turn| turn.spec.label)
+            .unwrap_or("idle")
+    }
+
+    fn active_transform(&self) -> Option<(MoveSpec, Mat3)> {
+        self.active_turn.as_ref().map(|turn| {
+            let t = (turn.elapsed / turn.duration).clamp(0.0, 1.0);
+            let progress = t * t * (3.0 - 2.0 * t);
+            (
+                turn.spec,
+                Mat3::from_axis(
+                    turn.spec.axis,
+                    turn.spec.dir as f32 * progress * std::f32::consts::FRAC_PI_2,
+                ),
+            )
+        })
+    }
+
+    fn tick(&mut self, delta: f32) -> bool {
+        let mut changed = false;
         if self.active_turn.is_none() {
             if let Some(queued) = self.queued_turns.pop_front() {
                 self.active_turn = Some(ActiveTurn {
@@ -366,32 +356,25 @@ impl RubiksApp {
                     elapsed: 0.0,
                     duration: TURN_DURATION,
                 });
-                let _ = self.register_cube_model();
+                changed = true;
             }
         }
 
         let Some(turn) = self.active_turn.as_mut() else {
-            return;
+            return changed;
         };
         turn.elapsed += delta;
-        let completed = if turn.elapsed < turn.duration {
-            None
-        } else {
-            Some(*turn)
-        };
+        if turn.elapsed < turn.duration {
+            return true;
+        }
 
-        if completed.is_none() {
-            let _ = self.register_cube_model();
-            return;
-        };
-
-        let completed = completed.expect("checked above");
+        let completed = *turn;
         self.apply_move(completed.spec);
         if completed.record {
             self.history.push(completed.spec);
         }
         self.active_turn = None;
-        let _ = self.register_cube_model();
+        true
     }
 
     fn queue_turn(&mut self, spec: MoveSpec, record: bool) {
@@ -465,8 +448,44 @@ impl RubiksApp {
     }
 }
 
+struct SceneView {
+    yaw: f32,
+    pitch: f32,
+    roll: f32,
+    zoom: f32,
+    spread: f32,
+    placed_area: Option<Rect>,
+}
+
+impl SceneView {
+    fn new() -> Self {
+        Self {
+            yaw: -0.58,
+            pitch: -0.42,
+            roll: 0.0,
+            zoom: 1.0,
+            spread: 1.0,
+            placed_area: None,
+        }
+    }
+
+    fn rotation(&self) -> Mat3 {
+        Mat3::rotation_x(self.pitch) * Mat3::rotation_y(self.yaw) * Mat3::rotation_z(self.roll)
+    }
+
+    fn cube_area(&self, viewport: Rect) -> Rect {
+        if viewport.is_empty() {
+            return viewport;
+        }
+        let width = viewport.width.saturating_sub(2).min(56).max(1);
+        let height = viewport.height.saturating_sub(2).min(24).max(1);
+        viewport.centered(Constraint::Length(width), Constraint::Length(height))
+    }
+}
+
 struct SceneObject {
     graphic: RattyGraphic<'static>,
+    model_revision: u32,
 }
 
 impl SceneObject {
@@ -480,18 +499,27 @@ impl SceneObject {
             .depth(0.0);
         Self {
             graphic: RattyGraphic::new(settings),
+            model_revision: 0,
         }
     }
 
-    fn apply(&mut self, update: SceneUpdate, metrics: &SceneMetrics) {
+    fn register_cube(&mut self, cube: &RubiksCube) -> io::Result<()> {
+        self.model_revision = self.model_revision.wrapping_add(1);
+        let path = self.asset_path()?;
+        fs::write(&path, CubeObj::from_cube(cube).into_bytes())?;
+        self.graphic.settings_mut().path = Cow::Owned(path.to_string_lossy().into_owned());
+        self.graphic.register()
+    }
+
+    fn apply(&mut self, rotation: Mat3, metrics: &SceneMetrics) {
         let settings = self.graphic.settings_mut();
         settings.animate = false;
         settings.depth = 0.0;
-        settings.rotation = update.rotation.to_euler_degrees();
+        settings.rotation = rotation.to_euler_degrees();
         settings.offset = [
-            update.position.x * metrics.unit,
-            update.position.y * metrics.unit,
-            metrics.unit * BASE_Z_UNITS + update.position.z * metrics.unit,
+            0.0,
+            0.0,
+            metrics.unit * BASE_Z_UNITS,
         ];
         settings.color = None;
         settings.brightness = 1.0;
@@ -499,23 +527,16 @@ impl SceneObject {
         settings.scale3 = [1.0, 1.0, 1.0];
     }
 
-    fn transform_update_sequence(&self) -> String {
-        let settings = self.graphic.settings();
-        format!(
-            "\x1b_ratty;g;u;id={};animate={};scale={};px={};py={};pz={};rx={};ry={};rz={};sx={};sy={};sz={}\x1b\\",
-            settings.id,
-            u8::from(settings.animate),
-            settings.scale,
-            settings.offset[0],
-            settings.offset[1],
-            settings.offset[2],
-            settings.rotation[0],
-            settings.rotation[1],
-            settings.rotation[2],
-            settings.scale3[0],
-            settings.scale3[1],
-            settings.scale3[2],
-        )
+    fn clear(&self) -> io::Result<()> {
+        let mut stdout = io::stdout();
+        stdout.write_all(self.graphic.delete_sequence().as_bytes())?;
+        stdout.flush()
+    }
+
+    fn asset_path(&self) -> io::Result<PathBuf> {
+        let dir = std::env::temp_dir().join("ratty-rubiks-cube");
+        fs::create_dir_all(&dir)?;
+        Ok(dir.join(format!("rubiks-cube-v5-{}.obj", self.model_revision)))
     }
 }
 
@@ -538,18 +559,6 @@ impl SceneMetrics {
     }
 }
 
-#[derive(Clone, Copy)]
-struct SceneUpdate {
-    position: Vec3,
-    rotation: Mat3,
-}
-
-impl SceneUpdate {
-    fn new(position: Vec3, rotation: Mat3) -> Self {
-        Self { position, rotation }
-    }
-}
-
 #[derive(Clone)]
 struct Cubie {
     pos: Vec3i,
@@ -558,12 +567,34 @@ struct Cubie {
 }
 
 impl Cubie {
-    fn new(pos: Vec3i, stickers: Vec<Sticker>) -> Self {
+    fn new(pos: Vec3i) -> Self {
         Self {
             pos,
             orientation: Mat3::IDENTITY,
-            stickers,
+            stickers: Sticker::for_cubie(pos),
         }
+    }
+
+    fn primitives(&self, active: Option<(MoveSpec, Mat3)>) -> Vec<MeshPrimitive> {
+        let turn_matrix = active
+            .filter(|(spec, _)| spec.includes(self.pos))
+            .map(|(_, matrix)| matrix)
+            .unwrap_or(Mat3::IDENTITY);
+        let center = turn_matrix.transform_vec(self.pos.to_vec3() * CUBIE_SPACING);
+        let rotation = turn_matrix * self.orientation;
+        let mut primitives = Vec::with_capacity(self.stickers.len() + 1);
+        primitives.push(MeshPrimitive::cuboid(
+            center,
+            Vec3::new(0.49, 0.49, 0.49),
+            [14, 15, 18],
+            rotation,
+        ));
+        primitives.extend(
+            self.stickers
+                .iter()
+                .map(|sticker| sticker.primitive(center, rotation)),
+        );
+        primitives
     }
 }
 
@@ -571,6 +602,77 @@ impl Cubie {
 struct Sticker {
     normal: Vec3i,
     face: Face,
+}
+
+impl Sticker {
+    fn new(normal: Vec3i, face: Face) -> Self {
+        Self { normal, face }
+    }
+
+    fn for_cubie(pos: Vec3i) -> Vec<Self> {
+        let mut stickers = Vec::new();
+        if pos.y == 1 {
+            stickers.push(Self::new(Vec3i::new(0, 1, 0), Face::Up));
+        }
+        if pos.y == -1 {
+            stickers.push(Self::new(Vec3i::new(0, -1, 0), Face::Down));
+        }
+        if pos.z == 1 {
+            stickers.push(Self::new(Vec3i::new(0, 0, 1), Face::Front));
+        }
+        if pos.z == -1 {
+            stickers.push(Self::new(Vec3i::new(0, 0, -1), Face::Back));
+        }
+        if pos.x == 1 {
+            stickers.push(Self::new(Vec3i::new(1, 0, 0), Face::Right));
+        }
+        if pos.x == -1 {
+            stickers.push(Self::new(Vec3i::new(-1, 0, 0), Face::Left));
+        }
+        stickers
+    }
+
+    fn primitive(self, cubie_center: Vec3, cubie_rotation: Mat3) -> MeshPrimitive {
+        let (local_center, half) = self.geometry();
+        MeshPrimitive::cuboid(
+            cubie_center + cubie_rotation.transform_vec(local_center),
+            half,
+            self.face.color(),
+            cubie_rotation,
+        )
+    }
+
+    fn geometry(self) -> (Vec3, Vec3) {
+        let face = 0.34;
+        let thickness = 0.018;
+        let lift = 0.516;
+        match (self.normal.x, self.normal.y, self.normal.z) {
+            (1, 0, 0) => (
+                Vec3::new(lift, 0.0, 0.0),
+                Vec3::new(thickness, face, face),
+            ),
+            (-1, 0, 0) => (
+                Vec3::new(-lift, 0.0, 0.0),
+                Vec3::new(thickness, face, face),
+            ),
+            (0, 1, 0) => (
+                Vec3::new(0.0, lift, 0.0),
+                Vec3::new(face, thickness, face),
+            ),
+            (0, -1, 0) => (
+                Vec3::new(0.0, -lift, 0.0),
+                Vec3::new(face, thickness, face),
+            ),
+            (0, 0, -1) => (
+                Vec3::new(0.0, 0.0, -lift),
+                Vec3::new(face, face, thickness),
+            ),
+            _ => (
+                Vec3::new(0.0, 0.0, lift),
+                Vec3::new(face, face, thickness),
+            ),
+        }
+    }
 }
 
 #[derive(Clone, Copy, PartialEq, Eq)]
@@ -583,45 +685,15 @@ enum Face {
     Left,
 }
 
-#[derive(Clone, Copy)]
-enum Palette {
-    Classic,
-    Pastel,
-}
-
-impl Palette {
-    fn next(self) -> Self {
+impl Face {
+    fn color(self) -> [u8; 3] {
         match self {
-            Self::Classic => Self::Pastel,
-            Self::Pastel => Self::Classic,
-        }
-    }
-
-    fn name(self) -> &'static str {
-        match self {
-            Self::Classic => "classic",
-            Self::Pastel => "pastel",
-        }
-    }
-
-    fn color(self, face: Face) -> [u8; 3] {
-        match self {
-            Self::Classic => match face {
-                Face::Up => [242, 242, 242],
-                Face::Down => [255, 213, 0],
-                Face::Front => [0, 155, 72],
-                Face::Back => [0, 70, 173],
-                Face::Right => [183, 18, 52],
-                Face::Left => [255, 88, 0],
-            },
-            Self::Pastel => match face {
-                Face::Up => [245, 236, 226],
-                Face::Down => [231, 201, 103],
-                Face::Front => [142, 204, 161],
-                Face::Back => [135, 161, 213],
-                Face::Right => [211, 128, 87],
-                Face::Left => [190, 139, 183],
-            },
+            Self::Up => [242, 242, 242],
+            Self::Down => [255, 213, 0],
+            Self::Front => [0, 155, 72],
+            Self::Back => [0, 70, 173],
+            Self::Right => [183, 18, 52],
+            Self::Left => [255, 88, 0],
         }
     }
 }
@@ -702,9 +774,6 @@ impl MoveSpec {
         }
     }
 
-    fn label(self) -> &'static str {
-        self.label
-    }
 }
 
 #[derive(Clone, Copy, PartialEq, Eq)]
@@ -858,68 +927,39 @@ impl std::ops::Mul for Mat3 {
     }
 }
 
-fn exposed_faces(pos: Vec3i) -> Vec<(Vec3i, Face)> {
-    let mut faces = Vec::new();
-    if pos.y == 1 {
-        faces.push((Vec3i::new(0, 1, 0), Face::Up));
-    }
-    if pos.y == -1 {
-        faces.push((Vec3i::new(0, -1, 0), Face::Down));
-    }
-    if pos.z == 1 {
-        faces.push((Vec3i::new(0, 0, 1), Face::Front));
-    }
-    if pos.z == -1 {
-        faces.push((Vec3i::new(0, 0, -1), Face::Back));
-    }
-    if pos.x == 1 {
-        faces.push((Vec3i::new(1, 0, 0), Face::Right));
-    }
-    if pos.x == -1 {
-        faces.push((Vec3i::new(-1, 0, 0), Face::Left));
-    }
-    faces
+struct CubeObj {
+    primitives: Vec<MeshPrimitive>,
 }
 
-fn cube_obj(cubies: &[Cubie], palette: Palette, active: Option<(MoveSpec, Mat3)>) -> Vec<u8> {
-    let sticker_count = cubies.iter().map(|cubie| cubie.stickers.len()).sum::<usize>();
-    let mut primitives = Vec::with_capacity(cubies.len() + sticker_count);
-
-    for cubie in cubies {
-        let turn_matrix = active
-            .filter(|(spec, _)| spec.includes(cubie.pos))
-            .map(|(_, matrix)| matrix)
-            .unwrap_or(Mat3::IDENTITY);
-        let center = turn_matrix.transform_vec(cubie.pos.to_vec3() * CUBIE_SPACING);
-        let rotation = turn_matrix * cubie.orientation;
-        primitives.push(cuboid_primitive(
-            center,
-            Vec3::new(0.49, 0.49, 0.49),
-            [14, 15, 18],
-            rotation,
-        ));
-
-        for sticker in &cubie.stickers {
-            let (local_center, half) = sticker_box(sticker.normal);
-            primitives.push(cuboid_primitive(
-                center + rotation.transform_vec(local_center),
-                half,
-                palette.color(sticker.face),
-                rotation,
-            ));
+impl CubeObj {
+    fn from_cube(cube: &RubiksCube) -> Self {
+        let sticker_count = cube
+            .cubies
+            .iter()
+            .map(|cubie| cubie.stickers.len())
+            .sum::<usize>();
+        let mut primitives = Vec::with_capacity(cube.cubies.len() + sticker_count);
+        for cubie in &cube.cubies {
+            primitives.extend(cubie.primitives(cube.active_transform()));
         }
+        Self { primitives }
     }
 
-    build_obj(&primitives).into_bytes()
-}
+    fn into_bytes(self) -> Vec<u8> {
+        self.to_obj_string().into_bytes()
+    }
 
-fn cube_asset_path(revision: u32, palette: Palette) -> io::Result<PathBuf> {
-    let dir = std::env::temp_dir().join("ratty-rubiks-cube");
-    fs::create_dir_all(&dir)?;
-    Ok(dir.join(format!(
-        "rubiks-cube-v5-{}-{revision}.obj",
-        palette.name()
-    )))
+    fn to_obj_string(&self) -> String {
+        let mut obj = String::from("# ratty-rubiks-cube\n");
+        let mut vertex_offset = 1usize;
+        let mut normal_offset = 1usize;
+        for primitive in &self.primitives {
+            primitive.write_obj(&mut obj, vertex_offset, normal_offset);
+            vertex_offset += primitive.positions.len();
+            normal_offset += primitive.normals.len();
+        }
+        obj
+    }
 }
 
 #[derive(Clone)]
@@ -930,109 +970,92 @@ struct MeshPrimitive {
     indices: Vec<u16>,
 }
 
-fn sticker_box(normal: Vec3i) -> (Vec3, Vec3) {
-    let face = 0.34;
-    let thickness = 0.018;
-    let lift = 0.516;
-    match (normal.x, normal.y, normal.z) {
-        (1, 0, 0) => (Vec3::new(lift, 0.0, 0.0), Vec3::new(thickness, face, face)),
-        (-1, 0, 0) => (Vec3::new(-lift, 0.0, 0.0), Vec3::new(thickness, face, face)),
-        (0, 1, 0) => (Vec3::new(0.0, lift, 0.0), Vec3::new(face, thickness, face)),
-        (0, -1, 0) => (Vec3::new(0.0, -lift, 0.0), Vec3::new(face, thickness, face)),
-        (0, 0, -1) => (Vec3::new(0.0, 0.0, -lift), Vec3::new(face, face, thickness)),
-        _ => (Vec3::new(0.0, 0.0, lift), Vec3::new(face, face, thickness)),
-    }
-}
+impl MeshPrimitive {
+    fn cuboid(center: Vec3, half: Vec3, color: [u8; 3], rotation: Mat3) -> Self {
+        let faces = [
+            (
+                Vec3::new(0.0, 0.0, 1.0),
+                [
+                    Vec3::new(-half.x, -half.y, half.z),
+                    Vec3::new(half.x, -half.y, half.z),
+                    Vec3::new(half.x, half.y, half.z),
+                    Vec3::new(-half.x, half.y, half.z),
+                ],
+            ),
+            (
+                Vec3::new(0.0, 0.0, -1.0),
+                [
+                    Vec3::new(half.x, -half.y, -half.z),
+                    Vec3::new(-half.x, -half.y, -half.z),
+                    Vec3::new(-half.x, half.y, -half.z),
+                    Vec3::new(half.x, half.y, -half.z),
+                ],
+            ),
+            (
+                Vec3::new(1.0, 0.0, 0.0),
+                [
+                    Vec3::new(half.x, -half.y, half.z),
+                    Vec3::new(half.x, -half.y, -half.z),
+                    Vec3::new(half.x, half.y, -half.z),
+                    Vec3::new(half.x, half.y, half.z),
+                ],
+            ),
+            (
+                Vec3::new(-1.0, 0.0, 0.0),
+                [
+                    Vec3::new(-half.x, -half.y, -half.z),
+                    Vec3::new(-half.x, -half.y, half.z),
+                    Vec3::new(-half.x, half.y, half.z),
+                    Vec3::new(-half.x, half.y, -half.z),
+                ],
+            ),
+            (
+                Vec3::new(0.0, 1.0, 0.0),
+                [
+                    Vec3::new(-half.x, half.y, half.z),
+                    Vec3::new(half.x, half.y, half.z),
+                    Vec3::new(half.x, half.y, -half.z),
+                    Vec3::new(-half.x, half.y, -half.z),
+                ],
+            ),
+            (
+                Vec3::new(0.0, -1.0, 0.0),
+                [
+                    Vec3::new(-half.x, -half.y, -half.z),
+                    Vec3::new(half.x, -half.y, -half.z),
+                    Vec3::new(half.x, -half.y, half.z),
+                    Vec3::new(-half.x, -half.y, half.z),
+                ],
+            ),
+        ];
 
-fn cuboid_primitive(center: Vec3, half: Vec3, color: [u8; 3], rotation: Mat3) -> MeshPrimitive {
-    let faces = [
-        (
-            Vec3::new(0.0, 0.0, 1.0),
-            [
-                Vec3::new(-half.x, -half.y, half.z),
-                Vec3::new(half.x, -half.y, half.z),
-                Vec3::new(half.x, half.y, half.z),
-                Vec3::new(-half.x, half.y, half.z),
-            ],
-        ),
-        (
-            Vec3::new(0.0, 0.0, -1.0),
-            [
-                Vec3::new(half.x, -half.y, -half.z),
-                Vec3::new(-half.x, -half.y, -half.z),
-                Vec3::new(-half.x, half.y, -half.z),
-                Vec3::new(half.x, half.y, -half.z),
-            ],
-        ),
-        (
-            Vec3::new(1.0, 0.0, 0.0),
-            [
-                Vec3::new(half.x, -half.y, half.z),
-                Vec3::new(half.x, -half.y, -half.z),
-                Vec3::new(half.x, half.y, -half.z),
-                Vec3::new(half.x, half.y, half.z),
-            ],
-        ),
-        (
-            Vec3::new(-1.0, 0.0, 0.0),
-            [
-                Vec3::new(-half.x, -half.y, -half.z),
-                Vec3::new(-half.x, -half.y, half.z),
-                Vec3::new(-half.x, half.y, half.z),
-                Vec3::new(-half.x, half.y, -half.z),
-            ],
-        ),
-        (
-            Vec3::new(0.0, 1.0, 0.0),
-            [
-                Vec3::new(-half.x, half.y, half.z),
-                Vec3::new(half.x, half.y, half.z),
-                Vec3::new(half.x, half.y, -half.z),
-                Vec3::new(-half.x, half.y, -half.z),
-            ],
-        ),
-        (
-            Vec3::new(0.0, -1.0, 0.0),
-            [
-                Vec3::new(-half.x, -half.y, -half.z),
-                Vec3::new(half.x, -half.y, -half.z),
-                Vec3::new(half.x, -half.y, half.z),
-                Vec3::new(-half.x, -half.y, half.z),
-            ],
-        ),
-    ];
-
-    let mut positions = Vec::with_capacity(24);
-    let mut normals = Vec::with_capacity(24);
-    let mut colors = Vec::with_capacity(24);
-    let mut indices = Vec::with_capacity(36);
-    for (normal, corners) in faces {
-        let base = positions.len() as u16;
-        for corner in corners {
-            positions.push((center + rotation.transform_vec(corner)).to_array());
-            colors.push(color);
+        let mut positions = Vec::with_capacity(24);
+        let mut normals = Vec::with_capacity(24);
+        let mut colors = Vec::with_capacity(24);
+        let mut indices = Vec::with_capacity(36);
+        for (normal, corners) in faces {
+            let base = positions.len() as u16;
+            for corner in corners {
+                positions.push((center + rotation.transform_vec(corner)).to_array());
+                colors.push(color);
+            }
+            let normal = rotation.transform_vec(normal).to_array();
+            for _ in 0..4 {
+                normals.push(normal);
+            }
+            indices.extend_from_slice(&[base, base + 1, base + 2, base, base + 2, base + 3]);
         }
-        let normal = rotation.transform_vec(normal).to_array();
-        for _ in 0..4 {
-            normals.push(normal);
+
+        Self {
+            positions,
+            normals,
+            colors,
+            indices,
         }
-        indices.extend_from_slice(&[base, base + 1, base + 2, base, base + 2, base + 3]);
     }
 
-    MeshPrimitive {
-        positions,
-        normals,
-        colors,
-        indices,
-    }
-}
-
-fn build_obj(primitives: &[MeshPrimitive]) -> String {
-    let mut obj = String::from("# ratty-rubiks-cube\n");
-    let mut vertex_offset = 1usize;
-    let mut normal_offset = 1usize;
-    for primitive in primitives {
-        for (position, color) in primitive.positions.iter().zip(&primitive.colors) {
+    fn write_obj(&self, obj: &mut String, vertex_offset: usize, normal_offset: usize) {
+        for (position, color) in self.positions.iter().zip(&self.colors) {
             let [r, g, b] = *color;
             obj.push_str(&format!(
                 "v {:.5} {:.5} {:.5} {:.5} {:.5} {:.5}\n",
@@ -1044,13 +1067,13 @@ fn build_obj(primitives: &[MeshPrimitive]) -> String {
                 f32::from(b) / 255.0,
             ));
         }
-        for normal in &primitive.normals {
+        for normal in &self.normals {
             obj.push_str(&format!(
                 "vn {:.5} {:.5} {:.5}\n",
                 normal[0], normal[1], normal[2],
             ));
         }
-        for triangle in primitive.indices.chunks_exact(3) {
+        for triangle in self.indices.chunks_exact(3) {
             let a = usize::from(triangle[0]);
             let b = usize::from(triangle[1]);
             let c = usize::from(triangle[2]);
@@ -1064,10 +1087,7 @@ fn build_obj(primitives: &[MeshPrimitive]) -> String {
                 normal_offset + c,
             ));
         }
-        vertex_offset += primitive.positions.len();
-        normal_offset += primitive.normals.len();
     }
-    obj
 }
 
 fn terminal_cell_pixels() -> (f32, f32) {
@@ -1087,22 +1107,6 @@ fn terminal_cell_pixels() -> (f32, f32) {
     (width.max(1.0), height.max(1.0))
 }
 
-fn centered_cube_area(bounds: Rect) -> Rect {
-    if bounds.is_empty() {
-        return bounds;
-    }
-    let width = bounds.width.saturating_sub(2).min(56).max(1);
-    let height = bounds.height.saturating_sub(2).min(24).max(1);
-    bounds.centered(Constraint::Length(width), Constraint::Length(height))
-}
-
-fn contains(area: Rect, position: Position) -> bool {
-    position.x >= area.x
-        && position.x < area.x.saturating_add(area.width)
-        && position.y >= area.y
-        && position.y < area.y.saturating_add(area.height)
-}
-
 fn emit_sequence(buf: &mut Buffer, x: u16, y: u16, sequence: &str) {
     let Some(cell) = buf.cell_mut((x, y)) else {
         return;
@@ -1120,8 +1124,4 @@ fn clear_demo_objects() -> io::Result<()> {
         stdout.write_all(format!("\x1b_ratty;g;d;id={id}\x1b\\").as_bytes())?;
     }
     stdout.flush()
-}
-
-fn smoothstep(t: f32) -> f32 {
-    t * t * (3.0 - 2.0 * t)
 }

--- a/widget/examples/rubiks_cube.rs
+++ b/widget/examples/rubiks_cube.rs
@@ -27,15 +27,9 @@ use ratatui_ratty::{ObjectFormat, RattyGraphic, RattyGraphicSettings};
 
 const TICK: Duration = Duration::from_millis(33);
 const TURN_DURATION: f32 = 0.26;
-const BODY_SCALE: f32 = 0.15;
+const BODY_SCALE: f32 = 0.46;
 const CUBIE_SPACING: f32 = 1.04;
 const BASE_Z_UNITS: f32 = 2.7;
-const GLB_JSON_CHUNK: u32 = 0x4e4f_534a;
-const GLB_BIN_CHUNK: u32 = 0x004e_4942;
-const ARRAY_BUFFER: u32 = 34_962;
-const ELEMENT_ARRAY_BUFFER: u32 = 34_963;
-const COMPONENT_F32: u32 = 5_126;
-const COMPONENT_U16: u32 = 5_123;
 
 fn main() -> io::Result<()> {
     let mut terminal = ratatui::init();
@@ -163,7 +157,7 @@ impl RubiksApp {
                 ),
             )
         });
-        let payload = cube_glb(&self.cubies, self.palette, active);
+        let payload = cube_obj(&self.cubies, self.palette, active);
         let path = cube_asset_path(self.model_revision, self.palette)?;
         fs::write(&path, payload)?;
         self.cube.graphic.settings_mut().path = Cow::Owned(path.to_string_lossy().into_owned());
@@ -477,9 +471,9 @@ struct SceneObject {
 
 impl SceneObject {
     fn new_cube(id: u32) -> Self {
-        let settings = RattyGraphicSettings::new(format!("rubiks-{id}.glb"))
+        let settings = RattyGraphicSettings::new(format!("rubiks-{id}.obj"))
             .id(id)
-            .format(ObjectFormat::Glb)
+            .format(ObjectFormat::Obj)
             .animate(false)
             .brightness(1.0)
             .depth(0.0);
@@ -886,7 +880,7 @@ fn exposed_faces(pos: Vec3i) -> Vec<(Vec3i, Face)> {
     faces
 }
 
-fn cube_glb(cubies: &[Cubie], palette: Palette, active: Option<(MoveSpec, Mat3)>) -> Vec<u8> {
+fn cube_obj(cubies: &[Cubie], palette: Palette, active: Option<(MoveSpec, Mat3)>) -> Vec<u8> {
     let sticker_count = cubies.iter().map(|cubie| cubie.stickers.len()).sum::<usize>();
     let mut primitives = Vec::with_capacity(cubies.len() + sticker_count);
 
@@ -900,7 +894,7 @@ fn cube_glb(cubies: &[Cubie], palette: Palette, active: Option<(MoveSpec, Mat3)>
         primitives.push(cuboid_primitive(
             center,
             Vec3::new(0.49, 0.49, 0.49),
-            0,
+            [14, 15, 18],
             rotation,
         ));
 
@@ -909,20 +903,20 @@ fn cube_glb(cubies: &[Cubie], palette: Palette, active: Option<(MoveSpec, Mat3)>
             primitives.push(cuboid_primitive(
                 center + rotation.transform_vec(local_center),
                 half,
-                sticker.face.material_index(),
+                palette.color(sticker.face),
                 rotation,
             ));
         }
     }
 
-    build_glb(&primitives, palette)
+    build_obj(&primitives).into_bytes()
 }
 
 fn cube_asset_path(revision: u32, palette: Palette) -> io::Result<PathBuf> {
     let dir = std::env::temp_dir().join("ratty-rubiks-cube");
     fs::create_dir_all(&dir)?;
     Ok(dir.join(format!(
-        "rubiks-cube-v4-{}-{revision}.glb",
+        "rubiks-cube-v5-{}-{revision}.obj",
         palette.name()
     )))
 }
@@ -931,64 +925,8 @@ fn cube_asset_path(revision: u32, palette: Palette) -> io::Result<PathBuf> {
 struct MeshPrimitive {
     positions: Vec<[f32; 3]>,
     normals: Vec<[f32; 3]>,
+    colors: Vec<[u8; 3]>,
     indices: Vec<u16>,
-    material: usize,
-}
-
-#[derive(Clone, Copy)]
-struct PrimitiveAccessors {
-    position: usize,
-    normal: usize,
-    indices: usize,
-    material: usize,
-}
-
-#[derive(Clone, Copy)]
-struct BufferViewInfo {
-    offset: usize,
-    length: usize,
-    target: u32,
-}
-
-enum AccessorInfo {
-    Positions {
-        view: usize,
-        count: usize,
-        min: [f32; 3],
-        max: [f32; 3],
-    },
-    Normals {
-        view: usize,
-        count: usize,
-    },
-    Indices {
-        view: usize,
-        count: usize,
-    },
-}
-
-impl Face {
-    fn material_index(self) -> usize {
-        match self {
-            Self::Up => 1,
-            Self::Down => 2,
-            Self::Front => 3,
-            Self::Back => 4,
-            Self::Right => 5,
-            Self::Left => 6,
-        }
-    }
-
-    fn name(self) -> &'static str {
-        match self {
-            Self::Up => "up",
-            Self::Down => "down",
-            Self::Front => "front",
-            Self::Back => "back",
-            Self::Right => "right",
-            Self::Left => "left",
-        }
-    }
 }
 
 fn sticker_box(normal: Vec3i) -> (Vec3, Vec3) {
@@ -1005,7 +943,7 @@ fn sticker_box(normal: Vec3i) -> (Vec3, Vec3) {
     }
 }
 
-fn cuboid_primitive(center: Vec3, half: Vec3, material: usize, rotation: Mat3) -> MeshPrimitive {
+fn cuboid_primitive(center: Vec3, half: Vec3, color: [u8; 3], rotation: Mat3) -> MeshPrimitive {
     let faces = [
         (
             Vec3::new(0.0, 0.0, 1.0),
@@ -1065,11 +1003,13 @@ fn cuboid_primitive(center: Vec3, half: Vec3, material: usize, rotation: Mat3) -
 
     let mut positions = Vec::with_capacity(24);
     let mut normals = Vec::with_capacity(24);
+    let mut colors = Vec::with_capacity(24);
     let mut indices = Vec::with_capacity(36);
     for (normal, corners) in faces {
         let base = positions.len() as u16;
         for corner in corners {
             positions.push((center + rotation.transform_vec(corner)).to_array());
+            colors.push(color);
         }
         let normal = rotation.transform_vec(normal).to_array();
         for _ in 0..4 {
@@ -1081,244 +1021,52 @@ fn cuboid_primitive(center: Vec3, half: Vec3, material: usize, rotation: Mat3) -
     MeshPrimitive {
         positions,
         normals,
+        colors,
         indices,
-        material,
     }
 }
 
-fn build_glb(primitives: &[MeshPrimitive], palette: Palette) -> Vec<u8> {
-    let mut bin = Vec::new();
-    let mut views = Vec::new();
-    let mut accessors = Vec::new();
-    let mut primitive_accessors = Vec::new();
-
+fn build_obj(primitives: &[MeshPrimitive]) -> String {
+    let mut obj = String::from("# ratty-rubiks-cube\n");
+    let mut vertex_offset = 1usize;
+    let mut normal_offset = 1usize;
     for primitive in primitives {
-        let (position_view, min, max) =
-            push_vec3_buffer(&mut bin, &mut views, &primitive.positions, ARRAY_BUFFER);
-        let position_accessor = accessors.len();
-        accessors.push(AccessorInfo::Positions {
-            view: position_view,
-            count: primitive.positions.len(),
-            min,
-            max,
-        });
-
-        let (normal_view, _, _) =
-            push_vec3_buffer(&mut bin, &mut views, &primitive.normals, ARRAY_BUFFER);
-        let normal_accessor = accessors.len();
-        accessors.push(AccessorInfo::Normals {
-            view: normal_view,
-            count: primitive.normals.len(),
-        });
-
-        let index_view = push_u16_buffer(
-            &mut bin,
-            &mut views,
-            &primitive.indices,
-            ELEMENT_ARRAY_BUFFER,
-        );
-        let index_accessor = accessors.len();
-        accessors.push(AccessorInfo::Indices {
-            view: index_view,
-            count: primitive.indices.len(),
-        });
-
-        primitive_accessors.push(PrimitiveAccessors {
-            position: position_accessor,
-            normal: normal_accessor,
-            indices: index_accessor,
-            material: primitive.material,
-        });
-    }
-
-    align4(&mut bin, 0);
-    let mut json = gltf_json(&views, &accessors, &primitive_accessors, palette).into_bytes();
-    align4(&mut json, b' ');
-
-    let total_len = 12 + 8 + json.len() + 8 + bin.len();
-    let mut glb = Vec::with_capacity(total_len);
-    glb.extend_from_slice(b"glTF");
-    glb.extend_from_slice(&2u32.to_le_bytes());
-    glb.extend_from_slice(&(total_len as u32).to_le_bytes());
-    glb.extend_from_slice(&(json.len() as u32).to_le_bytes());
-    glb.extend_from_slice(&GLB_JSON_CHUNK.to_le_bytes());
-    glb.extend_from_slice(&json);
-    glb.extend_from_slice(&(bin.len() as u32).to_le_bytes());
-    glb.extend_from_slice(&GLB_BIN_CHUNK.to_le_bytes());
-    glb.extend_from_slice(&bin);
-    glb
-}
-
-fn push_vec3_buffer(
-    bin: &mut Vec<u8>,
-    views: &mut Vec<BufferViewInfo>,
-    values: &[[f32; 3]],
-    target: u32,
-) -> (usize, [f32; 3], [f32; 3]) {
-    align4(bin, 0);
-    let offset = bin.len();
-    let mut min = [f32::INFINITY; 3];
-    let mut max = [f32::NEG_INFINITY; 3];
-    for value in values {
-        for index in 0..3 {
-            min[index] = min[index].min(value[index]);
-            max[index] = max[index].max(value[index]);
-            bin.extend_from_slice(&value[index].to_le_bytes());
+        for (position, color) in primitive.positions.iter().zip(&primitive.colors) {
+            let [r, g, b] = *color;
+            obj.push_str(&format!(
+                "v {:.5} {:.5} {:.5} {:.5} {:.5} {:.5}\n",
+                position[0],
+                position[1],
+                position[2],
+                f32::from(r) / 255.0,
+                f32::from(g) / 255.0,
+                f32::from(b) / 255.0,
+            ));
         }
-    }
-    let length = bin.len() - offset;
-    let view = views.len();
-    views.push(BufferViewInfo {
-        offset,
-        length,
-        target,
-    });
-    (view, min, max)
-}
-
-fn push_u16_buffer(
-    bin: &mut Vec<u8>,
-    views: &mut Vec<BufferViewInfo>,
-    values: &[u16],
-    target: u32,
-) -> usize {
-    align4(bin, 0);
-    let offset = bin.len();
-    for value in values {
-        bin.extend_from_slice(&value.to_le_bytes());
-    }
-    let length = bin.len() - offset;
-    let view = views.len();
-    views.push(BufferViewInfo {
-        offset,
-        length,
-        target,
-    });
-    view
-}
-
-fn gltf_json(
-    views: &[BufferViewInfo],
-    accessors: &[AccessorInfo],
-    primitives: &[PrimitiveAccessors],
-    palette: Palette,
-) -> String {
-    let bin_len = views
-        .iter()
-        .map(|view| view.offset + view.length)
-        .max()
-        .unwrap_or(0);
-    let mut json = String::new();
-    json.push_str("{\"asset\":{\"version\":\"2.0\",\"generator\":\"ratty-rubiks-cube\"},");
-    json.push_str("\"scene\":0,\"scenes\":[{\"nodes\":[0]}],\"nodes\":[{\"mesh\":0}],");
-    json.push_str("\"meshes\":[{\"primitives\":[");
-    for (index, primitive) in primitives.iter().enumerate() {
-        if index > 0 {
-            json.push(',');
+        for normal in &primitive.normals {
+            obj.push_str(&format!(
+                "vn {:.5} {:.5} {:.5}\n",
+                normal[0], normal[1], normal[2],
+            ));
         }
-        json.push_str(&format!(
-            "{{\"attributes\":{{\"POSITION\":{},\"NORMAL\":{}}},\"indices\":{},\"material\":{}}}",
-            primitive.position, primitive.normal, primitive.indices, primitive.material
-        ));
-    }
-    json.push_str("]}],\"materials\":[");
-    for (index, material) in material_defs(palette).iter().enumerate() {
-        if index > 0 {
-            json.push(',');
+        for triangle in primitive.indices.chunks_exact(3) {
+            let a = usize::from(triangle[0]);
+            let b = usize::from(triangle[1]);
+            let c = usize::from(triangle[2]);
+            obj.push_str(&format!(
+                "f {}//{} {}//{} {}//{}\n",
+                vertex_offset + a,
+                normal_offset + a,
+                vertex_offset + b,
+                normal_offset + b,
+                vertex_offset + c,
+                normal_offset + c,
+            ));
         }
-        json.push_str(&material_json(material));
+        vertex_offset += primitive.positions.len();
+        normal_offset += primitive.normals.len();
     }
-    json.push_str("],\"buffers\":[{\"byteLength\":");
-    json.push_str(&bin_len.to_string());
-    json.push_str("}],\"bufferViews\":[");
-    for (index, view) in views.iter().enumerate() {
-        if index > 0 {
-            json.push(',');
-        }
-        json.push_str(&format!(
-            "{{\"buffer\":0,\"byteOffset\":{},\"byteLength\":{},\"target\":{}}}",
-            view.offset, view.length, view.target
-        ));
-    }
-    json.push_str("],\"accessors\":[");
-    for (index, accessor) in accessors.iter().enumerate() {
-        if index > 0 {
-            json.push(',');
-        }
-        json.push_str(&accessor_json(accessor));
-    }
-    json.push_str("]}");
-    json
-}
-
-struct MaterialDef {
-    name: &'static str,
-    color: [u8; 3],
-    roughness: f32,
-}
-
-fn material_defs(palette: Palette) -> [MaterialDef; 7] {
-    [
-        MaterialDef {
-            name: "body",
-            color: [14, 15, 18],
-            roughness: 0.68,
-        },
-        face_material(Face::Up, palette),
-        face_material(Face::Down, palette),
-        face_material(Face::Front, palette),
-        face_material(Face::Back, palette),
-        face_material(Face::Right, palette),
-        face_material(Face::Left, palette),
-    ]
-}
-
-fn face_material(face: Face, palette: Palette) -> MaterialDef {
-    MaterialDef {
-        name: face.name(),
-        color: palette.color(face),
-        roughness: 0.46,
-    }
-}
-
-fn material_json(material: &MaterialDef) -> String {
-    let [r, g, b] = material.color;
-    format!(
-        "{{\"name\":\"{}\",\"doubleSided\":true,\"pbrMetallicRoughness\":{{\"baseColorFactor\":[{:.4},{:.4},{:.4},1.0],\"metallicFactor\":0.0,\"roughnessFactor\":{:.3}}}}}",
-        material.name,
-        f32::from(r) / 255.0,
-        f32::from(g) / 255.0,
-        f32::from(b) / 255.0,
-        material.roughness,
-    )
-}
-
-fn accessor_json(accessor: &AccessorInfo) -> String {
-    match accessor {
-        AccessorInfo::Positions {
-            view,
-            count,
-            min,
-            max,
-        } => format!(
-            "{{\"bufferView\":{},\"componentType\":{},\"count\":{},\"type\":\"VEC3\",\"min\":[{:.4},{:.4},{:.4}],\"max\":[{:.4},{:.4},{:.4}]}}",
-            view, COMPONENT_F32, count, min[0], min[1], min[2], max[0], max[1], max[2],
-        ),
-        AccessorInfo::Normals { view, count } => format!(
-            "{{\"bufferView\":{},\"componentType\":{},\"count\":{},\"type\":\"VEC3\"}}",
-            view, COMPONENT_F32, count
-        ),
-        AccessorInfo::Indices { view, count } => format!(
-            "{{\"bufferView\":{},\"componentType\":{},\"count\":{},\"type\":\"SCALAR\"}}",
-            view, COMPONENT_U16, count
-        ),
-    }
-}
-
-fn align4(bytes: &mut Vec<u8>, fill: u8) {
-    while bytes.len() % 4 != 0 {
-        bytes.push(fill);
-    }
+    obj
 }
 
 fn terminal_cell_pixels() -> (f32, f32) {

--- a/widget/src/lib.rs
+++ b/widget/src/lib.rs
@@ -353,6 +353,15 @@ impl<'a> RattyGraphic<'a> {
         format!("\x1b_ratty;g;d;id={}\x1b\\", self.settings.id)
     }
 
+    /// Returns the RGP sequence that deletes every Ratty graphic object.
+    ///
+    /// This emits `d` without an `id`, which is intentionally broader than
+    /// [`Self::delete_sequence`]. Use it for demo cleanup or full-scene reset
+    /// flows where removing all currently registered RGP objects is expected.
+    pub fn delete_all_sequence() -> String {
+        "\x1b_ratty;g;d\x1b\\".to_string()
+    }
+
     /// Writes the RGP delete sequence to stdout.
     ///
     /// # Errors
@@ -360,6 +369,20 @@ impl<'a> RattyGraphic<'a> {
     /// Returns an error if stdout cannot be written or flushed.
     pub fn clear(&self) -> io::Result<()> {
         io::stdout().write_all(self.delete_sequence().as_bytes())?;
+        io::stdout().flush()
+    }
+
+    /// Deletes every Ratty graphic object.
+    ///
+    /// This writes the RGP delete-all sequence to stdout. It affects all RGP
+    /// objects currently known to Ratty, not only objects created by this
+    /// process.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if stdout cannot be written or flushed.
+    pub fn clear_all() -> io::Result<()> {
+        io::stdout().write_all(Self::delete_all_sequence().as_bytes())?;
         io::stdout().flush()
     }
 

--- a/widget/src/lib.rs
+++ b/widget/src/lib.rs
@@ -54,6 +54,8 @@ pub struct RattyGraphicSettings<'a> {
     pub path: Cow<'a, str>,
     /// Asset format.
     pub format: ObjectFormat,
+    /// Controls registration-time normalization for OBJ assets.
+    pub normalize: bool,
     /// Enables default animation.
     pub animate: bool,
     /// Scale multiplier.
@@ -80,6 +82,7 @@ impl<'a> RattyGraphicSettings<'a> {
             id: 1,
             format: ObjectFormat::infer(&path),
             path,
+            normalize: true,
             animate: true,
             scale: 1.0,
             depth: 0.0,
@@ -100,6 +103,21 @@ impl<'a> RattyGraphicSettings<'a> {
     /// Sets the asset format.
     pub fn format(mut self, format: ObjectFormat) -> Self {
         self.format = format;
+        self
+    }
+
+    /// Enables or disables registration-time normalization for OBJ assets.
+    ///
+    /// Normalization is enabled by default. With normalization enabled, Ratty
+    /// recenters each OBJ mesh around its bounding-box center and scales it by
+    /// the largest bounding-box axis so imported models have a predictable
+    /// origin and approximate unit size.
+    ///
+    /// Use `normalize(false)` when the OBJ coordinates are already meaningful,
+    /// for example a generated object that uses Ratty's scene coordinates or a
+    /// larger assembly made from multiple separately registered objects.
+    pub fn normalize(mut self, normalize: bool) -> Self {
+        self.normalize = normalize;
         self
     }
 
@@ -176,10 +194,11 @@ impl<'a> RattyGraphic<'a> {
     /// Returns the RGP register sequence.
     pub fn register_sequence(&self) -> String {
         format!(
-            "\x1b_ratty;g;r;id={};fmt={};path={}\x1b\\",
+            "\x1b_ratty;g;r;id={};fmt={};path={};normalize={}\x1b\\",
             self.settings.id,
             self.settings.format.as_str(),
-            self.settings.path
+            self.settings.path,
+            u8::from(self.settings.normalize)
         )
     }
 
@@ -209,11 +228,12 @@ impl<'a> RattyGraphic<'a> {
             let chunk = &encoded[chunk_start..chunk_end];
             sequences.push(if index == 0 {
                 format!(
-                    "\x1b_ratty;g;r;id={};fmt={};source=payload;more={};name={};{}\x1b\\",
+                    "\x1b_ratty;g;r;id={};fmt={};source=payload;more={};name={};normalize={};{}\x1b\\",
                     self.settings.id,
                     self.settings.format.as_str(),
                     more,
                     name,
+                    u8::from(self.settings.normalize),
                     chunk
                 )
             } else {
@@ -229,10 +249,11 @@ impl<'a> RattyGraphic<'a> {
 
         if sequences.is_empty() {
             sequences.push(format!(
-                "\x1b_ratty;g;r;id={};fmt={};source=payload;more=0;name={};\x1b\\",
+                "\x1b_ratty;g;r;id={};fmt={};source=payload;more=0;name={};normalize={};\x1b\\",
                 self.settings.id,
                 self.settings.format.as_str(),
                 name,
+                u8::from(self.settings.normalize),
             ));
         }
 


### PR DESCRIPTION
https://github.com/user-attachments/assets/f1888795-0829-46ea-8df5-cfdcddcfb663

- add an interactive 3D Rubik's cube `ratatui-ratty` example
- add OBJ normalization control via `RattyGraphicSettings::normalize`
- add `RattyGraphic::clear_all` / `delete_all_sequence` for full RGP scene cleanup
