### PR TITLE
add gpuBackend/gpuAdapter module options for wgpu device selection under Nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -55,6 +55,30 @@
                 }
               '';
             };
+
+            gpuBackend = lib.mkOption {
+              type = lib.types.nullOr (lib.types.enum [ "vulkan" "gl" "gles" ]);
+              default = null;
+              description = ''
+                Force the wgpu backend.
+                Set to null (default) for auto-detection.
+                Useful when the Vulkan ICD loader selects an incompatible driver
+                or when running in headless/VNC environments where OpenGL is preferred.
+              '';
+              example = "vulkan";
+            };
+
+            gpuAdapter = lib.mkOption {
+              type = lib.types.nullOr lib.types.str;
+              default = null;
+              description = ''
+                Substring match to select a specific GPU adapter name.
+                Set to null (default) to use the system default.
+                Useful on multi-GPU systems (e.g. integrated + discrete)
+                or when wgpu picks the wrong adapter.
+              '';
+              example = "RTX 3060";
+            };
           };
         };
     in
@@ -126,10 +150,14 @@
       #       window = { opacity = 0.9; };
       #       shell = { program = "zsh"; };
       #     };
+      #     # Optional: force wgpu backend / adapter selection
+      #     gpuBackend = "vulkan";   # "vulkan" | "gl" | "gles"
+      #     gpuAdapter = "RTX 3060"; # substring match
       #   };
       #
       # Config is written to $XDG_CONFIG_HOME/ratty/ratty.toml
-      # ratty discovers this path automatically.
+      # GPU env vars are set via home.sessionVariables.
+      # ratty discovers the config path automatically.
       homeManagerModules.default =
         args@{
           config,
@@ -149,6 +177,10 @@
             xdg.configFile."ratty/ratty.toml" = lib.mkIf (cfg.settings != { }) {
               source = tomlFormat.generate "ratty.toml" cfg.settings;
             };
+            home.sessionVariables = lib.mkMerge [
+              (lib.mkIf (cfg.gpuBackend != null) { WGPU_BACKEND = cfg.gpuBackend; })
+              (lib.mkIf (cfg.gpuAdapter != null) { WGPU_ADAPTER_NAME = cfg.gpuAdapter; })
+            ];
           };
         };
 
@@ -161,10 +193,13 @@
       #       window = { opacity = 0.9; };
       #       shell = { program = "zsh"; };
       #     };
+      #     # Optional: force wgpu backend / adapter selection
+      #     gpuBackend = "vulkan";   # "vulkan" | "gl" | "gles"
+      #     gpuAdapter = "RTX 3060"; # substring match
       #   };
       #
       # Config is written to /etc/ratty/ratty.toml
-      # Binary is wrapped with --config-file flag to use system config.
+      # Binary is wrapped with --config-file and GPU env vars when set.
       nixosModules.default =
         args@{
           config,
@@ -181,21 +216,25 @@
           inherit (opts) options;
           config = lib.mkIf cfg.enable {
             environment.systemPackages = [
-              (
-                if cfg.settings == { } then
-                  cfg.package
-                else
-                  pkgs.symlinkJoin {
-                    name = "ratty-system-wrapped";
-                    paths = [ cfg.package ];
-                    nativeBuildInputs = [ pkgs.makeWrapper ];
-                    postBuild = ''
-                      rm -f $out/bin/ratty
-                      makeWrapper ${cfg.package}/bin/ratty $out/bin/ratty \
-                        --add-flags "--config-file /etc/ratty/ratty.toml"
-                    '';
-                  }
-              )
+              (let
+                hasSettings = cfg.settings != { };
+                hasGpuOpts = cfg.gpuBackend != null || cfg.gpuAdapter != null;
+              in
+              if !(hasSettings || hasGpuOpts) then
+                cfg.package
+              else
+                pkgs.symlinkJoin {
+                  name = "ratty-system-wrapped";
+                  paths = [ cfg.package ];
+                  nativeBuildInputs = [ pkgs.makeWrapper ];
+                  postBuild = ''
+                    rm -f $out/bin/ratty
+                    makeWrapper ${lib.getExe cfg.package} $out/bin/ratty \
+                      ${lib.optionalString hasSettings "--add-flags \"--config-file /etc/ratty/ratty.toml\""} \
+                      ${lib.optionalString (cfg.gpuBackend != null) "--set WGPU_BACKEND '${cfg.gpuBackend}'"} \
+                      ${lib.optionalString (cfg.gpuAdapter != null) "--set WGPU_ADAPTER_NAME '${cfg.gpuAdapter}'"}
+                  '';
+                })
             ];
 
             environment.etc."ratty/ratty.toml" = lib.mkIf (cfg.settings != { }) {

--- a/nix/README.md
+++ b/nix/README.md
@@ -181,12 +181,12 @@ binary wrapper:
 
 Both `nixosModules.default` and `homeManagerModules.default` expose:
 
-| Option                    | Type         | Default                        | Description                                        |
-| ------------------------- | ------------ | ------------------------------ | -------------------------------------------------- |
-| `programs.ratty.enable`   | bool         | `false`                        | Enable Ratty installation                          |
-| `programs.ratty.package`  | package      | `self.packages.<system>.ratty` | The Ratty package to use                           |
-| `programs.ratty.settings` | attrset      | `{}`                           | Configuration written to `ratty.toml`              |
-| `programs.ratty.gpuBackend` | null or enum | `null`                         | Force wgpu backend: `"vulkan"`, `"gl"`, or `"gles"`. null = auto-detect |
+| Option                      | Type         | Default                        | Description                                                                              |
+| --------------------------- | ------------ | ------------------------------ | ---------------------------------------------------------------------------------------- |
+| `programs.ratty.enable`     | bool         | `false`                        | Enable Ratty installation                                                                |
+| `programs.ratty.package`    | package      | `self.packages.<system>.ratty` | The Ratty package to use                                                                 |
+| `programs.ratty.settings`   | attrset      | `{}`                           | Configuration written to `ratty.toml`                                                    |
+| `programs.ratty.gpuBackend` | null or enum | `null`                         | Force wgpu backend: `"vulkan"`, `"gl"`, or `"gles"`. null = auto-detect                  |
 | `programs.ratty.gpuAdapter` | null or str  | `null`                         | Substring match to select a specific GPU adapter (e.g. `"RTX 3060"`). null = auto-detect |
 
 ## Package Architecture

--- a/nix/README.md
+++ b/nix/README.md
@@ -89,6 +89,26 @@ This will:
 - Write configuration to `/etc/ratty/ratty.toml` (only when `settings` is non-empty)
 - Wrap the binary to use `--config-file /etc/ratty/ratty.toml` (only when `settings` is non-empty)
 
+### GPU Backend Selection
+
+On systems with multiple GPUs or where the default Vulkan device creation fails
+(e.g. NVIDIA 580.x drivers reporting unsupported features), set `gpuBackend` and
+`gpuAdapter` to control wgpu device selection:
+
+```nix
+{
+  programs.ratty = {
+    enable = true;
+    gpuBackend = "vulkan";    # or "gl" / "gles"
+    gpuAdapter = "RTX 3060";  # substring match against adapter name
+  };
+}
+```
+
+When set, the NixOS module wraps the binary with `WGPU_BACKEND` and
+`WGPU_ADAPTER_NAME` environment variables. When both `settings` and GPU options
+are set, a single wrapper applies all flags.
+
 ## Home Manager Configuration
 
 For user-level configuration without root:
@@ -139,17 +159,35 @@ This will:
 
 - Install the Ratty package to your user profile
 - Write configuration to `$XDG_CONFIG_HOME/ratty/ratty.toml` (typically `~/.config/ratty/ratty.toml`) (only when `settings` is non-empty)
+- Set `WGPU_BACKEND` and `WGPU_ADAPTER_NAME` in the user session when GPU options are configured
 - Ratty discovers this path automatically
+
+### GPU Backend Selection (Home Manager)
+
+Same options as NixOS, but applied via `home.sessionVariables` instead of a
+binary wrapper:
+
+```nix
+{
+  programs.ratty = {
+    enable = true;
+    gpuBackend = "vulkan";
+    gpuAdapter = "RTX 3060";
+  };
+}
+```
 
 ## Module Options
 
 Both `nixosModules.default` and `homeManagerModules.default` expose:
 
-| Option                    | Type    | Default                        | Description                           |
-| ------------------------- | ------- | ------------------------------ | ------------------------------------- |
-| `programs.ratty.enable`   | bool    | `false`                        | Enable Ratty installation             |
-| `programs.ratty.package`  | package | `self.packages.<system>.ratty` | The Ratty package to use              |
-| `programs.ratty.settings` | attrset | `{}`                           | Configuration written to `ratty.toml` |
+| Option                    | Type         | Default                        | Description                                        |
+| ------------------------- | ------------ | ------------------------------ | -------------------------------------------------- |
+| `programs.ratty.enable`   | bool         | `false`                        | Enable Ratty installation                          |
+| `programs.ratty.package`  | package      | `self.packages.<system>.ratty` | The Ratty package to use                           |
+| `programs.ratty.settings` | attrset      | `{}`                           | Configuration written to `ratty.toml`              |
+| `programs.ratty.gpuBackend` | null or enum | `null`                         | Force wgpu backend: `"vulkan"`, `"gl"`, or `"gles"`. null = auto-detect |
+| `programs.ratty.gpuAdapter` | null or str  | `null`                         | Substring match to select a specific GPU adapter (e.g. `"RTX 3060"`). null = auto-detect |
 
 ## Package Architecture
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,8 @@ use std::time::Duration;
 use anyhow::anyhow;
 use bevy::asset::AssetPlugin;
 use bevy::prelude::*;
+use bevy::render::RenderPlugin;
+use bevy::render::settings::{WgpuSettings, WgpuSettingsPriority};
 use bevy::window::{PrimaryWindow, WindowCreated, WindowResolution};
 use bevy::winit::{UpdateMode, WINIT_WINDOWS, WinitSettings};
 use clap::Parser;
@@ -81,6 +83,15 @@ fn main() -> anyhow::Result<()> {
                 })
                 .set(AssetPlugin {
                     file_path: asset_root.to_string_lossy().into_owned(),
+                    ..default()
+                })
+                .set(RenderPlugin {
+                    render_creation: bevy::render::settings::RenderCreation::Automatic(
+                        WgpuSettings {
+                            priority: WgpuSettingsPriority::Compatibility,
+                            ..default()
+                        },
+                    ),
                     ..default()
                 }),
         )


### PR DESCRIPTION
The NixOS and Home Manager modules now expose two options for controlling wgpu device selection:
programs.ratty = {
  gpuBackend = "vulkan";    # "vulkan" | "gl" | "gles" | null
  gpuAdapter = "RTX 3060";  # substring match | null
};
gpuBackend — Sets WGPU_BACKEND to force the graphics API. Cases:
- "vulkan" — Explicit Vulkan path. Needed when the default backend auto-detection picks a broken backend, or when testing driver-specific behaviour.
- "gl" / "gles" — OpenGL fallback. Useful on systems where Vulkan is unavailable or broken (headless, VNC, older hardware, driver bugs).
- null — Auto-detect (default). wgpu picks the best available backend.
gpuAdapter — Sets WGPU_ADAPTER_NAME to select a specific GPU by name substring. Cases:
- Multi-GPU systems (integrated + discrete, or dual discrete) where wgpu picks the wrong adapter.
- Testing against a specific GPU without disabling others in BIOS.
- Offloading rendering to a secondary GPU while keeping the primary for display.
The NixOS module composes these into a single makeWrapper call alongside the existing --config-file flag. The Home Manager module sets them via home.sessionVariables.