### PR TITLE
feat(cursor): apply texture from config for obj and stl models

### DIFF
--- a/config/ratty.toml
+++ b/config/ratty.toml
@@ -23,6 +23,7 @@ size = 18
 
 [cursor.model]
 path = "CairoSpinyMouse.obj"
+# texture = "texture.png"
 scale_factor = 6.0
 brightness = 0.5
 x_offset = 0.5

--- a/src/config.rs
+++ b/src/config.rs
@@ -95,6 +95,9 @@ impl AppConfig {
     fn resolve_relative_paths(&mut self, path: &Path) {
         let config_dir = path.parent().unwrap_or_else(|| Path::new("."));
         self.cursor.model.path = resolve_config_path(config_dir, &self.cursor.model.path);
+        if let Some(texture) = self.cursor.model.texture.as_mut() {
+            *texture = resolve_config_path(config_dir, texture);
+        }
         if let Some(program) = self.shell.program.as_mut() {
             *program = resolve_config_path(config_dir, program);
         }
@@ -428,6 +431,8 @@ pub struct CursorModelConfig {
     pub color: [u8; 3],
     /// Cursor asset path.
     pub path: PathBuf,
+    /// Optional base-color texture image applied to the cursor model.
+    pub texture: Option<PathBuf>,
 }
 
 impl Default for CursorModelConfig {
@@ -440,6 +445,7 @@ impl Default for CursorModelConfig {
             brightness: 1.0,
             color: [255, 255, 255],
             path: PathBuf::from("CairoSpinyMouse.obj"),
+            texture: None,
         }
     }
 }

--- a/src/model.rs
+++ b/src/model.rs
@@ -173,7 +173,11 @@ fn load_texture_image(path: &Path) -> anyhow::Result<Image> {
     // Normalize to 8-bit RGBA so the texture uses a widely supported GPU format.
     // Decoded 16-bit images would otherwise need the TEXTURE_FORMAT_16BIT_NORM feature.
     let rgba = image::DynamicImage::ImageRgba8(dynamic.into_rgba8());
-    Ok(Image::from_dynamic(rgba, true, RenderAssetUsages::default()))
+    Ok(Image::from_dynamic(
+        rgba,
+        true,
+        RenderAssetUsages::default(),
+    ))
 }
 
 /// Loads an object source from a path.

--- a/src/model.rs
+++ b/src/model.rs
@@ -70,6 +70,7 @@ pub fn spawn_cursor_model(
     commands: &mut Commands,
     meshes: &mut Assets<Mesh>,
     materials: &mut Assets<StandardMaterial>,
+    images: &mut Assets<Image>,
     asset_server: &AssetServer,
     app_config: &AppConfig,
 ) {
@@ -81,9 +82,23 @@ pub fn spawn_cursor_model(
         ))
         .id();
 
+    let base_color_texture = app_config.cursor.model.texture.as_deref().and_then(|path| {
+        match load_texture_image(path) {
+            Ok(image) => {
+                info!("loaded cursor texture from {}", path.display());
+                Some(images.add(image))
+            }
+            Err(error) => {
+                warn!("failed to load cursor texture: {error:#}");
+                None
+            }
+        }
+    });
+
     let [r, g, b] = app_config.cursor.model.color;
     let material = materials.add(StandardMaterial {
         base_color: Color::srgb_u8(r, g, b),
+        base_color_texture,
         emissive: LinearRgba::rgb(0.35, 0.35, 0.35),
         metallic: 0.0,
         perceptual_roughness: 0.28,
@@ -142,6 +157,23 @@ pub fn spawn_cursor_model(
             });
         }
     }
+}
+
+/// Loads a base-color texture image from a path into a Bevy [`Image`].
+///
+/// # Errors
+///
+/// Returns an error if the file cannot be read or decoded.
+fn load_texture_image(path: &Path) -> anyhow::Result<Image> {
+    let path = expand_path(path);
+    let bytes =
+        std::fs::read(&path).with_context(|| format!("failed to read {}", path.display()))?;
+    let dynamic = image::load_from_memory(&bytes)
+        .with_context(|| format!("failed to decode texture {}", path.display()))?;
+    // Normalize to 8-bit RGBA so the texture uses a widely supported GPU format.
+    // Decoded 16-bit images would otherwise need the TEXTURE_FORMAT_16BIT_NORM feature.
+    let rgba = image::DynamicImage::ImageRgba8(dynamic.into_rgba8());
+    Ok(Image::from_dynamic(rgba, true, RenderAssetUsages::default()))
 }
 
 /// Loads an object source from a path.
@@ -492,6 +524,7 @@ fn build_meshes(
             PrimitiveTopology::TriangleList,
             RenderAssetUsages::default(),
         );
+        let position_count = positions.len();
         mesh.insert_attribute(Mesh::ATTRIBUTE_POSITION, positions);
 
         if !source_mesh.vertex_color.is_empty() {
@@ -512,6 +545,17 @@ fn build_meshes(
                 .map(|normal| [normal[0], normal[1], normal[2]])
                 .collect::<Vec<[f32; 3]>>();
             mesh.insert_attribute(Mesh::ATTRIBUTE_NORMAL, normals);
+        }
+
+        if !source_mesh.texcoords.is_empty() {
+            let uvs = source_mesh
+                .texcoords
+                .chunks_exact(2)
+                .map(|uv| [uv[0], 1.0 - uv[1]])
+                .collect::<Vec<[f32; 2]>>();
+            if uvs.len() == position_count {
+                mesh.insert_attribute(Mesh::ATTRIBUTE_UV_0, uvs);
+            }
         }
 
         mesh.insert_indices(Indices::U32(source_mesh.indices));

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -438,7 +438,14 @@ pub(crate) fn redraw_soft_terminal(mut params: RedrawParams) {
 
     if !model_load_state.loaded {
         if app_config.cursor.model.visible {
-            spawn_cursor_model(commands, meshes, materials, asset_server, app_config);
+            spawn_cursor_model(
+                commands,
+                meshes,
+                materials,
+                images,
+                asset_server,
+                app_config,
+            );
         }
         model_load_state.loaded = true;
     }


### PR DESCRIPTION
This adds a `texture` option to the cursor model config so a base-color texture can be applied to the cursor model without editing code. Addresses #78.

```toml
[cursor.model]
path = "CairoSpinyMouse.obj"
texture = "texture.png"
```

The path is resolved relative to the config file, the same way `path` is.

- `config`: new `texture: Option<PathBuf>` field on `[cursor.model]`, resolved relative to the config file.
- `model`: decode the image and set it as `base_color_texture` on the cursor material. Also load UV coordinates from OBJ files, which were previously dropped (a texture has nothing to map to without UVs).
- `systems`: thread the image asset store into cursor spawning.
- `config/ratty.toml`: documented example.
