### PR TITLE
fix(input): respect bracketed paste mode and harden paste handling

### DIFF
--- a/src/keyboard.rs
+++ b/src/keyboard.rs
@@ -456,11 +456,8 @@ pub fn handle_keyboard_input(
                 }
                 BindingAction::Paste => {
                     if let Some(text) = params.clipboard.paste() {
-                        let normalized = text.replace("\r\n", "\n").replace('\r', "\n");
-                        let mut bytes = Vec::from(b"\x1b[200~".as_slice());
-                        bytes.extend_from_slice(normalized.as_bytes());
-                        bytes.extend_from_slice(b"\x1b[201~");
-                        params.runtime.write_input(&bytes);
+                        let bracketed = params.runtime.parser.screen().bracketed_paste();
+                        params.runtime.write_input(&encode_paste(&text, bracketed));
                     } else {
                         warn!("failed to read clipboard contents for paste");
                     }
@@ -710,6 +707,32 @@ fn translate_key(key_code: KeyCode, ctx: KeyTranslationContext<'_>) -> Vec<u8> {
     }
 
     bytes
+}
+
+/// Bracketed paste start marker (DECSET 2004).
+const PASTE_START: &[u8] = b"\x1b[200~";
+/// Bracketed paste end marker.
+const PASTE_END: &[u8] = b"\x1b[201~";
+
+/// Encodes clipboard text as terminal input, wrapping it in bracketed paste
+/// markers when DECSET 2004 is active. The 7-bit `ESC` and 8-bit `CSI` control
+/// introducers are dropped from bracketed payloads so a paste can never
+/// terminate its own bracket (paste injection).
+fn encode_paste(text: &str, bracketed: bool) -> Vec<u8> {
+    if bracketed {
+        let normalized = text.replace("\r\n", "\n").replace('\r', "\n");
+        let sanitized: String = normalized
+            .chars()
+            .filter(|&ch| ch != '\u{1b}' && ch != '\u{9b}')
+            .collect();
+        let mut bytes = Vec::with_capacity(sanitized.len() + PASTE_START.len() + PASTE_END.len());
+        bytes.extend_from_slice(PASTE_START);
+        bytes.extend_from_slice(sanitized.as_bytes());
+        bytes.extend_from_slice(PASTE_END);
+        bytes
+    } else {
+        text.replace("\r\n", "\r").replace('\n', "\r").into_bytes()
+    }
 }
 
 /// Determine the text to send for a key event.
@@ -1009,5 +1032,53 @@ fn ctrl_keycode_byte(key: KeyCode) -> Option<u8> {
         KeyCode::KeyY => Some(0x19),
         KeyCode::KeyZ => Some(0x1a),
         _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bracketed_paste_wraps_payload_in_markers() {
+        assert_eq!(
+            encode_paste("echo hi", true),
+            b"\x1b[200~echo hi\x1b[201~".to_vec()
+        );
+    }
+
+    #[test]
+    fn bracketed_paste_normalizes_newlines() {
+        assert_eq!(
+            encode_paste("one\r\ntwo\rthree\n", true),
+            b"\x1b[200~one\ntwo\nthree\n\x1b[201~".to_vec()
+        );
+    }
+
+    #[test]
+    fn bracketed_paste_strips_control_introducers() {
+        // A 7-bit ESC or 8-bit CSI end marker embedded in the payload must be
+        // neutralized so the paste cannot terminate its own bracket.
+        assert_eq!(
+            encode_paste("before\x1b[201~after", true),
+            b"\x1b[200~before[201~after\x1b[201~".to_vec()
+        );
+        assert_eq!(
+            encode_paste("before\u{9b}201~after", true),
+            b"\x1b[200~before201~after\x1b[201~".to_vec()
+        );
+    }
+
+    #[test]
+    fn plain_paste_sends_no_markers() {
+        assert_eq!(encode_paste("echo hi", false), b"echo hi".to_vec());
+    }
+
+    #[test]
+    fn plain_paste_sends_newlines_as_carriage_returns() {
+        assert_eq!(
+            encode_paste("one\r\ntwo\nthree", false),
+            b"one\rtwo\rthree".to_vec()
+        );
     }
 }


### PR DESCRIPTION
## Summary

Fixes #122.

- keyboard: only wrap pasted text in `ESC[200~`/`ESC[201~` when the application has bracketed paste (DECSET 2004) enabled, via `vt100::Screen::bracketed_paste()`
- keyboard: drop the 7-bit `ESC` and 8-bit `CSI` (`U+009B`) control introducers from bracketed payloads so clipboard content containing `ESC[201~` (or its C1 equivalent) cannot terminate the bracket early and inject input
- keyboard: deliver newlines as carriage returns in non-bracketed pastes, matching the byte the Enter key sends

The paste encoding is extracted into `encode_paste`, a pure function, so the behavior is unit-testable. Control-introducer filtering happens per `char` rather than per byte, so it can't corrupt a multi-byte UTF-8 sequence whose continuation byte happens to be `0x9b`.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --lib` (5 unit tests: marker gating, newline handling in both modes, and the ESC/CSI injection cases)

To verify manually: run `cat > /tmp/out`, paste, then `xxd /tmp/out` — the file should contain only the pasted text, no `ESC[200~`/`ESC[201~`; pasting at a bash/zsh prompt (which enables bracketed paste) should still arrive as a single bracketed paste.
