### PR TITLE
feat(config): add window update_mode option

### DIFF
--- a/config/ratty.toml
+++ b/config/ratty.toml
@@ -3,8 +3,8 @@ width = 960
 height = 620
 opacity = 0.8
 # scale_factor = 1.0
-# update_mode = "Continuous"  # or "LowPower" to redraw reactively while focused
-# frame_interval_ms = 33      # frame rate cap in "LowPower" mode
+# update_mode = "Continuous"  # Use "LowPower" to redraw only after input or terminal output.
+# frame_interval_ms = 33      # Minimum milliseconds between LowPower redraws.
 
 [terminal]
 default_cols = 104

--- a/config/ratty.toml
+++ b/config/ratty.toml
@@ -3,6 +3,8 @@ width = 960
 height = 620
 opacity = 0.8
 # scale_factor = 1.0
+# update_mode = "Continuous"  # or "LowPower" to redraw reactively while focused
+# frame_interval_ms = 33      # frame rate cap in "LowPower" mode
 
 [terminal]
 default_cols = 104

--- a/src/config.rs
+++ b/src/config.rs
@@ -136,6 +136,11 @@ pub struct WindowConfig {
     pub scale_factor: Option<f32>,
     /// Window opacity from `0.0` to `1.0`.
     pub opacity: f32,
+    /// How the window schedules redraws while focused.
+    pub update_mode: UpdateModeConfig,
+    /// Minimum time between redraws while focused, in milliseconds.
+    /// Only applies when `update_mode` is `LowPower`.
+    pub frame_interval_ms: u64,
 }
 
 impl Default for WindowConfig {
@@ -145,8 +150,22 @@ impl Default for WindowConfig {
             height: 620,
             scale_factor: None,
             opacity: 1.0,
+            update_mode: UpdateModeConfig::Continuous,
+            frame_interval_ms: 33,
         }
     }
+}
+
+/// How the window schedules redraws while focused.
+#[derive(Debug, Clone, Copy, Deserialize, Default)]
+pub enum UpdateModeConfig {
+    /// Redraw continuously, regardless of input.
+    #[serde(rename = "Continuous")]
+    #[default]
+    Continuous,
+    /// Redraw in response to events, rate-limited to `frame_interval_ms`.
+    #[serde(rename = "LowPower")]
+    LowPower,
 }
 
 /// Terminal grid configuration.

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,15 +5,16 @@ use bevy::prelude::*;
 use bevy::render::RenderPlugin;
 use bevy::render::settings::{WgpuSettings, WgpuSettingsPriority};
 use bevy::window::{PrimaryWindow, WindowCreated, WindowResizeConstraints, WindowResolution};
-use bevy::winit::{WINIT_WINDOWS, WinitSettings};
+use bevy::winit::{UpdateMode, WINIT_WINDOWS, WinitSettings};
 use clap::Parser;
+use std::time::Duration;
 
 #[cfg(target_os = "windows")]
 use winit::platform::windows::{IconExtWindows, WindowExtWindows};
 use winit::window::Icon;
 
 use ratty::cli::Cli;
-use ratty::config::AppConfig;
+use ratty::config::{AppConfig, UpdateModeConfig};
 use ratty::paths::runtime_asset_root;
 use ratty::plugin::TerminalPlugin;
 use ratty::runtime::{RuntimeOptions, TerminalRuntime};
@@ -66,10 +67,19 @@ fn main() -> anyhow::Result<()> {
         .insert_resource(runtime)
         .insert_resource(terminal)
         .insert_non_send(AppWindowIcon { icon: window_icon })
-        // Always update continuously, focused or not. Bevy's default switches
-        // unfocused windows to a reactive mode, which would delay background
-        // PTY output.
-        .insert_resource(WinitSettings::continuous())
+        // Unfocused windows always update continuously. Bevy's default switches
+        // them to a reactive mode, which would delay background PTY output.
+        // While focused, `update_mode` picks between updating continuously and
+        // updating reactively at a capped frame rate to reduce idle CPU usage.
+        .insert_resource(match app_config.window.update_mode {
+            UpdateModeConfig::Continuous => WinitSettings::continuous(),
+            UpdateModeConfig::LowPower => WinitSettings {
+                focused_mode: UpdateMode::reactive_low_power(Duration::from_millis(
+                    app_config.window.frame_interval_ms,
+                )),
+                unfocused_mode: UpdateMode::Continuous,
+            },
+        })
         .add_plugins(
             DefaultPlugins
                 .set(WindowPlugin {


### PR DESCRIPTION
Closes #130.

Adds `[window] update_mode` (`"Continuous"` | `"LowPower"`) and `[window] frame_interval_ms`, exposing the winit `UpdateMode` used while the window is focused.

**The default is unchanged.** `update_mode` defaults to `Continuous`, which takes the same `WinitSettings::continuous()` path as today, so existing setups behave exactly as they do now.

`LowPower` restores what 0.4.2 used: `focused_mode: reactive_low_power(frame_interval_ms)` with `unfocused_mode: Continuous`. Keeping unfocused continuous preserves the reasoning behind the current code — the comment notes that a reactive unfocused mode would delay background PTY output, and that rationale is about the unfocused mode, so `LowPower` only changes the focused one. `frame_interval_ms` defaults to `33`, matching 0.4.2's `FOCUSED_UPDATE_INTERVAL`.

Measured on the setup from #130 (RTX 4080, Hyprland, 520x60 window, idle, same build — only the config differs):

| Config | CPU, one core |
|---|---|
| default (`Continuous`) | 49.3% |
| `update_mode = "LowPower"` | 7.85% |

The checks in CONTRIBUTING.md pass: `cargo check`, `cargo fmt --all -- --check`, and `cargo clippy --all-targets --all-features -- -D warnings`.

Two notes:

- I used PascalCase values (`"Continuous"` / `"LowPower"`) to match the existing enum values in `ratty.toml` (`style = "Regular"`, `action = "Copy"`) rather than the lowercase spelling I used in the issue. Easy to change if you'd prefer.
- No tests added — there's no existing test setup for config parsing, and the default path is unchanged. Happy to add some if you want them.

I'm not a Rust developer, and I used Claude to help write this patch. I've built and tested it on the machine from #130, and I'm glad to test any changes you'd like against that setup.
