### PR TITLE
feat: add text-based model positioning mode

### DIFF
--- a/protocols/graphics.md
+++ b/protocols/graphics.md
@@ -65,7 +65,7 @@ ESC _ ratty;g;s ESC \
 Ratty replies:
 
 ```text
-ESC _ ratty;g;s;v=1;fmt=obj|glb;path=1;payload=1;chunk=1;anim=1;depth=1;color=1;brightness=1;transform=1;update=1 ESC \
+ESC _ ratty;g;s;v=1;fmt=obj|glb;path=1;payload=1;chunk=1;anim=1;depth=1;color=1;brightness=1;transform=1;update=1;anchor=screen|text ESC \
 ```
 
 Fields:
@@ -81,6 +81,7 @@ Fields:
 - `brightness=1`: `brightness=<f32>` placement is supported
 - `transform=1`: transform fields such as rotation and offsets are supported
 - `update=1`: `u` object updates are supported
+- `anchor=screen|text`: fixed screen and text-tracked placements are supported
 
 If no reply arrives, the terminal does not support the protocol.
 
@@ -161,6 +162,10 @@ Fields:
 - `col`: anchor column at the center of the placement
 - `w`: width in terminal cells
 - `h`: height in terminal cells
+- `anchor`: optional anchoring mode, defaults to `screen`
+  - `screen`: keep the object at the specified screen coordinates
+  - `text`: attach the object to the text cell immediately preceding the place
+    sequence in the output stream
 - `animate`: optional, `1` enables default animation
 - `scale`: optional scale factor, defaults to `1.0`
 - `depth`: optional z-offset, defaults to `0.0`
@@ -171,6 +176,26 @@ Fields:
 - `sx`, `sy`, `sz`: optional non-uniform scale, defaults to `1`
 
 Clients that only send the original v1 fields still work unchanged.
+
+#### Text-anchored placement
+
+With `anchor=text`, Ratty stores a zero-width marker in the preceding terminal
+cell. The object follows that cell when terminal output scrolls or rearranges
+the text buffer. It is hidden while the cell is outside the visible viewport
+and reappears when the cell returns through scrollback.
+
+The place sequence must be emitted immediately after the character at
+`row`,`col`. For example, this output attaches object `42` to `X`:
+
+```text
+X ESC _ ratty;g;p;id=42;row=12;col=8;w=4;h=2;anchor=text ESC \
+```
+
+`row` and `col` remain the center of the placement. The tracked character is
+therefore also the placement's anchor cell. Applications using
+`ratatui-ratty` can select this behavior with
+`RattyGraphicSettings::anchor_mode(AnchorMode::Text)`; the widget emits the
+character and sequence in the required order.
 
 ### 4. Update Object
 

--- a/src/inline.rs
+++ b/src/inline.rs
@@ -10,7 +10,7 @@ use vt100::Callbacks;
 use crate::kitty::{KittyOperation, KittyParserState, refresh_kitty_placeholder_anchors};
 use crate::model::{ObjectSource, load_object_source, load_object_source_from_bytes};
 use crate::rgp::{
-    RgpOperation, RgpPlacementStyle, RgpPlacementUpdate, RgpRegisterSource,
+    RgpAnchorMode, RgpOperation, RgpPlacementStyle, RgpPlacementUpdate, RgpRegisterSource,
     consume_sequence as consume_rgp_sequence, support_reply,
 };
 const APC_START: &[u8] = b"\x1b_";
@@ -42,6 +42,7 @@ pub struct TerminalInlineObjects {
     last_viewport_size: Vec2,
     last_cols: u16,
     last_rows: u16,
+    next_rgp_marker_id: u32,
     pub(crate) objects: HashMap<u32, InlineObject>,
     pub(crate) anchors: HashMap<u32, InlineAnchor>,
 }
@@ -79,8 +80,7 @@ impl TerminalInlineObjects {
                 return replies;
             };
             let sequence = self.pending_bytes[start..end].to_vec();
-            let (handled, reply) =
-                self.handle_apc_sequence(&sequence, parser.screen().cursor_position());
+            let (handled, reply) = self.handle_apc_sequence(&sequence, parser);
             if let Some(reply) = reply {
                 replies.push(reply);
             }
@@ -107,44 +107,120 @@ impl TerminalInlineObjects {
         self.last_rows = rows;
     }
 
-    /// Applies upward scroll to anchored objects.
+    /// Applies inferred upward scroll to legacy scroll-coupled objects.
     pub fn apply_scroll(&mut self, rows_scrolled: u16) {
         if rows_scrolled == 0 || self.anchors.is_empty() {
             return;
         }
 
-        self.anchors.retain(|object_id, anchor| {
-            if self
-                .objects
-                .get(object_id)
-                .is_some_and(|object| !object.scrolls_with_text())
-            {
-                return true;
+        for (object_id, anchor) in &mut self.anchors {
+            let scrolls_with_text = match self.objects.get(object_id) {
+                Some(InlineObject::KittyImage(object)) => !object.uses_placeholders,
+                Some(InlineObject::RgpObject(_)) => anchor.marker_id.is_some(),
+                None => false,
+            };
+            if scrolls_with_text {
+                anchor.row -= i32::from(rows_scrolled);
+                anchor.visible = anchor.row + anchor.rows as i32 > 0;
             }
-            let new_row = anchor.row as i32 - rows_scrolled as i32;
-            if new_row + anchor.rows as i32 <= 0 {
-                return false;
-            }
-            anchor.row = new_row.max(0) as u16;
-            true
-        });
+        }
         self.dirty = true;
     }
 
     /// Returns whether any anchors need scroll tracking.
     pub fn has_scroll_tracked_anchors(&self) -> bool {
-        self.anchors.keys().any(|object_id| {
-            self.objects
-                .get(object_id)
-                .is_some_and(InlineObject::scrolls_with_text)
-        })
+        self.anchors
+            .iter()
+            .any(|(object_id, anchor)| match self.objects.get(object_id) {
+                Some(InlineObject::KittyImage(object)) => !object.uses_placeholders,
+                Some(InlineObject::RgpObject(_)) => anchor.marker_id.is_some(),
+                None => false,
+            })
     }
 
-    /// Refreshes placeholder-derived Kitty anchors.
+    /// Refreshes anchors derived from markers in the terminal buffer.
     pub fn refresh_placeholder_anchors(&mut self, screen: &vt100::Screen) {
-        if refresh_kitty_placeholder_anchors(&self.objects, &mut self.anchors, screen) {
+        self.refresh_anchors(screen, false);
+    }
+
+    /// Moves text anchors with a scrollback viewport change, then resolves visible markers.
+    pub fn apply_scrollback_change(&mut self, previous: usize, screen: &vt100::Screen) {
+        let delta = scrollback_row_delta(previous, screen.scrollback());
+        if delta != 0 {
+            let viewport_rows = screen.size().0;
+            for anchor in self.anchors.values_mut() {
+                if anchor.mode == InlineAnchorMode::Text && anchor.marker_id.is_some() {
+                    anchor.row = anchor.row.saturating_add(delta);
+                    anchor.visible =
+                        anchor_intersects_viewport(anchor.row, anchor.rows, viewport_rows);
+                }
+            }
             self.dirty = true;
         }
+        self.refresh_anchors(screen, true);
+    }
+
+    /// Refreshes anchors after PTY output, retaining objects that are still scrolling offscreen.
+    pub fn refresh_anchors_after_output(&mut self, screen: &vt100::Screen) {
+        self.refresh_anchors(screen, true);
+    }
+
+    fn refresh_anchors(&mut self, screen: &vt100::Screen, preserve_exiting: bool) {
+        if refresh_kitty_placeholder_anchors(&self.objects, &mut self.anchors, screen)
+            | self.refresh_rgp_text_anchors(screen, preserve_exiting)
+        {
+            self.dirty = true;
+        }
+    }
+
+    fn refresh_rgp_text_anchors(&mut self, screen: &vt100::Screen, preserve_exiting: bool) -> bool {
+        let tracked_anchors = self
+            .anchors
+            .iter()
+            .filter_map(|(object_id, anchor)| {
+                (anchor.mode == InlineAnchorMode::Text).then_some((*object_id, anchor.marker_id?))
+            })
+            .collect::<Vec<_>>();
+        if tracked_anchors.is_empty() {
+            return false;
+        }
+
+        let mut positions = HashMap::new();
+        let (rows, cols) = screen.size();
+        for row in 0..rows {
+            for col in 0..cols {
+                let Some(object_id) = screen
+                    .cell(row, col)
+                    .and_then(|cell| rgp_text_marker_id(cell.contents()))
+                else {
+                    continue;
+                };
+                positions.insert(object_id, (row, col));
+            }
+        }
+
+        let mut changed = false;
+        for (object_id, marker_id) in tracked_anchors {
+            let Some(anchor) = self.anchors.get_mut(&object_id) else {
+                continue;
+            };
+            if let Some((row, col)) = positions.get(&marker_id).copied() {
+                let top = text_anchor_top(row, anchor.marker_row_offset);
+                let left = col.saturating_sub(anchor.marker_col_offset);
+                changed |= anchor.row != top || anchor.col != left || !anchor.visible;
+                anchor.row = top;
+                anchor.col = left;
+                anchor.visible = true;
+            } else if preserve_exiting && anchor.row < 0 {
+                let visible = anchor_intersects_viewport_top(anchor.row, anchor.rows);
+                changed |= anchor.visible != visible;
+                anchor.visible = visible;
+            } else {
+                changed |= anchor.visible;
+                anchor.visible = false;
+            }
+        }
+        changed
     }
 
     fn set_anchor(&mut self, object_id: u32, anchor: InlineAnchor) {
@@ -166,15 +242,16 @@ impl TerminalInlineObjects {
         self.dirty = true;
     }
 
-    fn handle_apc_sequence(
+    fn handle_apc_sequence<CB: Callbacks>(
         &mut self,
         sequence: &[u8],
-        cursor_position: (u16, u16),
+        parser: &mut vt100::Parser<CB>,
     ) -> (bool, Option<Vec<u8>>) {
-        if let Some(reply) = self.handle_rgp_sequence(sequence) {
+        if let Some(reply) = self.handle_rgp_sequence(sequence, parser) {
             return (true, reply);
         }
 
+        let cursor_position = parser.screen().cursor_position();
         let Some(operation) = self.kitty.consume_sequence(sequence, cursor_position) else {
             return (false, None);
         };
@@ -193,10 +270,15 @@ impl TerminalInlineObjects {
                 anchor,
             } => {
                 self.remove_objects_at(&InlineAnchor {
-                    row: anchor.row,
+                    row: i32::from(anchor.row),
                     col: anchor.col,
                     columns: anchor.columns,
                     rows: anchor.rows,
+                    mode: InlineAnchorMode::Screen,
+                    marker_id: None,
+                    marker_row_offset: 0,
+                    marker_col_offset: 0,
+                    visible: true,
                     style: InlineStyle::default(),
                 });
                 self.objects
@@ -204,10 +286,15 @@ impl TerminalInlineObjects {
                 self.set_anchor(
                     object_id,
                     InlineAnchor {
-                        row: anchor.row,
+                        row: i32::from(anchor.row),
                         col: anchor.col,
                         columns: anchor.columns,
                         rows: anchor.rows,
+                        mode: InlineAnchorMode::Screen,
+                        marker_id: None,
+                        marker_row_offset: 0,
+                        marker_col_offset: 0,
+                        visible: true,
                         style: InlineStyle::default(),
                     },
                 );
@@ -218,10 +305,15 @@ impl TerminalInlineObjects {
                     self.set_anchor(
                         object_id,
                         InlineAnchor {
-                            row: anchor.row,
+                            row: i32::from(anchor.row),
                             col: anchor.col,
                             columns: anchor.columns,
                             rows: anchor.rows,
+                            mode: InlineAnchorMode::Screen,
+                            marker_id: None,
+                            marker_row_offset: 0,
+                            marker_col_offset: 0,
+                            visible: true,
                             style: InlineStyle::default(),
                         },
                     );
@@ -239,7 +331,11 @@ impl TerminalInlineObjects {
         }
     }
 
-    fn handle_rgp_sequence(&mut self, sequence: &[u8]) -> Option<Option<Vec<u8>>> {
+    fn handle_rgp_sequence<CB: Callbacks>(
+        &mut self,
+        sequence: &[u8],
+        parser: &mut vt100::Parser<CB>,
+    ) -> Option<Option<Vec<u8>>> {
         let operation = consume_rgp_sequence(sequence)?;
         Some(match operation {
             RgpOperation::SupportQuery => Some(support_reply()),
@@ -290,12 +386,14 @@ impl TerminalInlineObjects {
             }
             RgpOperation::Place { object_id, anchor } => {
                 if self.objects.contains_key(&object_id) {
-                    let row = anchor
-                        .row
-                        .saturating_sub(anchor.rows.saturating_sub(1).div_ceil(2) as u16);
+                    let marker_row_offset = anchor.rows.saturating_sub(1).div_ceil(2) as u16;
+                    let row = i32::from(anchor.row) - i32::from(marker_row_offset);
                     let col = anchor
                         .col
                         .saturating_sub(anchor.columns.saturating_sub(1).div_ceil(2) as u16);
+                    let marker_col_offset = anchor.col.saturating_sub(col);
+                    let marker_id =
+                        (anchor.mode == RgpAnchorMode::Text).then(|| self.allocate_rgp_marker_id());
                     self.set_anchor(
                         object_id,
                         InlineAnchor {
@@ -303,9 +401,17 @@ impl TerminalInlineObjects {
                             col,
                             columns: anchor.columns,
                             rows: anchor.rows,
+                            mode: anchor.mode.into(),
+                            marker_id,
+                            marker_row_offset,
+                            marker_col_offset,
+                            visible: true,
                             style: anchor.style.into(),
                         },
                     );
+                    if let Some(marker_id) = marker_id {
+                        parser.process(rgp_text_marker(marker_id).as_bytes());
+                    }
                 }
                 None
             }
@@ -328,8 +434,14 @@ impl TerminalInlineObjects {
         })
     }
 
+    fn allocate_rgp_marker_id(&mut self) -> u32 {
+        let marker_id = self.next_rgp_marker_id;
+        self.next_rgp_marker_id = self.next_rgp_marker_id.wrapping_add(1);
+        marker_id
+    }
+
     fn remove_objects_at(&mut self, new_anchor: &InlineAnchor) {
-        let row_start = new_anchor.row as i32;
+        let row_start = new_anchor.row;
         let row_end = row_start + new_anchor.rows as i32;
         let col_start = new_anchor.col as i32;
         let col_end = col_start + new_anchor.columns as i32;
@@ -338,7 +450,7 @@ impl TerminalInlineObjects {
             .anchors
             .iter()
             .filter_map(|(object_id, anchor)| {
-                let anchor_row_start = anchor.row as i32;
+                let anchor_row_start = anchor.row;
                 let anchor_row_end = anchor_row_start + anchor.rows as i32;
                 let anchor_col_start = anchor.col as i32;
                 let anchor_col_end = anchor_col_start + anchor.columns as i32;
@@ -536,11 +648,21 @@ pub enum RgpInlineObject {
     },
 }
 
-impl InlineObject {
-    fn scrolls_with_text(&self) -> bool {
-        match self {
-            InlineObject::KittyImage(object) => !object.uses_placeholders,
-            InlineObject::RgpObject(_) => true,
+/// How an inline anchor follows terminal content.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub enum InlineAnchorMode {
+    /// Remain at fixed screen coordinates.
+    #[default]
+    Screen,
+    /// Follow a marker attached to a terminal cell.
+    Text,
+}
+
+impl From<RgpAnchorMode> for InlineAnchorMode {
+    fn from(value: RgpAnchorMode) -> Self {
+        match value {
+            RgpAnchorMode::Screen => Self::Screen,
+            RgpAnchorMode::Text => Self::Text,
         }
     }
 }
@@ -548,15 +670,93 @@ impl InlineObject {
 /// Inline object anchor.
 pub struct InlineAnchor {
     /// Anchor row.
-    pub row: u16,
+    pub row: i32,
     /// Anchor column.
     pub col: u16,
     /// Object width in cells.
     pub columns: u32,
     /// Object height in cells.
     pub rows: u32,
+    /// Anchor tracking mode.
+    pub mode: InlineAnchorMode,
+    /// Unique marker token for a text-tracked placement.
+    pub marker_id: Option<u32>,
+    /// Marker row offset from the placement's top-left cell.
+    pub marker_row_offset: u16,
+    /// Marker column offset from the placement's top-left cell.
+    pub marker_col_offset: u16,
+    /// Whether the anchor marker is currently visible.
+    pub visible: bool,
     /// Inline styling.
     pub style: InlineStyle,
+}
+
+const VARIATION_SELECTOR_1: u32 = 0xfe00;
+const VARIATION_SELECTOR_17: u32 = 0xe0100;
+
+/// Encodes an object id as four zero-width Unicode variation selectors.
+pub fn rgp_text_marker(object_id: u32) -> String {
+    object_id
+        .to_be_bytes()
+        .into_iter()
+        .map(|byte| {
+            let codepoint = if byte < 16 {
+                VARIATION_SELECTOR_1 + u32::from(byte)
+            } else {
+                VARIATION_SELECTOR_17 + u32::from(byte - 16)
+            };
+            char::from_u32(codepoint).expect("variation selector is a valid scalar")
+        })
+        .collect()
+}
+
+/// Removes an RGP text marker suffix before a cell is rendered.
+pub fn strip_rgp_text_marker(contents: &str) -> &str {
+    let Some((start, _)) = decode_rgp_text_marker(contents) else {
+        return contents;
+    };
+    &contents[..start]
+}
+
+fn rgp_text_marker_id(contents: &str) -> Option<u32> {
+    decode_rgp_text_marker(contents).map(|(_, object_id)| object_id)
+}
+
+fn decode_rgp_text_marker(contents: &str) -> Option<(usize, u32)> {
+    let chars = contents.char_indices().collect::<Vec<_>>();
+    if chars.len() < 4 {
+        return None;
+    }
+    let marker = &chars[chars.len() - 4..];
+    let mut bytes = [0; 4];
+    for (index, (_, ch)) in marker.iter().enumerate() {
+        let codepoint = u32::from(*ch);
+        bytes[index] = if (VARIATION_SELECTOR_1..VARIATION_SELECTOR_1 + 16).contains(&codepoint) {
+            (codepoint - VARIATION_SELECTOR_1) as u8
+        } else if (VARIATION_SELECTOR_17..VARIATION_SELECTOR_17 + 240).contains(&codepoint) {
+            (codepoint - VARIATION_SELECTOR_17 + 16) as u8
+        } else {
+            return None;
+        };
+    }
+    Some((marker[0].0, u32::from_be_bytes(bytes)))
+}
+
+fn text_anchor_top(marker_row: u16, marker_row_offset: u16) -> i32 {
+    i32::from(marker_row) - i32::from(marker_row_offset)
+}
+
+fn anchor_intersects_viewport_top(row: i32, rows: u32) -> bool {
+    row + rows as i32 > 0
+}
+
+fn anchor_intersects_viewport(row: i32, rows: u32, viewport_rows: u16) -> bool {
+    row < i32::from(viewport_rows) && anchor_intersects_viewport_top(row, rows)
+}
+
+fn scrollback_row_delta(previous: usize, current: usize) -> i32 {
+    let delta = current as i128 - previous as i128;
+    delta.clamp(i128::from(i32::MIN), i128::from(i32::MAX)) as i32
 }
 
 /// Inline object style.
@@ -625,5 +825,54 @@ fn apply_vec3_update(target: &mut Vec3, update: [Option<f32>; 3]) {
     }
     if let Some(z) = update[2] {
         target.z = z;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        anchor_intersects_viewport_top, rgp_text_marker, rgp_text_marker_id, scrollback_row_delta,
+        strip_rgp_text_marker, text_anchor_top,
+    };
+
+    #[test]
+    fn text_marker_round_trips_full_object_id() {
+        for object_id in [0, 1, 0x00ff_ffff, u32::MAX] {
+            let contents = format!("x{}", rgp_text_marker(object_id));
+            assert_eq!(rgp_text_marker_id(&contents), Some(object_id));
+            assert_eq!(strip_rgp_text_marker(&contents), "x");
+        }
+    }
+
+    #[test]
+    fn ordinary_variation_selector_is_not_a_marker() {
+        let contents = "text\u{fe0f}";
+        assert_eq!(rgp_text_marker_id(contents), None);
+        assert_eq!(strip_rgp_text_marker(contents), contents);
+    }
+
+    #[test]
+    fn vt_parser_attaches_marker_to_preceding_character() {
+        let mut parser = vt100::Parser::new(2, 10, 0);
+        let marker = rgp_text_marker(u32::MAX);
+        parser.process(format!("x{marker}").as_bytes());
+
+        let contents = parser.screen().cell(0, 0).unwrap().contents();
+        assert_eq!(rgp_text_marker_id(contents), Some(u32::MAX));
+        assert_eq!(strip_rgp_text_marker(contents), "x");
+    }
+
+    #[test]
+    fn text_anchor_can_scroll_partially_above_viewport() {
+        assert_eq!(text_anchor_top(0, 3), -3);
+        assert!(anchor_intersects_viewport_top(-3, 8));
+        assert!(anchor_intersects_viewport_top(-7, 8));
+        assert!(!anchor_intersects_viewport_top(-8, 8));
+    }
+
+    #[test]
+    fn scrollback_delta_moves_anchor_before_marker_is_visible() {
+        assert_eq!(scrollback_row_delta(0, 1), 1);
+        assert_eq!(scrollback_row_delta(4, 1), -3);
     }
 }

--- a/src/keyboard.rs
+++ b/src/keyboard.rs
@@ -315,6 +315,7 @@ pub struct KeyboardSystemParams<'w, 's> {
     mobius_transition: ResMut<'w, MobiusTransition>,
     clipboard: NonSendMut<'w, TerminalClipboard>,
     runtime: NonSendMut<'w, TerminalRuntime>,
+    inline_objects: ResMut<'w, crate::inline::TerminalInlineObjects>,
     terminal: NonSendMut<'w, TerminalSurface>,
     viewport: Res<'w, TerminalViewport>,
     bindings: Res<'w, TerminalKeyBindings>,
@@ -421,6 +422,9 @@ pub fn handle_keyboard_input(
                             current.saturating_sub(amount)
                         };
                         screen.set_scrollback(next);
+                        params
+                            .inline_objects
+                            .apply_scrollback_change(current, params.runtime.parser.screen());
                         params.selection.clear();
                         params.redraw.request();
                     }
@@ -512,7 +516,11 @@ pub fn handle_keyboard_input(
         ) {
             let screen = params.runtime.parser.screen_mut();
             if screen.scrollback() != 0 {
+                let previous = screen.scrollback();
                 screen.set_scrollback(0);
+                params
+                    .inline_objects
+                    .apply_scrollback_change(previous, params.runtime.parser.screen());
                 params.redraw.request();
             }
             params.runtime.write_input(&input);

--- a/src/kitty.rs
+++ b/src/kitty.rs
@@ -328,16 +328,21 @@ pub fn refresh_kitty_placeholder_anchors(
             let columns = u32::from(right - left + 1);
             let rows = u32::from(bottom - top + 1);
             let new_anchor = InlineAnchor {
-                row: top,
+                row: i32::from(top),
                 col: left,
                 columns,
                 rows,
+                mode: crate::inline::InlineAnchorMode::Text,
+                marker_id: None,
+                marker_row_offset: 0,
+                marker_col_offset: 0,
+                visible: true,
                 style: InlineStyle::default(),
             };
             changed |= anchors
                 .insert(object_id, new_anchor)
                 .is_none_or(|old_anchor| {
-                    old_anchor.row != top
+                    old_anchor.row != i32::from(top)
                         || old_anchor.col != left
                         || old_anchor.columns != columns
                         || old_anchor.rows != rows

--- a/src/mouse.rs
+++ b/src/mouse.rs
@@ -163,7 +163,7 @@ impl TerminalSelection {
                 }
 
                 let symbol = if cell.has_contents() {
-                    cell.contents()
+                    crate::inline::strip_rgp_text_marker(cell.contents())
                 } else {
                     " "
                 };
@@ -187,6 +187,7 @@ impl TerminalSelection {
 pub struct MouseSystemParams<'w, 's> {
     primary_window: Query<'w, 's, (Entity, &'static Window), With<PrimaryWindow>>,
     runtime: NonSendMut<'w, TerminalRuntime>,
+    inline_objects: ResMut<'w, crate::inline::TerminalInlineObjects>,
     terminal: NonSend<'w, TerminalSurface>,
     viewport: Res<'w, TerminalViewport>,
     presentation: Res<'w, TerminalPresentation>,
@@ -208,6 +209,7 @@ pub(crate) fn handle_mouse_input(
     let MouseSystemParams {
         primary_window,
         runtime,
+        inline_objects,
         terminal,
         viewport,
         presentation,
@@ -455,9 +457,10 @@ pub(crate) fn handle_mouse_input(
 
             if amount != 0 {
                 let screen = runtime.parser.screen_mut();
-                let current = screen.scrollback() as isize;
-                let next = (current + amount).max(0) as usize;
+                let current = screen.scrollback();
+                let next = (current as isize + amount).max(0) as usize;
                 screen.set_scrollback(next);
+                inline_objects.apply_scrollback_change(current, runtime.parser.screen());
                 selection.clear();
                 redraw.request();
             }

--- a/src/rgp.rs
+++ b/src/rgp.rs
@@ -7,6 +7,16 @@ pub const RGP_APC_START: &[u8] = b"\x1b_ratty;g;";
 const ST: &[u8] = b"\x1b\\";
 const C1_ST: u8 = 0x9c;
 
+/// How an RGP placement is anchored.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub enum RgpAnchorMode {
+    /// Keep the placement at its screen coordinates.
+    #[default]
+    Screen,
+    /// Follow the terminal character immediately preceding the place sequence.
+    Text,
+}
+
 /// Placement style for an RGP object.
 #[derive(Clone, Copy, Default)]
 pub struct RgpPlacementStyle {
@@ -93,6 +103,7 @@ pub fn consume_sequence(sequence: &[u8]) -> Option<RgpOperation> {
     let mut col = None;
     let mut width = None;
     let mut height = None;
+    let mut anchor_mode = None;
     let mut animate = None;
     let mut scale = None;
     let mut depth = None;
@@ -127,6 +138,13 @@ pub fn consume_sequence(sequence: &[u8]) -> Option<RgpOperation> {
             "col" => col = value.parse().ok(),
             "w" => width = value.parse().ok(),
             "h" => height = value.parse().ok(),
+            "anchor" => {
+                anchor_mode = match value {
+                    "screen" => Some(RgpAnchorMode::Screen),
+                    "text" => Some(RgpAnchorMode::Text),
+                    _ => None,
+                }
+            }
             "animate" => animate = parse_bool(value),
             "scale" => scale = value.parse().ok(),
             "depth" => depth = value.parse().ok(),
@@ -177,6 +195,7 @@ pub fn consume_sequence(sequence: &[u8]) -> Option<RgpOperation> {
                 col: col?,
                 columns: width?,
                 rows: height?,
+                mode: anchor_mode.unwrap_or_default(),
                 style: RgpPlacementStyle {
                     animate: animate.unwrap_or(false),
                     scale: scale.unwrap_or(1.0),
@@ -218,6 +237,8 @@ pub struct RgpAnchor {
     pub columns: u32,
     /// Object height in cells.
     pub rows: u32,
+    /// Placement anchoring mode.
+    pub mode: RgpAnchorMode,
     /// Placement style.
     pub style: RgpPlacementStyle,
 }
@@ -260,7 +281,7 @@ pub enum RgpOperation {
 
 /// Returns the RGP support reply sequence.
 pub fn support_reply() -> Vec<u8> {
-    b"\x1b_ratty;g;s;v=1;fmt=obj|glb;path=1;payload=1;chunk=1;anim=1;depth=1;color=1;brightness=1;transform=1;update=1\x1b\\".to_vec()
+    b"\x1b_ratty;g;s;v=1;fmt=obj|glb;path=1;payload=1;chunk=1;anim=1;depth=1;color=1;brightness=1;transform=1;update=1;anchor=screen|text\x1b\\".to_vec()
 }
 
 fn parse_color(value: &str) -> Option<[u8; 3]> {
@@ -281,5 +302,37 @@ fn parse_bool(value: &str) -> Option<bool> {
         "1" | "true" => Some(true),
         "0" | "false" => Some(false),
         _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{RgpAnchorMode, RgpOperation, consume_sequence, support_reply};
+
+    #[test]
+    fn place_defaults_to_screen_anchor() {
+        let sequence = b"\x1b_ratty;g;p;id=7;row=5;col=10;w=3;h=2\x1b\\";
+        let Some(RgpOperation::Place { anchor, .. }) = consume_sequence(sequence) else {
+            panic!("expected place operation");
+        };
+        assert_eq!(anchor.mode, RgpAnchorMode::Screen);
+    }
+
+    #[test]
+    fn parses_text_anchor() {
+        let sequence = b"\x1b_ratty;g;p;id=7;row=5;col=10;w=3;h=2;anchor=text\x1b\\";
+        let Some(RgpOperation::Place { anchor, .. }) = consume_sequence(sequence) else {
+            panic!("expected place operation");
+        };
+        assert_eq!(anchor.mode, RgpAnchorMode::Text);
+    }
+
+    #[test]
+    fn advertises_text_anchors() {
+        assert!(
+            std::str::from_utf8(&support_reply())
+                .unwrap()
+                .contains("anchor=screen|text")
+        );
     }
 }

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -145,7 +145,7 @@ pub fn pump_pty_output(
                     let scrolled = infer_upward_scroll(&prev_rows, &next_rows);
                     inline_objects.apply_scroll(scrolled);
                 }
-                inline_objects.refresh_placeholder_anchors(runtime.parser.screen());
+                inline_objects.refresh_anchors_after_output(runtime.parser.screen());
                 processed_output = true;
             }
             Err(TryRecvError::Empty) => break,
@@ -479,7 +479,10 @@ pub(crate) fn sync_inline_objects(mut params: SyncInlineParams) {
         .iter()
         .filter_map(|(object_id, anchor)| {
             inline_objects.objects.get(object_id)?;
-            let start = anchor.row as i32;
+            if !anchor.visible {
+                return None;
+            }
+            let start = anchor.row;
             let end = start + anchor.rows as i32;
             (start < terminal.rows as i32 && end > 0).then_some(*object_id)
         })

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -358,7 +358,7 @@ impl Widget for TerminalWidget<'_> {
                 let mut style =
                     vt100_cell_style(vt_cell, &theme_palette, theme_fg, self.font_style);
                 let symbol = if vt_cell.has_contents() {
-                    vt_cell.contents()
+                    crate::inline::strip_rgp_text_marker(vt_cell.contents())
                 } else {
                     " "
                 };

--- a/widget/README.md
+++ b/widget/README.md
@@ -10,7 +10,7 @@ inline 3D objects in [Ratty](https://github.com/orhun/ratty) through the
 use std::io;
 
 use ratatui_core::{buffer::Buffer, layout::Rect, widgets::Widget};
-use ratatui_ratty::{ObjectFormat, RattyGraphic, RattyGraphicSettings};
+use ratatui_ratty::{AnchorMode, ObjectFormat, RattyGraphic, RattyGraphicSettings};
 
 fn main() -> io::Result<()> {
     let mut graphic = RattyGraphic::new(
@@ -18,6 +18,7 @@ fn main() -> io::Result<()> {
             .id(7)
             .format(ObjectFormat::Glb)
             .animate(true)
+            .anchor_mode(AnchorMode::Text)
             .scale(1.0)
             .depth(1.5)
             .rotation([0.0, 30.0, 0.0]),
@@ -41,6 +42,11 @@ fn main() -> io::Result<()> {
 The widget emits RGP APC sequences into the target buffer cell. Ratty then
 resolves the asset and renders it as an inline 3D object anchored to that
 terminal region.
+
+`AnchorMode::Screen` is the backward-compatible default. `AnchorMode::Text`
+attaches the graphic to the character in the anchor cell, so the graphic moves
+with that character during terminal scrolling and disappears while the
+character is outside the visible viewport.
 
 ## Payload Registration
 

--- a/widget/src/lib.rs
+++ b/widget/src/lib.rs
@@ -17,6 +17,25 @@ pub enum ObjectFormat {
     Glb,
 }
 
+/// How a graphic placement is anchored.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum AnchorMode {
+    /// Keep the graphic at fixed screen coordinates.
+    #[default]
+    Screen,
+    /// Follow the terminal character containing the placement sequence.
+    Text,
+}
+
+impl AnchorMode {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Screen => "screen",
+            Self::Text => "text",
+        }
+    }
+}
+
 impl ObjectFormat {
     fn as_str(self) -> &'static str {
         match self {
@@ -70,6 +89,8 @@ pub struct RattyGraphicSettings<'a> {
     pub rotation: [f32; 3],
     /// Non-uniform scale multiplier.
     pub scale3: [f32; 3],
+    /// Placement anchoring mode.
+    pub anchor_mode: AnchorMode,
 }
 
 impl<'a> RattyGraphicSettings<'a> {
@@ -88,6 +109,7 @@ impl<'a> RattyGraphicSettings<'a> {
             offset: [0.0, 0.0, 0.0],
             rotation: [0.0, 0.0, 0.0],
             scale3: [1.0, 1.0, 1.0],
+            anchor_mode: AnchorMode::Screen,
         }
     }
 
@@ -148,6 +170,12 @@ impl<'a> RattyGraphicSettings<'a> {
     /// Sets the non-uniform scale multiplier.
     pub fn scale3(mut self, scale3: [f32; 3]) -> Self {
         self.scale3 = scale3;
+        self
+    }
+
+    /// Sets how the graphic follows terminal content.
+    pub fn anchor_mode(mut self, anchor_mode: AnchorMode) -> Self {
+        self.anchor_mode = anchor_mode;
         self
     }
 }
@@ -276,12 +304,13 @@ impl<'a> RattyGraphic<'a> {
         let center_row = area.y.saturating_add(area.height.saturating_sub(1) / 2);
         let center_col = area.x.saturating_add(area.width.saturating_sub(1) / 2);
         format!(
-            "\x1b_ratty;g;p;id={};row={};col={};w={};h={};animate={};scale={};depth={};color={};brightness={};px={};py={};pz={};rx={};ry={};rz={};sx={};sy={};sz={}\x1b\\",
+            "\x1b_ratty;g;p;id={};row={};col={};w={};h={};anchor={};animate={};scale={};depth={};color={};brightness={};px={};py={};pz={};rx={};ry={};rz={};sx={};sy={};sz={}\x1b\\",
             self.settings.id,
             center_row,
             center_col,
             area.width.max(1),
             area.height.max(1),
+            self.settings.anchor_mode.as_str(),
             u8::from(self.settings.animate),
             self.settings.scale,
             self.settings.depth,
@@ -361,13 +390,49 @@ impl Widget for &RattyGraphic<'_> {
         }
 
         let place = self.place_sequence(area);
+        let marker_position = if self.settings.anchor_mode == AnchorMode::Text {
+            (
+                area.x.saturating_add(area.width.saturating_sub(1) / 2),
+                area.y.saturating_add(area.height.saturating_sub(1) / 2),
+            )
+        } else {
+            (area.x, area.y)
+        };
 
-        if let Some(cell) = buf.cell_mut((area.x, area.y)) {
+        if let Some(cell) = buf.cell_mut(marker_position) {
             let existing = cell.symbol();
             let mut symbol = String::with_capacity(place.len() + existing.len());
-            symbol.push_str(&place);
-            symbol.push_str(existing);
+            if self.settings.anchor_mode == AnchorMode::Text {
+                symbol.push_str(existing);
+                symbol.push_str(&place);
+            } else {
+                symbol.push_str(&place);
+                symbol.push_str(existing);
+            }
             cell.set_symbol(&symbol);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use ratatui_core::{buffer::Buffer, layout::Rect, widgets::Widget};
+
+    use super::{AnchorMode, RattyGraphic, RattyGraphicSettings};
+
+    #[test]
+    fn text_anchor_sequence_follows_cell_character() {
+        let graphic = RattyGraphic::new(
+            RattyGraphicSettings::new("model.obj").anchor_mode(AnchorMode::Text),
+        );
+        let area = Rect::new(2, 3, 1, 1);
+        let mut buffer = Buffer::empty(Rect::new(0, 0, 10, 10));
+        buffer[(2, 3)].set_char('x');
+
+        (&graphic).render(area, &mut buffer);
+
+        let symbol = buffer[(2, 3)].symbol();
+        assert!(symbol.starts_with('x'));
+        assert!(symbol.contains("anchor=text"));
     }
 }


### PR DESCRIPTION
# Summary:

Changes to implement a proof of concept text-based positioning mode. This allows you to have persistent 3D models inline, and obey scrolling actions and scrollback history.

# Demo:

https://github.com/user-attachments/assets/9a6daa30-609b-4670-82a9-1ce69e647510

# Disclaimer:

I am opening this as a draft because it should not be merged as-is, since I used AI tools to modify the code and did not verify the quality.

***\*Needs cleaning up***
@orhun sorry for the late PR
Addresses issue: #100 