### PR TITLE
Swap the vt100 terminal engine for rio-vt, without a shim

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,30 +38,36 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - label: aarch64-apple-darwin
-            os: macos-latest
-            target: aarch64-apple-darwin
-          - label: x86_64-apple-darwin
-            os: macos-latest
-            target: x86_64-apple-darwin
-          - label: aarch64-unknown-linux-gnu
-            os: ubuntu-latest
-            target: aarch64-unknown-linux-gnu
-          - label: x86_64-unknown-linux-gnu
-            os: ubuntu-latest
-            target: x86_64-unknown-linux-gnu
-          - label: x86_64-pc-windows-msvc
-            os: windows-latest
-            target: x86_64-pc-windows-msvc
+        target:
+          - aarch64-apple-darwin
+          - x86_64-apple-darwin
+          - aarch64-unknown-linux-gnu
+          - x86_64-unknown-linux-gnu
+          - x86_64-pc-windows-msvc
         manifest:
           - Cargo.toml
           - widget/Cargo.toml
+        include:
+          - target: aarch64-apple-darwin
+            label: aarch64-apple-darwin
+            os: macos-latest
+          - target: x86_64-apple-darwin
+            label: x86_64-apple-darwin
+            os: macos-latest
+          - target: aarch64-unknown-linux-gnu
+            label: aarch64-unknown-linux-gnu
+            os: ubuntu-24.04-arm
+          - target: x86_64-unknown-linux-gnu
+            label: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+          - target: x86_64-pc-windows-msvc
+            label: x86_64-pc-windows-msvc
+            os: windows-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Install system dependencies
-        if: matrix.os == 'ubuntu-latest'
+        if: startsWith(matrix.os, 'ubuntu-')
         run: |
           sudo apt-get update
           sudo apt-get install -y \
@@ -82,6 +88,32 @@ jobs:
         uses: Swatinem/rust-cache@v2
       - name: Run cargo check
         run: cargo check --manifest-path ${{ matrix.manifest }} --target ${{ matrix.target }}
+
+  test:
+    name: Test library
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            pkg-config \
+            libasound2-dev \
+            libfontconfig1-dev \
+            libudev-dev \
+            libwayland-dev \
+            libxkbcommon-dev \
+            libxkbcommon-x11-dev \
+            libxcb-shape0-dev \
+            libxcb-xfixes0-dev
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@stable
+      - name: Cache Cargo dependencies
+        uses: Swatinem/rust-cache@v2
+      - name: Run library tests
+        run: cargo test --lib --locked
 
   clippy:
     name: Clippy (${{ matrix.manifest }})

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -71,7 +71,7 @@ dependencies = [
  "accesskit_consumer 0.35.0",
  "hashbrown 0.16.1",
  "static_assertions",
- "windows",
+ "windows 0.62.2",
  "windows-core",
 ]
 
@@ -100,7 +100,7 @@ version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "getrandom 0.3.4",
  "once_cell",
  "version_check",
@@ -243,7 +243,7 @@ dependencies = [
  "objc2-foundation 0.3.2",
  "parking_lot",
  "percent-encoding",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
  "wl-clipboard-rs",
  "x11rb",
 ]
@@ -342,7 +342,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
 dependencies = [
  "autocfg",
- "cfg-if",
+ "cfg-if 1.0.4",
  "concurrent-queue",
  "futures-io",
  "futures-lite",
@@ -412,6 +412,12 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b25655df2c3cdd83c5e5b293b88acd880332b2ddadd7c30ac43144fdc0033da9"
 
 [[package]]
 name = "bevy"
@@ -797,7 +803,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84e21ad83b7dc8d456491ea3d50057685d8c4cca8bc52a1b4a7161c86c369842"
 dependencies = [
  "async-lock",
- "base64",
+ "base64 0.22.1",
  "bevy_animation",
  "bevy_app",
  "bevy_asset",
@@ -1580,7 +1586,7 @@ dependencies = [
  "arrayref",
  "arrayvec",
  "cc",
- "cfg-if",
+ "cfg-if 1.0.4",
  "constant_time_eq",
  "cpufeatures 0.3.0",
 ]
@@ -1724,6 +1730,12 @@ dependencies = [
 
 [[package]]
 name = "cfg-if"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
+
+[[package]]
+name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
@@ -1834,7 +1846,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb1325a1cece981e8a296ab8f0f9b63ae357bd0784a9faaf548cc7b480707a"
 dependencies = [
  "castaway",
- "cfg-if",
+ "cfg-if 1.0.4",
  "itoa",
  "rustversion",
  "ryu",
@@ -1857,7 +1869,7 @@ version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a06aeb73f470f66dcdbf7223caeebb85984942f22f1adb2a088cf9668146bbbc"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "wasm-bindgen",
 ]
 
@@ -1904,6 +1916,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
 dependencies = [
  "unicode-segmentation",
+]
+
+[[package]]
+name = "corcovado"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81416d77146f514567682a0fda159fdb60cfad7c8f71e44515a8597cd4962298"
+dependencies = [
+ "cfg-if 0.1.10",
+ "fuchsia-zircon",
+ "fuchsia-zircon-sys",
+ "iovec",
+ "libc",
+ "miow 0.5.0",
+ "slab",
+ "socket2",
+ "tracing",
+ "windows 0.42.0",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -1970,7 +2001,7 @@ version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
 ]
 
 [[package]]
@@ -2016,7 +2047,7 @@ dependencies = [
  "mio",
  "parking_lot",
  "rustix 1.1.4",
- "signal-hook",
+ "signal-hook 0.3.18",
  "signal-hook-mio",
  "winapi",
 ]
@@ -2053,7 +2084,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb2a7d3066da2de787b7f032c736763eb7ae5d355f81a68bab2675a96008b0bf"
 dependencies = [
  "lab",
- "phf",
+ "phf 0.11.3",
 ]
 
 [[package]]
@@ -2329,7 +2360,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de48cc4d1c1d97a20fd819def54b890cadde72ed3ad0c614822a0a433361be96"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "windows-sys 0.61.2",
 ]
 
@@ -2503,7 +2534,7 @@ dependencies = [
  "read-fonts",
  "roxmltree",
  "smallvec",
- "windows",
+ "windows 0.62.2",
  "windows-core",
  "yeslogic-fontconfig-sys",
 ]
@@ -2534,6 +2565,22 @@ name = "foreign-types-shared"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b"
+
+[[package]]
+name = "fuchsia-zircon"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
+dependencies = [
+ "bitflags 1.3.2",
+ "fuchsia-zircon-sys",
+]
+
+[[package]]
+name = "fuchsia-zircon-sys"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 
 [[package]]
 name = "futures-channel"
@@ -2636,7 +2683,7 @@ version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "libc",
  "wasi",
 ]
@@ -2647,7 +2694,7 @@ version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
@@ -2659,7 +2706,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "libc",
  "r-efi 6.0.0",
  "wasip2",
@@ -2758,7 +2805,7 @@ dependencies = [
  "log",
  "presser",
  "thiserror 2.0.18",
- "windows",
+ "windows 0.62.2",
 ]
 
 [[package]]
@@ -2808,7 +2855,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
 dependencies = [
  "bytemuck",
- "cfg-if",
+ "cfg-if 1.0.4",
  "crunchy",
  "num-traits",
  "zerocopy",
@@ -3126,6 +3173,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "iovec"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3152,7 +3208,7 @@ version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "combine",
  "jni-macros",
  "jni-sys 0.4.1",
@@ -3220,7 +3276,7 @@ version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "futures-util",
  "once_cell",
  "wasm-bindgen",
@@ -3295,9 +3351,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.184"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "libloading"
@@ -3305,7 +3361,7 @@ version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "windows-link",
 ]
 
@@ -3411,9 +3467,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "memmap2"
@@ -3477,6 +3533,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "miow"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ffbca2f655e33c08be35d87278e5b18b89550a37dbd598c20db92f6a471123"
+dependencies = [
+ "windows-sys 0.42.0",
+]
+
+[[package]]
+name = "miow"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "536bfad37a309d62069485248eeaba1e8d9853aaf951caaeaed0585a95346f08"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "moxcms"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3495,7 +3569,7 @@ dependencies = [
  "arrayvec",
  "bit-set 0.9.1",
  "bitflags 2.13.0",
- "cfg-if",
+ "cfg-if 1.0.4",
  "cfg_aliases",
  "codespan-reporting 0.13.1",
  "half",
@@ -3507,7 +3581,7 @@ dependencies = [
  "num-traits",
  "once_cell",
  "pp-rs",
- "rustc-hash",
+ "rustc-hash 1.1.0",
  "spirv",
  "thiserror 2.0.18",
  "unicode-ident",
@@ -3524,7 +3598,7 @@ dependencies = [
  "indexmap",
  "naga",
  "regex",
- "rustc-hash",
+ "rustc-hash 1.1.0",
  "thiserror 2.0.18",
  "tracing",
  "unicode-ident",
@@ -3568,7 +3642,7 @@ checksum = "f346ff70e7dbfd675fe90590b92d59ef2de15a8779ae305ebcbfd3f0caf59be4"
 dependencies = [
  "autocfg",
  "bitflags 1.3.2",
- "cfg-if",
+ "cfg-if 1.0.4",
  "libc",
  "memoffset 0.6.5",
  "pin-utils",
@@ -3581,7 +3655,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
  "bitflags 2.13.0",
- "cfg-if",
+ "cfg-if 1.0.4",
  "cfg_aliases",
  "libc",
  "memoffset 0.9.1",
@@ -3594,7 +3668,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d6d0705320c1e6ba1d912b5e37cf18071b6c2e9b7fa8215a1e8a7651966f5d3"
 dependencies = [
  "bitflags 2.13.0",
- "cfg-if",
+ "cfg-if 1.0.4",
  "cfg_aliases",
  "libc",
 ]
@@ -4108,7 +4182,7 @@ version = "0.9.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "libc",
  "redox_syscall 0.5.18",
  "smallvec",
@@ -4243,7 +4317,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
 dependencies = [
  "phf_macros",
- "phf_shared",
+ "phf_shared 0.11.3",
+]
+
+[[package]]
+name = "phf"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
+dependencies = [
+ "phf_shared 0.13.1",
+ "serde",
 ]
 
 [[package]]
@@ -4253,7 +4337,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
 dependencies = [
  "phf_generator",
- "phf_shared",
+ "phf_shared 0.11.3",
 ]
 
 [[package]]
@@ -4262,7 +4346,7 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
- "phf_shared",
+ "phf_shared 0.11.3",
  "rand 0.8.5",
 ]
 
@@ -4273,7 +4357,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
 dependencies = [
  "phf_generator",
- "phf_shared",
+ "phf_shared 0.11.3",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -4284,6 +4368,15 @@ name = "phf_shared"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
 dependencies = [
  "siphasher",
 ]
@@ -4362,7 +4455,7 @@ version = "3.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "concurrent-queue",
  "hermit-abi",
  "pin-project-lite",
@@ -4620,7 +4713,7 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "567584a3b0e6a8203c23de40b4861497266725eb5363dbfd18a1edd603cca9f0"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "crossterm",
  "instability",
  "ratatui-core",
@@ -4683,7 +4776,7 @@ version = "0.5.0"
 dependencies = [
  "anyhow",
  "arboard",
- "base64",
+ "base64 0.22.1",
  "bevy",
  "clap",
  "etcetera",
@@ -4691,13 +4784,13 @@ dependencies = [
  "parley_ratatui",
  "portable-pty",
  "ratatui",
+ "rio-vt",
  "rust-embed",
  "serde",
  "shellexpand",
  "stl_io",
  "tobj",
  "toml 0.8.23",
- "vt100",
  "winit",
  "winresource",
 ]
@@ -4788,9 +4881,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.14"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+checksum = "8fcfdb36bda0c880c5931cdc7a2bcdc8ba4556847b9d912bca70bc94708711ad"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -4808,6 +4901,54 @@ name = "renderdoc-sys"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19b30a45b0cd0bcca8037f3d0dc3421eaf95327a17cad11964fb8179b4fc4832"
+
+[[package]]
+name = "rio-grapheme-width"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcd46980a38f999d3510ab0fddc4e89720b7f5e13812481067436cafd7322f67"
+dependencies = [
+ "phf 0.13.1",
+ "ucd-trie",
+]
+
+[[package]]
+name = "rio-graphics"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75494a34484fc889e83f039cea187e2e3a37730d73fc0d9385b3adfdd3b1384"
+dependencies = [
+ "rustc-hash 2.1.3",
+ "tracing",
+]
+
+[[package]]
+name = "rio-vt"
+version = "0.5.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b8c519237d02247700b7be993edbd1d8a6f89605aada9b69d62e22e12a9340f"
+dependencies = [
+ "base64 0.23.0",
+ "bitflags 2.13.0",
+ "corcovado",
+ "cursor-icon",
+ "flate2",
+ "libc",
+ "memchr",
+ "parking_lot",
+ "regex",
+ "regex-automata",
+ "rio-grapheme-width",
+ "rio-graphics",
+ "rustc-hash 2.1.3",
+ "serde",
+ "simdutf",
+ "smallvec",
+ "teletypewriter",
+ "tracing",
+ "unicode-width-16",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "ron"
@@ -4871,6 +5012,12 @@ name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
 
 [[package]]
 name = "rustc_version"
@@ -4976,9 +5123,9 @@ checksum = "cd0b0ec5f1c1ca621c432a25813d8d60c88abe6d3e08a3eb9cf37d97a0fe3d73"
 
 [[package]]
 name = "serde"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
  "serde_derive",
@@ -4986,22 +5133,22 @@ dependencies = [
 
 [[package]]
 name = "serde_core"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -5083,7 +5230,7 @@ version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "cpufeatures 0.2.17",
  "digest",
 ]
@@ -5139,6 +5286,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "signal-hook"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a0c28ca5908dbdbcd52e6fdaa00358ab88637f8ab33e1f188dd510eb44b53d"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
 name = "signal-hook-mio"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5146,7 +5303,7 @@ checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
 dependencies = [
  "libc",
  "mio",
- "signal-hook",
+ "signal-hook 0.3.18",
 ]
 
 [[package]]
@@ -5173,6 +5330,16 @@ checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
 dependencies = [
  "rustc_version",
  "simdutf8",
+]
+
+[[package]]
+name = "simdutf"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f542752c7335a9174e7bb81112c3ca1415a7a6b6ec2c3e840aca347a30f9141"
+dependencies = [
+ "bitflags 2.13.0",
+ "cc",
 ]
 
 [[package]]
@@ -5214,9 +5381,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.15.1"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "smithay-client-toolkit"
@@ -5250,6 +5417,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd538fb6910ac1099850255cf94a94df6551fbdd602454387d0adb2d1ca6dead"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "socket2"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5370,6 +5547,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "synstructure"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5378,6 +5566,23 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "teletypewriter"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7daff686bf09eb6541f5e3a092666445b58ad3091a4f7c1e31455a55f6d13aea"
+dependencies = [
+ "corcovado",
+ "dirs",
+ "iovec",
+ "libc",
+ "miow 0.6.1",
+ "parking_lot",
+ "signal-hook 0.4.4",
+ "tracing",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5398,7 +5603,7 @@ dependencies = [
  "bitflags 2.13.0",
  "parking_lot",
  "rustix 1.1.4",
- "signal-hook",
+ "signal-hook 0.3.18",
  "windows-sys 0.61.2",
 ]
 
@@ -5410,7 +5615,7 @@ checksum = "d4ea810f0692f9f51b382fff5893887bb4580f5fa246fde546e0b13e7fcee662"
 dependencies = [
  "fnv",
  "nom 7.1.3",
- "phf",
+ "phf 0.11.3",
  "phf_codegen",
 ]
 
@@ -5439,7 +5644,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4676b37242ccbd1aabf56edb093a4827dc49086c0ffd764a5705899e0f35f8f7"
 dependencies = [
  "anyhow",
- "base64",
+ "base64 0.22.1",
  "bitflags 2.13.0",
  "fancy-regex",
  "filedescriptor",
@@ -5456,9 +5661,9 @@ dependencies = [
  "ordered-float",
  "pest",
  "pest_derive",
- "phf",
+ "phf 0.11.3",
  "sha2",
- "signal-hook",
+ "signal-hook 0.3.18",
  "siphasher",
  "terminfo",
  "termios 0.3.3",
@@ -5520,7 +5725,7 @@ version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
 ]
 
 [[package]]
@@ -5567,7 +5772,7 @@ dependencies = [
  "arrayref",
  "arrayvec",
  "bytemuck",
- "cfg-if",
+ "cfg-if 1.0.4",
  "log",
  "tiny-skia-path",
 ]
@@ -5760,7 +5965,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d76902d2a8d5f9f55a81155c08971734071968c90f2d9bfe645fe700579b2950"
 dependencies = [
  "cc",
- "cfg-if",
+ "cfg-if 1.0.4",
  "tracing-core",
  "tracing-subscriber",
 ]
@@ -5871,6 +6076,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
+name = "unicode-width-16"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9eba15036aa0f5bf8ed6cd12a624ddb61fd50b0779b1c05d89b663bcaed7b5c2"
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5970,27 +6181,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
-name = "vt100"
-version = "0.16.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "054ff75fb8fa83e609e685106df4faeffdf3a735d3c74ebce97ec557d5d36fd9"
-dependencies = [
- "itoa",
- "unicode-width",
- "vte",
-]
-
-[[package]]
-name = "vte"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5924018406ce0063cd67f8e008104968b74b563ee1b85dde3ed1f7cb87d3dbd"
-dependencies = [
- "arrayvec",
- "memchr",
-]
-
-[[package]]
 name = "vtparse"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6039,7 +6229,7 @@ version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "once_cell",
  "rustversion",
  "wasm-bindgen-macro",
@@ -6254,7 +6444,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1cdc136a53ccd64a1211f107ccc34404769fbcc0f165f1afa065f5d88ab93538"
 dependencies = [
  "async-task",
- "cfg-if",
+ "cfg-if 1.0.4",
  "js-sys",
  "wasm-bindgen",
 ]
@@ -6356,7 +6546,7 @@ dependencies = [
  "arrayvec",
  "bitflags 2.13.0",
  "bytemuck",
- "cfg-if",
+ "cfg-if 1.0.4",
  "cfg_aliases",
  "document-features",
  "hashbrown 0.16.1",
@@ -6399,7 +6589,7 @@ dependencies = [
  "portable-atomic",
  "profiling",
  "raw-window-handle",
- "rustc-hash",
+ "rustc-hash 1.1.0",
  "smallvec",
  "thiserror 2.0.18",
  "wgpu-core-deps-apple",
@@ -6450,7 +6640,7 @@ dependencies = [
  "bitflags 2.13.0",
  "block2 0.6.2",
  "bytemuck",
- "cfg-if",
+ "cfg-if 1.0.4",
  "cfg_aliases",
  "glow",
  "glutin_wgl_sys",
@@ -6486,7 +6676,7 @@ dependencies = [
  "web-sys",
  "wgpu-naga-bridge",
  "wgpu-types",
- "windows",
+ "windows 0.62.2",
  "windows-core",
  "windows-result",
 ]
@@ -6546,6 +6736,21 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0286ba339aa753e70765d521bb0242cc48e1194562bfa2a2ad7ac8a6de28f5d5"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
+]
 
 [[package]]
 name = "windows"
@@ -6650,11 +6855,26 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -6663,7 +6883,16 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
 ]
 
 [[package]]
@@ -6681,14 +6910,31 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -6702,9 +6948,27 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -6713,10 +6977,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
 
 [[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
+
+[[package]]
 name = "windows_i686_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
 
 [[package]]
 name = "windows_i686_gnullvm"
@@ -6725,10 +7007,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
 name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -6737,16 +7043,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
 name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winit"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -71,7 +71,7 @@ dependencies = [
  "accesskit_consumer 0.35.0",
  "hashbrown 0.16.1",
  "static_assertions",
- "windows 0.62.2",
+ "windows",
  "windows-core",
 ]
 
@@ -100,7 +100,7 @@ version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
- "cfg-if 1.0.4",
+ "cfg-if",
  "getrandom 0.3.4",
  "once_cell",
  "version_check",
@@ -342,7 +342,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
 dependencies = [
  "autocfg",
- "cfg-if 1.0.4",
+ "cfg-if",
  "concurrent-queue",
  "futures-io",
  "futures-lite",
@@ -1586,7 +1586,7 @@ dependencies = [
  "arrayref",
  "arrayvec",
  "cc",
- "cfg-if 1.0.4",
+ "cfg-if",
  "constant_time_eq",
  "cpufeatures 0.3.0",
 ]
@@ -1730,12 +1730,6 @@ dependencies = [
 
 [[package]]
 name = "cfg-if"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
-
-[[package]]
-name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
@@ -1846,7 +1840,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb1325a1cece981e8a296ab8f0f9b63ae357bd0784a9faaf548cc7b480707a"
 dependencies = [
  "castaway",
- "cfg-if 1.0.4",
+ "cfg-if",
  "itoa",
  "rustversion",
  "ryu",
@@ -1869,7 +1863,7 @@ version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a06aeb73f470f66dcdbf7223caeebb85984942f22f1adb2a088cf9668146bbbc"
 dependencies = [
- "cfg-if 1.0.4",
+ "cfg-if",
  "wasm-bindgen",
 ]
 
@@ -1916,25 +1910,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
 dependencies = [
  "unicode-segmentation",
-]
-
-[[package]]
-name = "corcovado"
-version = "0.5.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81416d77146f514567682a0fda159fdb60cfad7c8f71e44515a8597cd4962298"
-dependencies = [
- "cfg-if 0.1.10",
- "fuchsia-zircon",
- "fuchsia-zircon-sys",
- "iovec",
- "libc",
- "miow 0.5.0",
- "slab",
- "socket2",
- "tracing",
- "windows 0.42.0",
- "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -2001,7 +1976,7 @@ version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
- "cfg-if 1.0.4",
+ "cfg-if",
 ]
 
 [[package]]
@@ -2047,7 +2022,7 @@ dependencies = [
  "mio",
  "parking_lot",
  "rustix 1.1.4",
- "signal-hook 0.3.18",
+ "signal-hook",
  "signal-hook-mio",
  "winapi",
 ]
@@ -2360,7 +2335,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de48cc4d1c1d97a20fd819def54b890cadde72ed3ad0c614822a0a433361be96"
 dependencies = [
- "cfg-if 1.0.4",
+ "cfg-if",
  "windows-sys 0.61.2",
 ]
 
@@ -2534,7 +2509,7 @@ dependencies = [
  "read-fonts",
  "roxmltree",
  "smallvec",
- "windows 0.62.2",
+ "windows",
  "windows-core",
  "yeslogic-fontconfig-sys",
 ]
@@ -2565,22 +2540,6 @@ name = "foreign-types-shared"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b"
-
-[[package]]
-name = "fuchsia-zircon"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
-dependencies = [
- "bitflags 1.3.2",
- "fuchsia-zircon-sys",
-]
-
-[[package]]
-name = "fuchsia-zircon-sys"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 
 [[package]]
 name = "futures-channel"
@@ -2683,7 +2642,7 @@ version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
- "cfg-if 1.0.4",
+ "cfg-if",
  "libc",
  "wasi",
 ]
@@ -2694,7 +2653,7 @@ version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
- "cfg-if 1.0.4",
+ "cfg-if",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
@@ -2706,7 +2665,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
- "cfg-if 1.0.4",
+ "cfg-if",
  "libc",
  "r-efi 6.0.0",
  "wasip2",
@@ -2805,7 +2764,7 @@ dependencies = [
  "log",
  "presser",
  "thiserror 2.0.18",
- "windows 0.62.2",
+ "windows",
 ]
 
 [[package]]
@@ -2855,7 +2814,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
 dependencies = [
  "bytemuck",
- "cfg-if 1.0.4",
+ "cfg-if",
  "crunchy",
  "num-traits",
  "zerocopy",
@@ -3173,15 +3132,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "iovec"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3208,7 +3158,7 @@ version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
 dependencies = [
- "cfg-if 1.0.4",
+ "cfg-if",
  "combine",
  "jni-macros",
  "jni-sys 0.4.1",
@@ -3276,7 +3226,7 @@ version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
 dependencies = [
- "cfg-if 1.0.4",
+ "cfg-if",
  "futures-util",
  "once_cell",
  "wasm-bindgen",
@@ -3361,7 +3311,7 @@ version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
 dependencies = [
- "cfg-if 1.0.4",
+ "cfg-if",
  "windows-link",
 ]
 
@@ -3533,24 +3483,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "miow"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ffbca2f655e33c08be35d87278e5b18b89550a37dbd598c20db92f6a471123"
-dependencies = [
- "windows-sys 0.42.0",
-]
-
-[[package]]
-name = "miow"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "536bfad37a309d62069485248eeaba1e8d9853aaf951caaeaed0585a95346f08"
-dependencies = [
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "moxcms"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3569,7 +3501,7 @@ dependencies = [
  "arrayvec",
  "bit-set 0.9.1",
  "bitflags 2.13.0",
- "cfg-if 1.0.4",
+ "cfg-if",
  "cfg_aliases",
  "codespan-reporting 0.13.1",
  "half",
@@ -3642,7 +3574,7 @@ checksum = "f346ff70e7dbfd675fe90590b92d59ef2de15a8779ae305ebcbfd3f0caf59be4"
 dependencies = [
  "autocfg",
  "bitflags 1.3.2",
- "cfg-if 1.0.4",
+ "cfg-if",
  "libc",
  "memoffset 0.6.5",
  "pin-utils",
@@ -3655,7 +3587,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
  "bitflags 2.13.0",
- "cfg-if 1.0.4",
+ "cfg-if",
  "cfg_aliases",
  "libc",
  "memoffset 0.9.1",
@@ -3668,7 +3600,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d6d0705320c1e6ba1d912b5e37cf18071b6c2e9b7fa8215a1e8a7651966f5d3"
 dependencies = [
  "bitflags 2.13.0",
- "cfg-if 1.0.4",
+ "cfg-if",
  "cfg_aliases",
  "libc",
 ]
@@ -4182,7 +4114,7 @@ version = "0.9.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
- "cfg-if 1.0.4",
+ "cfg-if",
  "libc",
  "redox_syscall 0.5.18",
  "smallvec",
@@ -4455,7 +4387,7 @@ version = "3.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
 dependencies = [
- "cfg-if 1.0.4",
+ "cfg-if",
  "concurrent-queue",
  "hermit-abi",
  "pin-project-lite",
@@ -4713,7 +4645,7 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "567584a3b0e6a8203c23de40b4861497266725eb5363dbfd18a1edd603cca9f0"
 dependencies = [
- "cfg-if 1.0.4",
+ "cfg-if",
  "crossterm",
  "instability",
  "ratatui-core",
@@ -4904,9 +4836,9 @@ checksum = "19b30a45b0cd0bcca8037f3d0dc3421eaf95327a17cad11964fb8179b4fc4832"
 
 [[package]]
 name = "rio-grapheme-width"
-version = "0.5.14"
+version = "0.5.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcd46980a38f999d3510ab0fddc4e89720b7f5e13812481067436cafd7322f67"
+checksum = "8748a230342b653830718978aa78fc7e4887bcf2d1292228ea1e033dd0207151"
 dependencies = [
  "phf 0.13.1",
  "ucd-trie",
@@ -4914,9 +4846,9 @@ dependencies = [
 
 [[package]]
 name = "rio-graphics"
-version = "0.5.14"
+version = "0.5.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75494a34484fc889e83f039cea187e2e3a37730d73fc0d9385b3adfdd3b1384"
+checksum = "150067cf37f1468cffffae9cbfd40e106adc5f8451239b5b0a7fa660b6a5a91c"
 dependencies = [
  "rustc-hash 2.1.3",
  "tracing",
@@ -4924,13 +4856,12 @@ dependencies = [
 
 [[package]]
 name = "rio-vt"
-version = "0.5.13"
+version = "0.5.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b8c519237d02247700b7be993edbd1d8a6f89605aada9b69d62e22e12a9340f"
+checksum = "82bb771ed37480c3bec80684513a5d136a7cd5a32a86c0bf13a6d7cb0239b600"
 dependencies = [
  "base64 0.23.0",
  "bitflags 2.13.0",
- "corcovado",
  "cursor-icon",
  "flate2",
  "libc",
@@ -4944,7 +4875,6 @@ dependencies = [
  "serde",
  "simdutf",
  "smallvec",
- "teletypewriter",
  "tracing",
  "unicode-width-16",
  "windows-sys 0.61.2",
@@ -5230,7 +5160,7 @@ version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
- "cfg-if 1.0.4",
+ "cfg-if",
  "cpufeatures 0.2.17",
  "digest",
 ]
@@ -5286,16 +5216,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "signal-hook"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2a0c28ca5908dbdbcd52e6fdaa00358ab88637f8ab33e1f188dd510eb44b53d"
-dependencies = [
- "libc",
- "signal-hook-registry",
-]
-
-[[package]]
 name = "signal-hook-mio"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5303,7 +5223,7 @@ checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
 dependencies = [
  "libc",
  "mio",
- "signal-hook 0.3.18",
+ "signal-hook",
 ]
 
 [[package]]
@@ -5417,16 +5337,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd538fb6910ac1099850255cf94a94df6551fbdd602454387d0adb2d1ca6dead"
 dependencies = [
  "serde",
-]
-
-[[package]]
-name = "socket2"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
-dependencies = [
- "libc",
- "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5569,23 +5479,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "teletypewriter"
-version = "0.5.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7daff686bf09eb6541f5e3a092666445b58ad3091a4f7c1e31455a55f6d13aea"
-dependencies = [
- "corcovado",
- "dirs",
- "iovec",
- "libc",
- "miow 0.6.1",
- "parking_lot",
- "signal-hook 0.4.4",
- "tracing",
- "windows-sys 0.59.0",
-]
-
-[[package]]
 name = "termcolor"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5603,7 +5496,7 @@ dependencies = [
  "bitflags 2.13.0",
  "parking_lot",
  "rustix 1.1.4",
- "signal-hook 0.3.18",
+ "signal-hook",
  "windows-sys 0.61.2",
 ]
 
@@ -5663,7 +5556,7 @@ dependencies = [
  "pest_derive",
  "phf 0.11.3",
  "sha2",
- "signal-hook 0.3.18",
+ "signal-hook",
  "siphasher",
  "terminfo",
  "termios 0.3.3",
@@ -5725,7 +5618,7 @@ version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
- "cfg-if 1.0.4",
+ "cfg-if",
 ]
 
 [[package]]
@@ -5772,7 +5665,7 @@ dependencies = [
  "arrayref",
  "arrayvec",
  "bytemuck",
- "cfg-if 1.0.4",
+ "cfg-if",
  "log",
  "tiny-skia-path",
 ]
@@ -5965,7 +5858,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d76902d2a8d5f9f55a81155c08971734071968c90f2d9bfe645fe700579b2950"
 dependencies = [
  "cc",
- "cfg-if 1.0.4",
+ "cfg-if",
  "tracing-core",
  "tracing-subscriber",
 ]
@@ -6229,7 +6122,7 @@ version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
 dependencies = [
- "cfg-if 1.0.4",
+ "cfg-if",
  "once_cell",
  "rustversion",
  "wasm-bindgen-macro",
@@ -6444,7 +6337,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1cdc136a53ccd64a1211f107ccc34404769fbcc0f165f1afa065f5d88ab93538"
 dependencies = [
  "async-task",
- "cfg-if 1.0.4",
+ "cfg-if",
  "js-sys",
  "wasm-bindgen",
 ]
@@ -6546,7 +6439,7 @@ dependencies = [
  "arrayvec",
  "bitflags 2.13.0",
  "bytemuck",
- "cfg-if 1.0.4",
+ "cfg-if",
  "cfg_aliases",
  "document-features",
  "hashbrown 0.16.1",
@@ -6640,7 +6533,7 @@ dependencies = [
  "bitflags 2.13.0",
  "block2 0.6.2",
  "bytemuck",
- "cfg-if 1.0.4",
+ "cfg-if",
  "cfg_aliases",
  "glow",
  "glutin_wgl_sys",
@@ -6676,7 +6569,7 @@ dependencies = [
  "web-sys",
  "wgpu-naga-bridge",
  "wgpu-types",
- "windows 0.62.2",
+ "windows",
  "windows-core",
  "windows-result",
 ]
@@ -6736,21 +6629,6 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-
-[[package]]
-name = "windows"
-version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0286ba339aa753e70765d521bb0242cc48e1194562bfa2a2ad7ac8a6de28f5d5"
-dependencies = [
- "windows_aarch64_gnullvm 0.42.2",
- "windows_aarch64_msvc 0.42.2",
- "windows_i686_gnu 0.42.2",
- "windows_i686_msvc 0.42.2",
- "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm 0.42.2",
- "windows_x86_64_msvc 0.42.2",
-]
 
 [[package]]
 name = "windows"
@@ -6855,21 +6733,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
-dependencies = [
- "windows_aarch64_gnullvm 0.42.2",
- "windows_aarch64_msvc 0.42.2",
- "windows_i686_gnu 0.42.2",
- "windows_i686_msvc 0.42.2",
- "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm 0.42.2",
- "windows_x86_64_msvc 0.42.2",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -6948,12 +6811,6 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -6966,12 +6823,6 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -6981,12 +6832,6 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -7014,12 +6859,6 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -7029,12 +6868,6 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -7050,12 +6883,6 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -7065,12 +6892,6 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,13 +45,13 @@ image = { version = "0.25", default-features = false, features = ["png", "ico"] 
 parley_ratatui = "0.3.4"
 portable-pty = "0.8"
 ratatui = "0.30"
+rio-vt = "0.5.13"
 rust-embed = "8.5"
 serde = { version = "1.0", features = ["derive"] }
 shellexpand = "3.1"
 stl_io = "0.11.0"
 tobj = "4.0"
 toml = "0.8"
-vt100 = "0.16"
 winit = { version = "0.30", default-features = false }
 
 [build-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ image = { version = "0.25", default-features = false, features = ["png", "ico"] 
 parley_ratatui = "0.3.4"
 portable-pty = "0.8"
 ratatui = "0.30"
-rio-vt = "0.5.13"
+rio-vt = { version = "0.5.19", default-features = false }
 rust-embed = "8.5"
 serde = { version = "1.0", features = ["derive"] }
 shellexpand = "3.1"

--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ and [Bevy](https://bevyengine.org/) for scene presentation.
 
 Current workflow:
 
-1. PTY output is parsed by `vt100` and drawn into a Ratatui buffer on CPU
+1. PTY output is parsed by [`rio-vt`](https://crates.io/crates/rio-vt) and drawn into a Ratatui buffer on CPU
 2. `parley_ratatui` shapes the buffer with Parley and records it as a Vello scene
 3. The scene is handed to Bevy's render world through a double-buffered
    exchange (scenes are recycled between frames, never cloned or re-recorded)

--- a/src/inline.rs
+++ b/src/inline.rs
@@ -1,11 +1,9 @@
 //! Inline object state and APC handling.
 
-use std::borrow::Cow;
 use std::collections::HashMap;
 use std::path::Path;
 
 use bevy::prelude::*;
-use vt100::Callbacks;
 
 use crate::camera::{OptionalVec3, TerminalCameraUpdate};
 use crate::kitty::{KittyOperation, KittyParserState, refresh_kitty_placeholder_anchors};
@@ -16,6 +14,8 @@ use crate::rgp::{
     RgpOperation, RgpPlacementStyle, RgpPlacementUpdate, RgpRegisterSource,
     consume_sequence as consume_rgp_sequence, support_reply,
 };
+use crate::runtime::TerminalRuntime;
+use crate::vt::{self, VtTerminal};
 
 const APC_START: &[u8] = b"\x1b_";
 const ST: &[u8] = b"\x1b\\";
@@ -81,10 +81,10 @@ pub struct TerminalInlineObjects {
 
 impl TerminalInlineObjects {
     /// Consumes PTY output and extracts inline object control sequences.
-    pub fn consume_pty_output<CB: Callbacks>(
+    pub fn consume_pty_output(
         &mut self,
         chunk: &[u8],
-        parser: &mut vt100::Parser<CB>,
+        runtime: &mut TerminalRuntime,
         camera_updates: &mut Vec<TerminalCameraUpdate>,
         terminal_output: &mut bool,
     ) -> Vec<Vec<u8>> {
@@ -101,9 +101,7 @@ impl TerminalInlineObjects {
                 let keep_from = pending_apc_prefix_start(&self.pending_bytes, cursor);
                 if cursor < keep_from {
                     *terminal_output = true;
-                    parser.process(&normalize_hvp_sequences(
-                        &self.pending_bytes[cursor..keep_from],
-                    ));
+                    runtime.process(&self.pending_bytes[cursor..keep_from]);
                 }
                 if keep_from < pending_len {
                     self.pending_bytes.drain(..keep_from);
@@ -115,7 +113,7 @@ impl TerminalInlineObjects {
             let start = cursor + start_offset;
             if cursor < start {
                 *terminal_output = true;
-                parser.process(&normalize_hvp_sequences(&self.pending_bytes[cursor..start]));
+                runtime.process(&self.pending_bytes[cursor..start]);
             }
 
             let payload_start = start + APC_START.len();
@@ -126,7 +124,7 @@ impl TerminalInlineObjects {
             let sequence = self.pending_bytes[start..end].to_vec();
             let (handled, reply) = self.handle_apc_sequence(
                 &sequence,
-                parser.screen().cursor_position(),
+                vt::cursor_position(&runtime.term),
                 camera_updates,
             );
             if let Some(reply) = reply {
@@ -134,7 +132,7 @@ impl TerminalInlineObjects {
             }
             if !handled {
                 *terminal_output = true;
-                parser.process(&sequence);
+                runtime.process(&sequence);
             }
             cursor = end;
         }
@@ -190,8 +188,8 @@ impl TerminalInlineObjects {
     }
 
     /// Refreshes placeholder-derived Kitty anchors.
-    pub fn refresh_placeholder_anchors(&mut self, screen: &vt100::Screen) {
-        if refresh_kitty_placeholder_anchors(&self.objects, &mut self.anchors, screen) {
+    pub fn refresh_placeholder_anchors(&mut self, term: &VtTerminal) {
+        if refresh_kitty_placeholder_anchors(&self.objects, &mut self.anchors, term) {
             self.dirty = true;
         }
     }
@@ -501,43 +499,6 @@ struct PendingRgpPayload {
     name: Option<String>,
     data: Vec<u8>,
     options: ObjectLoadOptions,
-}
-
-fn normalize_hvp_sequences(bytes: &[u8]) -> Cow<'_, [u8]> {
-    // vt100 handles CUP (`H`) but not HVP (`f`), so normalize cursor-positioning sequences.
-    let mut normalized = None;
-    let mut i = 0;
-
-    while i < bytes.len() {
-        if bytes[i] == 0x1b && i + 2 < bytes.len() && bytes[i + 1] == b'[' {
-            let mut j = i + 2;
-            while j < bytes.len() && matches!(bytes[j], b'0'..=b'9' | b';') {
-                j += 1;
-            }
-
-            if j < bytes.len() && bytes[j] == b'f' && j > i + 2 {
-                let out = normalized.get_or_insert_with(|| {
-                    let mut out = Vec::with_capacity(bytes.len());
-                    out.extend_from_slice(&bytes[..i]);
-                    out
-                });
-                out.extend_from_slice(&bytes[i..j]);
-                out.push(b'H');
-                i = j + 1;
-                continue;
-            }
-        }
-
-        if let Some(out) = normalized.as_mut() {
-            out.push(bytes[i]);
-        }
-        i += 1;
-    }
-
-    match normalized {
-        Some(bytes) => Cow::Owned(bytes),
-        None => Cow::Borrowed(bytes),
-    }
 }
 
 fn pending_apc_prefix_start(bytes: &[u8], cursor: usize) -> usize {

--- a/src/keyboard.rs
+++ b/src/keyboard.rs
@@ -21,6 +21,7 @@ use crate::scene::{
     TerminalPlaneWarp, TerminalPresentationMode, TerminalViewport, sync_terminal_layout,
 };
 use crate::terminal::{TerminalRedrawState, TerminalSurface, render_scale_for_window};
+use crate::vt::{self, MouseProtocolMode};
 
 /// Clipboard bridge for terminal copy and paste.
 pub struct TerminalClipboard {
@@ -400,7 +401,7 @@ pub fn handle_keyboard_input(
         let modifiers = current_modifiers(&params.keys).union(keyboard.modifiers());
         if event.state == ButtonState::Pressed
             && let Some(action) = params.bindings.action_for(binding_key_code, modifiers)
-            && !(is_scroll_action(action) && params.runtime.parser.screen().alternate_screen())
+            && !(is_scroll_action(action) && vt::alternate_screen(&params.runtime.term))
         {
             if event.repeat
                 && !matches!(
@@ -481,12 +482,12 @@ pub fn handle_keyboard_input(
                         _ => unreachable!(),
                     };
 
-                    let mouse_mode = params.runtime.parser.screen().mouse_protocol_mode();
+                    let mouse_mode = vt::mouse_protocol_mode(&params.runtime.term);
                     if params.camera_slots.active().mode == TerminalPresentationMode::Flat2d
-                        && mouse_mode != vt100::MouseProtocolMode::None
+                        && mouse_mode != MouseProtocolMode::None
                     {
-                        let encoding = params.runtime.parser.screen().mouse_protocol_encoding();
-                        let (row, col) = params.runtime.parser.screen().cursor_position();
+                        let encoding = vt::mouse_protocol_encoding(&params.runtime.term);
+                        let (row, col) = vt::cursor_position(&params.runtime.term);
                         let cell = UVec2::new(col as u32, row as u32);
                         for _ in 0..amount {
                             params.runtime.write_input(&encode_mouse_wheel(
@@ -496,14 +497,13 @@ pub fn handle_keyboard_input(
                             ));
                         }
                     } else {
-                        let screen = params.runtime.parser.screen_mut();
-                        let current = screen.scrollback();
+                        let current = vt::scrollback(&params.runtime.term);
                         let next = if direction.is_positive() {
                             current.saturating_add(amount)
                         } else {
                             current.saturating_sub(amount)
                         };
-                        screen.set_scrollback(next);
+                        vt::set_scrollback(&mut params.runtime.term, next);
                         params.selection.clear();
                         params.redraw.request();
                     }
@@ -520,9 +520,7 @@ pub fn handle_keyboard_input(
                     continue;
                 }
                 BindingAction::Copy => {
-                    if let Some(text) = params
-                        .selection
-                        .selected_text(params.runtime.parser.screen())
+                    if let Some(text) = params.selection.selected_text(&params.runtime.term)
                         && !text.is_empty()
                     {
                         params.clipboard.copy(&text);
@@ -534,7 +532,7 @@ pub fn handle_keyboard_input(
                 }
                 BindingAction::Paste => {
                     if let Some(text) = params.clipboard.paste() {
-                        let bracketed = params.runtime.parser.screen().bracketed_paste();
+                        let bracketed = vt::bracketed_paste(&params.runtime.term);
                         params.runtime.write_input(&encode_paste(&text, bracketed));
                     } else {
                         warn!("failed to read clipboard contents for paste");
@@ -604,13 +602,12 @@ pub fn handle_keyboard_input(
 
         if let Some(input) = keyboard.handle_event_with_modes(
             event,
-            params.runtime.parser.screen().application_cursor(),
+            vt::application_cursor(&params.runtime.term),
             params.runtime.kitty_keyboard_flags(),
             params.runtime.modify_other_keys(),
         ) {
-            let screen = params.runtime.parser.screen_mut();
-            if screen.scrollback() != 0 {
-                screen.set_scrollback(0);
+            if vt::scrollback(&params.runtime.term) != 0 {
+                vt::set_scrollback(&mut params.runtime.term, 0);
                 params.redraw.request();
             }
             params.runtime.write_input(&input);

--- a/src/kitty.rs
+++ b/src/kitty.rs
@@ -3,8 +3,10 @@
 use std::collections::HashMap;
 
 use base64::Engine as _;
+use rio_vt::crosswords::pos::Column;
 
 use crate::inline::{InlineAnchor, InlineObject, InlineStyle, KittyInlineObject, RasterObject};
+use crate::vt::{self, CellColor, VtTerminal};
 
 /// Kitty graphics APC prefix.
 pub const KITTY_APC_START: &[u8] = b"\x1b_G";
@@ -273,11 +275,11 @@ impl KittyTransfer {
     }
 }
 
-/// Refreshes placeholder-backed Kitty anchors from the VT100 screen.
+/// Refreshes placeholder-backed Kitty anchors from the terminal grid.
 pub fn refresh_kitty_placeholder_anchors(
     objects: &HashMap<u32, InlineObject>,
     anchors: &mut HashMap<u32, InlineAnchor>,
-    screen: &vt100::Screen,
+    term: &VtTerminal,
 ) -> bool {
     let placeholder_ids = objects
         .iter()
@@ -295,16 +297,25 @@ pub fn refresh_kitty_placeholder_anchors(
         .collect::<HashMap<_, _>>();
 
     let mut bounds = HashMap::<u32, (u16, u16, u16, u16)>::new();
-    let (rows, cols) = screen.size();
+    let rows = u16::try_from(term.screen_lines()).unwrap_or(u16::MAX);
+    let cols = u16::try_from(term.columns()).unwrap_or(u16::MAX);
+    let styles = vt::styles(term);
     for row in 0..rows {
+        let Some(grid_row) = vt::visible_row(term, row) else {
+            continue;
+        };
+        // rio-vt flags rows holding a U+10EEEE placeholder, so rows without one
+        // skip the per-cell scan entirely.
+        if !grid_row.kitty_virtual_placeholder {
+            continue;
+        }
         for col in 0..cols {
-            let Some(cell) = screen.cell(row, col) else {
-                continue;
-            };
-            if !cell.contents().starts_with('\u{10EEEE}') {
+            let square = grid_row[Column(usize::from(col))];
+            if square.c() != '\u{10EEEE}' {
                 continue;
             }
-            let vt100::Color::Rgb(r, g, b) = cell.fgcolor() else {
+            let (fg, _, _) = vt::cell_attributes(styles, square);
+            let CellColor::Rgb(r, g, b) = fg else {
                 continue;
             };
             let placeholder_id = ((r as u32) << 16) | ((g as u32) << 8) | (b as u32);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,3 +24,4 @@ pub mod runtime;
 pub mod scene;
 pub mod systems;
 pub mod terminal;
+pub mod vt;

--- a/src/mouse.rs
+++ b/src/mouse.rs
@@ -6,7 +6,6 @@ use bevy::input::ButtonState;
 use bevy::input::mouse::{MouseButton, MouseButtonInput, MouseScrollUnit, MouseWheel};
 use bevy::prelude::*;
 use bevy::window::{CursorMoved, PrimaryWindow, Window, WindowFocused};
-use vt100::{MouseProtocolEncoding, MouseProtocolMode};
 
 use crate::camera::{
     MAX_PERSPECTIVE_FOV, MIN_ORTHOGRAPHIC_SCALE, MIN_PERSPECTIVE_FOV, TerminalCameraInteraction,
@@ -16,6 +15,7 @@ use crate::config::AppConfig;
 use crate::runtime::TerminalRuntime;
 use crate::scene::{MobiusTransition, TerminalPresentationMode, TerminalViewport};
 use crate::terminal::TerminalSurface;
+use crate::vt::{self, MouseProtocolEncoding, MouseProtocolMode, VtTerminal};
 
 /// Distance in pixels the pointer must move with a pending selection to start dragging.
 const SELECTION_DRAG_THRESHOLD: f32 = 4.0;
@@ -188,10 +188,15 @@ impl TerminalSelection {
     }
 
     /// Returns the selected screen text.
-    pub fn selected_text(&self, screen: &vt100::Screen) -> Option<String> {
+    ///
+    /// Kept hand-rolled rather than delegating to rio-vt's `selection_to_string`:
+    /// ratty's selection is a plain rectangular row/column range driven by the
+    /// 3D viewport, not rio-vt's `Selection` (which models linewise and
+    /// semantic modes over absolute grid positions).
+    pub fn selected_text(&self, term: &VtTerminal) -> Option<String> {
         let bounds = self.normalized_bounds()?;
 
-        let (_, cols) = screen.size();
+        let cols = u16::try_from(term.columns()).unwrap_or(u16::MAX);
         let mut out = String::new();
 
         let start_row = bounds.start_row as u16;
@@ -207,20 +212,23 @@ impl TerminalSelection {
                 cols.saturating_sub(1)
             };
 
-            for col in row_start..=row_end {
-                let Some(cell) = screen.cell(row, col) else {
-                    continue;
-                };
-                if cell.is_wide_continuation() {
-                    continue;
-                }
+            if vt::visible_row(term, row).is_some() {
+                for col in row_start..=row_end {
+                    if usize::from(col) >= term.columns() {
+                        break;
+                    }
+                    let pos = vt::visible_pos(term, row, col);
+                    if vt::is_wide_spacer(&term.grid, pos) {
+                        continue;
+                    }
 
-                let symbol = if cell.has_contents() {
-                    cell.contents()
-                } else {
-                    " "
-                };
-                out.push_str(symbol);
+                    let before = out.len();
+                    vt::push_cell_text(&mut out, &term.grid, pos);
+                    if out.len() == before {
+                        // Blank cell: rio-vt stores it as NUL, not a space.
+                        out.push(' ');
+                    }
+                }
             }
 
             if row != end_row {
@@ -277,8 +285,8 @@ pub(crate) fn handle_mouse_input(
     };
 
     let window_size = window.resolution.size().max(Vec2::ONE);
-    let mouse_mode = runtime.parser.screen().mouse_protocol_mode();
-    let mouse_encoding = runtime.parser.screen().mouse_protocol_encoding();
+    let mouse_mode = vt::mouse_protocol_mode(&runtime.term);
+    let mouse_encoding = vt::mouse_protocol_encoding(&runtime.term);
 
     // Button releases delivered while the window is unfocused never reach the
     // handlers below, so losing focus mid-drag would otherwise leave held
@@ -516,9 +524,7 @@ pub(crate) fn handle_mouse_input(
                     mouse_encoding,
                 ));
             }
-        } else if mode == TerminalPresentationMode::Flat2d
-            && !runtime.parser.screen().alternate_screen()
-        {
+        } else if mode == TerminalPresentationMode::Flat2d && !vt::alternate_screen(&runtime.term) {
             let amount = match event.unit {
                 MouseScrollUnit::Line => {
                     app_config.terminal.mouse_scroll_lines as isize
@@ -534,10 +540,9 @@ pub(crate) fn handle_mouse_input(
             };
 
             if amount != 0 {
-                let screen = runtime.parser.screen_mut();
-                let current = screen.scrollback() as isize;
+                let current = vt::scrollback(&runtime.term) as isize;
                 let next = (current + amount).max(0) as usize;
-                screen.set_scrollback(next);
+                vt::set_scrollback(&mut runtime.term, next);
                 selection.clear();
                 redraw.request();
             }
@@ -758,5 +763,73 @@ mod wheel_zoom_tests {
         // The ordinary interactive range still behaves as before.
         assert_eq!(wheel_zoomed_orthographic_scale(1.0, 0.1), 0.9);
         assert_eq!(wheel_zoomed_orthographic_scale(3.95, -0.1), 4.0);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use rio_vt::ansi::CursorShape;
+    use rio_vt::crosswords::{Crosswords, CrosswordsSize};
+    use rio_vt::event::WindowId;
+    use rio_vt::performer::handler::Processor;
+
+    use crate::vt::TerminalEventSink;
+
+    fn terminal(rows: u16, cols: u16, input: &str) -> VtTerminal {
+        let mut term = Crosswords::new(
+            CrosswordsSize::new(usize::from(cols), usize::from(rows)),
+            CursorShape::Block,
+            TerminalEventSink::default(),
+            WindowId::from(0),
+            0,
+            1000,
+        );
+        Processor::default().advance(&mut term, input.as_bytes());
+        term
+    }
+
+    fn select(start: (u32, u32), end: (u32, u32)) -> TerminalSelection {
+        let mut selection = TerminalSelection::default();
+        selection.begin(UVec2::new(start.0, start.1));
+        selection.update(UVec2::new(end.0, end.1));
+        selection
+    }
+
+    #[test]
+    fn selection_returns_the_drawn_text() {
+        let term = terminal(3, 20, "hello world");
+        let selection = select((0, 0), (10, 0));
+        assert_eq!(
+            selection.selected_text(&term).as_deref(),
+            Some("hello world")
+        );
+    }
+
+    #[test]
+    fn selection_spans_multiple_rows() {
+        let term = terminal(3, 20, "first\r\nsecond");
+        let selection = select((0, 0), (5, 1));
+        assert_eq!(
+            selection.selected_text(&term).as_deref(),
+            Some("first\nsecond")
+        );
+    }
+
+    #[test]
+    fn selection_preserves_wide_characters_and_combining_marks() {
+        let term = terminal(3, 20, "你好e\u{0301}z");
+        let selection = select((0, 0), (5, 0));
+        assert_eq!(
+            selection.selected_text(&term).as_deref(),
+            Some("你好e\u{0301}z")
+        );
+    }
+
+    #[test]
+    fn selection_without_a_drag_is_empty() {
+        let term = terminal(3, 20, "hello");
+        assert_eq!(TerminalSelection::default().selected_text(&term), None);
     }
 }

--- a/src/rendering.rs
+++ b/src/rendering.rs
@@ -136,7 +136,7 @@ impl<'a> CellDebugImageRenderer<'a> {
                 if let (Ok(row), Ok(col)) = (u16::try_from(row), u16::try_from(col)) {
                     vt::push_cell_text(&mut text, &term.grid, vt::visible_pos(term, row, col));
                 }
-                let active = !text.is_empty() && !matches!(square.wide(), Wide::Spacer);
+                let active = cell_is_active(&text, square.wide());
                 let fill = if active {
                     bg
                 } else {
@@ -258,6 +258,10 @@ impl<'a> CellDebugImageRenderer<'a> {
     }
 }
 
+fn cell_is_active(text: &str, wide: Wide) -> bool {
+    !text.is_empty() && !matches!(wide, Wide::Spacer | Wide::LeadingSpacer)
+}
+
 #[derive(Clone, Copy)]
 struct CellRect {
     x0: u32,
@@ -344,5 +348,38 @@ fn ansi_index_to_rgba(index: u8) -> Rgba {
             let shade = 8 + (index - 232) * 10;
             [shade, shade, shade, 255]
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use rio_vt::ansi::CursorShape;
+    use rio_vt::crosswords::{Crosswords, CrosswordsSize};
+    use rio_vt::event::WindowId;
+    use rio_vt::performer::handler::Processor;
+
+    use crate::vt::TerminalEventSink;
+
+    #[test]
+    fn wrapped_wide_character_padding_is_not_active_content() {
+        let mut term = Crosswords::new(
+            CrosswordsSize::new(14, 2),
+            CursorShape::Block,
+            TerminalEventSink::default(),
+            WindowId::from(0),
+            0,
+            1000,
+        );
+        Processor::default().advance(&mut term, "abcdefghijklm\u{4f60}".as_bytes());
+
+        let row = vt::visible_row(&term, 0).expect("row 0");
+        let square = row[Column(13)];
+        assert!(matches!(square.wide(), Wide::LeadingSpacer));
+
+        let mut text = String::new();
+        vt::push_cell_text(&mut text, &term.grid, vt::visible_pos(&term, 0, 13));
+        assert!(!cell_is_active(&text, square.wide()));
     }
 }

--- a/src/rendering.rs
+++ b/src/rendering.rs
@@ -2,8 +2,12 @@
 
 use bevy::prelude::*;
 use bevy::render::render_resource::Extent3d;
+use rio_vt::crosswords::pos::Column;
+use rio_vt::crosswords::square::Wide;
+use rio_vt::crosswords::style::StyleFlags;
 
 use crate::terminal::TerminalSurface;
+use crate::vt::{self, CellColor, VtTerminal};
 
 type Rgba = [u8; 4];
 const DEBUG_BG: Rgba = [18, 20, 28, 255];
@@ -17,7 +21,7 @@ const DEBUG_BG_FALLBACK: Rgba = [31, 31, 40, 255];
 pub fn sync_terminal_debug_image(
     terminal: &TerminalSurface,
     images: &mut Assets<Image>,
-    screen: &vt100::Screen,
+    term: &VtTerminal,
 ) {
     let Some(handle) = terminal.back_image_handle.as_ref() else {
         return;
@@ -42,7 +46,7 @@ pub fn sync_terminal_debug_image(
         data.resize(rgba_len, 0);
     }
 
-    CellDebugImageRenderer::new(data, width, height, terminal.cols, terminal.rows).render(screen);
+    CellDebugImageRenderer::new(data, width, height, terminal.cols, terminal.rows).render(term);
 }
 
 /// Synchronizes an image handle across plane materials.
@@ -99,22 +103,40 @@ impl<'a> CellDebugImageRenderer<'a> {
         }
     }
 
-    fn render(&mut self, screen: &vt100::Screen) {
+    fn render(&mut self, term: &VtTerminal) {
         self.fill(DEBUG_BG);
 
+        let styles = vt::styles(term);
+        let columns = term.columns();
+        let mut text = String::new();
+
         for row in 0..self.rows {
+            let grid_row = u16::try_from(row)
+                .ok()
+                .and_then(|row| vt::visible_row(term, row));
+
             for col in 0..self.cols {
                 let rect = self.cell_rect(row, col);
                 self.draw_rect(rect, DEBUG_GRID);
                 self.draw_rect_outline(rect, DEBUG_GRID_OUTLINE);
 
-                let Some(cell) = screen.cell(row as u16, col as u16) else {
+                let Some(grid_row) = grid_row else {
                     continue;
                 };
+                if col as usize >= columns {
+                    continue;
+                }
+                let square = grid_row[Column(col as usize)];
 
-                let bg = vt100_debug_color(cell.bgcolor()).unwrap_or(DEBUG_BG_FALLBACK);
-                let fg = vt100_debug_color(cell.fgcolor()).unwrap_or(DEBUG_FG_FALLBACK);
-                let active = cell.has_contents() && !cell.is_wide_continuation();
+                let (fg, bg, flags) = vt::cell_attributes(styles, square);
+                let bg = debug_color(bg).unwrap_or(DEBUG_BG_FALLBACK);
+                let fg = debug_color(fg).unwrap_or(DEBUG_FG_FALLBACK);
+
+                text.clear();
+                if let (Ok(row), Ok(col)) = (u16::try_from(row), u16::try_from(col)) {
+                    vt::push_cell_text(&mut text, &term.grid, vt::visible_pos(term, row, col));
+                }
+                let active = !text.is_empty() && !matches!(square.wide(), Wide::Spacer);
                 let fill = if active {
                     bg
                 } else {
@@ -129,7 +151,7 @@ impl<'a> CellDebugImageRenderer<'a> {
                     self.draw_rect(indicator, fg);
                 }
 
-                if cell.underline() {
+                if flags.intersects(StyleFlags::ALL_UNDERLINES) {
                     let underline = CellRect {
                         x0: rect.x0.saturating_add(2),
                         y0: rect.y1.saturating_sub(2),
@@ -139,16 +161,16 @@ impl<'a> CellDebugImageRenderer<'a> {
                     self.draw_rect(underline, fg);
                 }
 
-                if cell.bold() {
+                if flags.contains(StyleFlags::BOLD) {
                     self.draw_rect_outline(rect.inset(1), [255, 255, 255, 90]);
                 }
             }
         }
 
-        if !screen.hide_cursor() {
-            let (cursor_row, cursor_col) = screen.cursor_position();
+        if !vt::cursor_hidden(term) {
+            let (cursor_row, cursor_col) = vt::cursor_position(term);
             self.draw_rect_outline(
-                self.cell_rect(cursor_row as u32, cursor_col as u32),
+                self.cell_rect(u32::from(cursor_row), u32::from(cursor_col)),
                 DEBUG_CURSOR,
             );
         }
@@ -284,11 +306,11 @@ fn blend_rgba(top: Rgba, bottom: Rgba, top_mix: f32) -> Rgba {
     ]
 }
 
-fn vt100_debug_color(color: vt100::Color) -> Option<Rgba> {
+fn debug_color(color: CellColor) -> Option<Rgba> {
     match color {
-        vt100::Color::Default => None,
-        vt100::Color::Idx(index) => Some(ansi_index_to_rgba(index)),
-        vt100::Color::Rgb(r, g, b) => Some([r, g, b, 255]),
+        CellColor::Default => None,
+        CellColor::Indexed(index) => Some(ansi_index_to_rgba(index)),
+        CellColor::Rgb(r, g, b) => Some([r, g, b, 255]),
     }
 }
 

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1,6 +1,5 @@
-//! PTY runtime and parser state.
+//! PTY runtime and terminal state.
 
-use std::collections::HashSet;
 use std::env;
 use std::io::{ErrorKind, Read, Write};
 use std::path::PathBuf;
@@ -12,9 +11,13 @@ use anyhow::Context;
 use bevy::platform::cell::SyncCell;
 use bevy::prelude::Resource;
 use portable_pty::{CommandBuilder, MasterPty, PtySize, native_pty_system};
-use vt100::{Callbacks, Parser, Screen};
+use rio_vt::ansi::CursorShape;
+use rio_vt::crosswords::{Crosswords, CrosswordsSize};
+use rio_vt::event::WindowId;
+use rio_vt::performer::handler::Processor;
 
 use crate::config::AppConfig;
+use crate::vt::{TerminalEventSink, VtTerminal};
 
 /// Command-line runtime overrides.
 #[derive(Debug, Clone, Default)]
@@ -23,151 +26,6 @@ pub struct RuntimeOptions {
     pub command: Option<Vec<String>>,
     /// Working directory used for the spawned PTY command.
     pub working_dir: Option<PathBuf>,
-}
-
-/// Callback state for unhandled parser sequences.
-#[derive(Default)]
-pub struct TerminalParserCallbacks {
-    seen_csi: HashSet<String>,
-    seen_escape: HashSet<String>,
-    pending_replies: Vec<Vec<u8>>,
-    kitty_keyboard_flags: u8,
-    modify_other_keys: Option<u8>,
-}
-
-impl TerminalParserCallbacks {
-    /// Drains any terminal replies queued by parser callbacks.
-    pub fn take_replies(&mut self) -> Vec<Vec<u8>> {
-        std::mem::take(&mut self.pending_replies)
-    }
-
-    /// Returns the active kitty keyboard enhancement flags.
-    pub fn kitty_keyboard_flags(&self) -> u8 {
-        self.kitty_keyboard_flags
-    }
-
-    /// Returns the active xterm `modifyOtherKeys` level.
-    pub fn modify_other_keys(&self) -> Option<u8> {
-        self.modify_other_keys
-    }
-}
-
-impl Callbacks for TerminalParserCallbacks {
-    fn unhandled_csi(
-        &mut self,
-        screen: &mut Screen,
-        i1: Option<u8>,
-        i2: Option<u8>,
-        params: &[&[u16]],
-        c: char,
-    ) {
-        // CSI 0 c = primary device attributes request.
-        if i1.is_none() && i2.is_none() && c == 'c' && params.len() == 1 && params[0] == [0] {
-            self.pending_replies.push(b"\x1b[?1;2c".to_vec());
-            return;
-        }
-
-        // CSI 5 n = device status report request.
-        if i1.is_none() && i2.is_none() && c == 'n' && params.len() == 1 && params[0] == [5] {
-            self.pending_replies.push(b"\x1b[0n".to_vec());
-            return;
-        }
-
-        // CSI 6 n = cursor position report request.
-        if i1.is_none() && i2.is_none() && c == 'n' && params.len() == 1 && params[0] == [6] {
-            let (row, col) = screen.cursor_position();
-            self.pending_replies
-                .push(format!("\x1b[{};{}R", row + 1, col + 1).into_bytes());
-            return;
-        }
-
-        // CSI ? u = kitty keyboard protocol flag query. Reply with the currently active flags so
-        // apps can detect whether enhanced key reporting is enabled.
-        if i1 == Some(b'?') && i2.is_none() && c == 'u' && params.is_empty() {
-            self.pending_replies
-                .push(format!("\x1b[?{}u", self.kitty_keyboard_flags).into_bytes());
-            return;
-        }
-
-        // CSI > flags u = enable kitty keyboard protocol flags for subsequent key reports.
-        if i1 == Some(b'>') && i2.is_none() && c == 'u' && params.len() == 1 && params[0].len() == 1
-        {
-            self.kitty_keyboard_flags = params[0][0].min(u8::MAX as u16) as u8;
-            return;
-        }
-
-        // CSI < 1 u = pop kitty keyboard enhancement state and fall back to legacy reporting.
-        if i1 == Some(b'<') && i2.is_none() && c == 'u' && params.len() == 1 && params[0] == [1] {
-            self.kitty_keyboard_flags = 0;
-            return;
-        }
-
-        // CSI > 4 ; level m = xterm modifyOtherKeys mode. We track the current level so keys like
-        // Ctrl+Enter can be encoded in the form the foreground app asked for.
-        if i1 == Some(b'>') && i2.is_none() && c == 'm' {
-            match params {
-                [resource, level] if *resource == [4] && level.len() == 1 => {
-                    self.modify_other_keys = Some(level[0].min(u8::MAX as u16) as u8);
-                    return;
-                }
-                [resource] if *resource == [4] => {
-                    self.modify_other_keys = None;
-                    return;
-                }
-                _ => {}
-            }
-        }
-
-        // CSI ? 7 h / CSI ? 7 l toggle line wrapping. Ratty does not model the mode yet, but
-        // treating it as known avoids noisy warnings for shells and TUIs that flip it frequently.
-        if i1 == Some(b'?')
-            && i2.is_none()
-            && params.len() == 1
-            && params[0] == [7]
-            && matches!(c, 'h' | 'l')
-        {
-            return;
-        }
-
-        let mut sequence = String::from("\u{1b}[");
-        if let Some(i1) = i1 {
-            sequence.push(i1 as char);
-        }
-        if let Some(i2) = i2 {
-            sequence.push(i2 as char);
-        }
-        for (idx, param) in params.iter().enumerate() {
-            if idx > 0 {
-                sequence.push(';');
-            }
-            for (j, value) in param.iter().enumerate() {
-                if j > 0 {
-                    sequence.push(':');
-                }
-                sequence.push_str(&value.to_string());
-            }
-        }
-        sequence.push(c);
-
-        if self.seen_csi.insert(sequence.clone()) {
-            bevy::log::warn!("unhandled terminal CSI sequence: {sequence}");
-        }
-    }
-
-    fn unhandled_escape(&mut self, _: &mut Screen, i1: Option<u8>, i2: Option<u8>, b: u8) {
-        let mut sequence = String::from("\u{1b}");
-        if let Some(i1) = i1 {
-            sequence.push(i1 as char);
-        }
-        if let Some(i2) = i2 {
-            sequence.push(i2 as char);
-        }
-        sequence.push(b as char);
-
-        if self.seen_escape.insert(sequence.clone()) {
-            bevy::log::warn!("unhandled terminal escape sequence: {sequence}");
-        }
-    }
 }
 
 /// Running PTY and parser state.
@@ -187,9 +45,12 @@ pub struct TerminalRuntime {
     child: Option<Box<dyn portable_pty::Child + Send + Sync>>,
     /// PTY reader thread.
     reader_thread: Option<JoinHandle<()>>,
-    /// Terminal parser.
-    pub parser: Parser<TerminalParserCallbacks>,
-    scrollback_len: usize,
+    /// Terminal grid and VT state.
+    pub term: VtTerminal,
+    /// VT state machine feeding [`Self::term`].
+    processor: Processor,
+    /// Reply queue shared with the terminal's event listener.
+    sink: TerminalEventSink,
     /// Indicates PTY shutdown.
     pub pty_disconnected: bool,
     shutdown_started: bool,
@@ -345,22 +206,40 @@ impl TerminalRuntime {
             }
         });
 
+        let sink = TerminalEventSink::default();
+        let term = Crosswords::new(
+            CrosswordsSize::new(usize::from(cols.max(1)), usize::from(rows.max(1))),
+            CursorShape::Block,
+            sink.clone(),
+            // Route and window ids are Rio's multiplexer bookkeeping; ratty
+            // drives a single terminal, so both are zero.
+            WindowId::from(0),
+            0,
+            config.terminal.scrollback,
+        );
+
         Ok(Self {
             rx: SyncCell::new(rx),
             writer: Arc::new(Mutex::new(Some(writer))),
             master: SyncCell::new(Some(pair.master)),
             child: Some(child),
             reader_thread: Some(reader_thread),
-            parser: Parser::new_with_callbacks(
-                rows,
-                cols,
-                config.terminal.scrollback,
-                TerminalParserCallbacks::default(),
-            ),
-            scrollback_len: config.terminal.scrollback,
+            term,
+            processor: Processor::default(),
+            sink,
             pty_disconnected: false,
             shutdown_started: false,
         })
+    }
+
+    /// Feeds bytes from the PTY into the VT state machine.
+    pub fn process(&mut self, bytes: &[u8]) {
+        self.processor.advance(&mut self.term, bytes);
+    }
+
+    /// Drains the replies rio-vt has queued for write-back to the PTY.
+    pub fn take_replies(&mut self) -> Vec<Vec<u8>> {
+        self.sink.take_replies()
     }
 
     /// Receives pending PTY output without blocking.
@@ -397,26 +276,20 @@ impl TerminalRuntime {
             });
         }
 
-        let (_, old_cols) = self.parser.screen().size();
-        if old_cols == cols || self.parser.screen().alternate_screen() {
-            self.parser.screen_mut().set_size(rows, cols);
-            return;
-        }
-
-        let state = self.parser.screen().state_formatted();
-        let callbacks = std::mem::take(self.parser.callbacks_mut());
-        self.parser = Parser::new_with_callbacks(rows, cols, self.scrollback_len, callbacks);
-        self.parser.process(&state);
+        // rio-vt reflows content and resets the scrolling region natively, so
+        // the grid resize is the whole operation — no snapshot and replay.
+        self.term
+            .resize(CrosswordsSize::new(usize::from(cols), usize::from(rows)));
     }
 
     /// Returns the active kitty keyboard enhancement flags.
     pub fn kitty_keyboard_flags(&self) -> u8 {
-        self.parser.callbacks().kitty_keyboard_flags()
+        crate::vt::kitty_keyboard_flags(&self.term)
     }
 
     /// Returns the active xterm `modifyOtherKeys` level.
     pub fn modify_other_keys(&self) -> Option<u8> {
-        self.parser.callbacks().modify_other_keys()
+        self.term.modify_other_keys()
     }
 
     /// Shuts down the PTY runtime without blocking the Bevy main thread indefinitely.

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -45,6 +45,7 @@ use crate::scene::{
 use crate::terminal::{
     TerminalRedrawState, TerminalSurface, TerminalWidget, render_scale_for_window,
 };
+use crate::vt;
 use bevy::app::AppExit;
 use bevy::asset::AssetMut;
 use bevy::camera::visibility::NoFrustumCulling;
@@ -163,42 +164,32 @@ pub fn pump_pty_output(
     mut app_exit: MessageWriter<AppExit>,
     mut redraw: ResMut<TerminalRedrawState>,
 ) {
-    let screen_rows = |screen: &vt100::Screen| {
-        let (_, cols) = screen.size();
-        screen.rows(0, cols).collect::<Vec<_>>()
-    };
-
     let mut processed_output = false;
     let mut camera_updates = Vec::new();
     loop {
         match runtime.try_recv() {
             Ok(chunk) => {
                 let track_scroll = inline_objects.has_scroll_tracked_anchors();
-                let prev_rows: Option<Vec<String>> = if track_scroll {
-                    let (_, cols) = runtime.parser.screen().size();
-                    Some(runtime.parser.screen().rows(0, cols).collect::<Vec<_>>())
-                } else {
-                    None
-                };
+                let prev_rows = track_scroll.then(|| vt::visible_row_texts(&runtime.term));
                 let mut replies = inline_objects.consume_pty_output(
                     &chunk,
-                    &mut runtime.parser,
+                    &mut runtime,
                     &mut camera_updates,
                     &mut processed_output,
                 );
                 for update in camera_updates.drain(..) {
                     camera_update_writer.write(update);
                 }
-                replies.extend(runtime.parser.callbacks_mut().take_replies());
+                replies.extend(runtime.take_replies());
                 for reply in replies {
                     runtime.write_input(&reply);
                 }
                 if let Some(prev_rows) = prev_rows {
-                    let next_rows = screen_rows(runtime.parser.screen());
+                    let next_rows = vt::visible_row_texts(&runtime.term);
                     let scrolled = infer_upward_scroll(&prev_rows, &next_rows);
                     inline_objects.apply_scroll(scrolled);
                 }
-                inline_objects.refresh_placeholder_anchors(runtime.parser.screen());
+                inline_objects.refresh_placeholder_anchors(&runtime.term);
             }
             Err(TryRecvError::Empty) => break,
             Err(TryRecvError::Disconnected) => {
@@ -279,8 +270,8 @@ pub(crate) fn handle_window_resize(
     };
 
     // Minimizing the window reports a 0x0 size. Skip it so the terminal keeps
-    // its last good grid instead of collapsing to a degenerate size that the
-    // vt100 parser can't safely process.
+    // its last good grid instead of collapsing to a degenerate size the VT
+    // engine can't safely process.
     if window_size.x < 1.0 || window_size.y < 1.0 {
         return;
     }
@@ -398,11 +389,11 @@ pub(crate) fn render_terminal_widget(mut params: RenderWidgetParams) {
         return;
     }
 
-    let screen = runtime.parser.screen();
+    let term = &runtime.term;
     let _ = terminal.tui.draw(|frame| {
         frame.render_widget(
             TerminalWidget {
-                screen,
+                term,
                 selection,
                 theme: &app_config.theme,
                 font_style: app_config.font.style,
@@ -410,8 +401,8 @@ pub(crate) fn render_terminal_widget(mut params: RenderWidgetParams) {
             frame.area(),
         );
 
-        if !app_config.cursor.model.visible && !screen.hide_cursor() {
-            let (cursor_row, cursor_col) = screen.cursor_position();
+        if !app_config.cursor.model.visible && !vt::cursor_hidden(term) {
+            let (cursor_row, cursor_col) = vt::cursor_position(term);
             frame.set_cursor_position((cursor_col, cursor_row));
         }
     });
@@ -468,7 +459,7 @@ pub(crate) fn sync_terminal_materials(mut params: SyncMaterialsParams) {
 
     let in_3d = camera_slots.active().mode.is_3d();
     if in_3d {
-        sync_terminal_debug_image(terminal, images, runtime.parser.screen());
+        sync_terminal_debug_image(terminal, images, &runtime.term);
     }
 
     sync_plane_texture(terminal.image_handle.as_ref(), plane_materials, materials);
@@ -1710,8 +1701,7 @@ fn cursor_pose(
     let cell_height = ctx.viewport.size.y / rows;
     let scale = cell_width.min(cell_height) * app_config.cursor.model.scale_factor;
 
-    let screen = ctx.runtime.parser.screen();
-    let (cursor_row, cursor_col) = screen.cursor_position();
+    let (cursor_row, cursor_col) = vt::cursor_position(&ctx.runtime.term);
     let cursor_col = cursor_col.min(ctx.terminal.cols.saturating_sub(1)) as f32;
     let cursor_row = cursor_row.min(ctx.terminal.rows.saturating_sub(1)) as f32;
 
@@ -1733,7 +1723,7 @@ fn cursor_pose(
         (
             Vec3::new(local_x, local_y + bob, CURSOR_DEPTH),
             Quat::from_rotation_y(spin) * Quat::from_rotation_x(-0.25),
-            if !app_config.cursor.model.visible || screen.hide_cursor() {
+            if !app_config.cursor.model.visible || vt::cursor_hidden(&ctx.runtime.term) {
                 Visibility::Hidden
             } else {
                 Visibility::Visible

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -9,6 +9,9 @@ use parley_ratatui::ratatui::widgets::Widget;
 use parley_ratatui::{
     CellQuantization, FontOptions, ParleyBackend, TerminalRenderer, TexturePresentation,
 };
+use rio_vt::crosswords::pos::Column;
+use rio_vt::crosswords::square::{Square, Wide};
+use rio_vt::crosswords::style::{Style as VtStyle, StyleFlags};
 
 use crate::config::{AppConfig, FontConfig, FontStyleConfig, ThemeConfig};
 use crate::direct_render::{
@@ -16,6 +19,7 @@ use crate::direct_render::{
     update_direct_terminal_frame,
 };
 use crate::mouse::TerminalSelection;
+use crate::vt::{self, CellColor, VtTerminal};
 
 /// Terminal grid and presentation dimensions.
 #[derive(Clone, Copy, Debug)]
@@ -175,16 +179,12 @@ impl TerminalSurface {
 
         let metrics = self.renderer.logical_metrics(self.render_scale);
         let logical_size = logical_size.max(Vec2::ONE);
-        // A single-column grid makes vt100's wide-character wrap logic
-        // underflow (`cols - width` for a 2-cell glyph), so keep at least two.
         let cols = (logical_size.x / metrics.cell_width)
             .floor()
-            .clamp(2.0, u16::MAX as f32) as u16;
-        // Likewise, a single-row grid makes vt100's wrap/scroll bookkeeping
-        // underflow (`prev_row - scrolled`), so keep at least two rows.
+            .clamp(1.0, u16::MAX as f32) as u16;
         let rows = (logical_size.y / metrics.cell_height)
             .floor()
-            .clamp(2.0, u16::MAX as f32) as u16;
+            .clamp(1.0, u16::MAX as f32) as u16;
 
         if cols != self.cols || rows != self.rows {
             self.resize(cols, rows);
@@ -367,10 +367,10 @@ fn build_terminal_renderer(
     )
 }
 
-/// Ratatui widget backed by a VT100 screen.
+/// Ratatui widget backed by the rio-vt grid.
 pub struct TerminalWidget<'a> {
-    /// Screen to render.
-    pub screen: &'a vt100::Screen,
+    /// Terminal state to render.
+    pub term: &'a VtTerminal,
     /// Active selection.
     pub selection: &'a TerminalSelection,
     /// Terminal theme.
@@ -387,49 +387,63 @@ impl Widget for TerminalWidget<'_> {
         buf.set_style(area, Style::default().fg(theme_fg));
 
         let selection = self.selection.normalized_bounds();
-        let (rows, cols) = self.screen.size();
+        let rows = u16::try_from(self.term.screen_lines()).unwrap_or(u16::MAX);
+        let cols = u16::try_from(self.term.columns()).unwrap_or(u16::MAX);
         let draw_rows = rows.min(area.height);
         let draw_cols = cols.min(area.width);
+        let styles = vt::styles(self.term);
+        let mut symbol = String::new();
 
         for row in 0..draw_rows {
+            let Some(grid_row) = vt::visible_row(self.term, row) else {
+                continue;
+            };
             for col in 0..draw_cols {
-                let Some(vt_cell) = self.screen.cell(row, col) else {
-                    continue;
-                };
-                if vt_cell.is_wide_continuation() {
+                let square = grid_row[Column(usize::from(col))];
+                // Both spacer kinds are padding rather than content and must be
+                // left at the buffer's blank default. `Spacer` is the second
+                // half of a wide glyph; `LeadingSpacer` is the pad rio-vt writes
+                // at end-of-line when a wide glyph wraps — it holds a space
+                // carrying the active SGR style, so drawing it would paint a
+                // styled block there and defeat the renderer's wide-cell
+                // heuristic, which only treats a trailing space as a
+                // continuation when it has no background.
+                if matches!(square.wide(), Wide::Spacer | Wide::LeadingSpacer) {
                     continue;
                 }
 
-                let mut style =
-                    vt100_cell_style(vt_cell, &theme_palette, theme_fg, self.font_style);
-                let symbol = if vt_cell.has_contents() {
-                    vt_cell.contents()
-                } else {
-                    " "
-                };
+                symbol.clear();
+                vt::push_cell_text(
+                    &mut symbol,
+                    &self.term.grid,
+                    vt::visible_pos(self.term, row, col),
+                );
 
+                let mut style =
+                    square_style(styles, square, &theme_palette, theme_fg, self.font_style);
                 if selection.is_some_and(|bounds| bounds.contains(row, col)) {
                     style = style.add_modifier(Modifier::REVERSED);
                 }
 
                 buf[(area.x + col, area.y + row)]
-                    .set_symbol(symbol)
+                    .set_symbol(if symbol.is_empty() { " " } else { &symbol })
                     .set_style(style);
             }
         }
     }
 }
 
-fn vt100_cell_style(
-    cell: &vt100::Cell,
+fn square_style(
+    styles: &[VtStyle],
+    square: Square,
     theme_palette: &[TuiColor; 16],
     theme_fg: TuiColor,
     font_style: FontStyleConfig,
 ) -> Style {
-    let mut style =
-        Style::default().fg(vt100_color_to_tui(cell.fgcolor(), theme_palette).unwrap_or(theme_fg));
+    let (fg, bg, flags) = vt::cell_attributes(styles, square);
 
-    if let Some(bg) = vt100_color_to_tui(cell.bgcolor(), theme_palette) {
+    let mut style = Style::default().fg(cell_color_to_tui(fg, theme_palette).unwrap_or(theme_fg));
+    if let Some(bg) = cell_color_to_tui(bg, theme_palette) {
         style = style.bg(bg);
     }
 
@@ -439,19 +453,22 @@ fn vt100_cell_style(
         FontStyleConfig::Italic => Modifier::ITALIC,
         FontStyleConfig::BoldItalic => Modifier::BOLD | Modifier::ITALIC,
     };
-    if cell.bold() {
+    if flags.contains(StyleFlags::BOLD) {
         modifiers |= Modifier::BOLD;
     }
-    if cell.dim() {
+    if flags.contains(StyleFlags::DIM) {
         modifiers |= Modifier::DIM;
     }
-    if cell.italic() {
+    if flags.contains(StyleFlags::ITALIC) {
         modifiers |= Modifier::ITALIC;
     }
-    if cell.underline() {
+    // Ratatui has a single underline modifier, so every underline style
+    // rio-vt distinguishes (straight, double, curly, dotted, dashed) collapses
+    // onto it.
+    if flags.intersects(StyleFlags::ALL_UNDERLINES) {
         modifiers |= Modifier::UNDERLINED;
     }
-    if cell.inverse() {
+    if flags.contains(StyleFlags::INVERSE) {
         modifiers |= Modifier::REVERSED;
     }
 
@@ -459,11 +476,11 @@ fn vt100_cell_style(
     style
 }
 
-fn vt100_color_to_tui(color: vt100::Color, theme_palette: &[TuiColor; 16]) -> Option<TuiColor> {
+fn cell_color_to_tui(color: CellColor, theme_palette: &[TuiColor; 16]) -> Option<TuiColor> {
     match color {
-        vt100::Color::Default => None,
-        vt100::Color::Idx(index) => Some(ansi_index_to_tui(index, theme_palette)),
-        vt100::Color::Rgb(r, g, b) => Some(TuiColor::Rgb(r, g, b)),
+        CellColor::Default => None,
+        CellColor::Indexed(index) => Some(ansi_index_to_tui(index, theme_palette)),
+        CellColor::Rgb(r, g, b) => Some(TuiColor::Rgb(r, g, b)),
     }
 }
 
@@ -488,6 +505,134 @@ fn ansi_index_to_tui(index: u8, theme_palette: &[TuiColor; 16]) -> TuiColor {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    use parley_ratatui::ratatui::buffer::Cell;
+    use rio_vt::ansi::CursorShape;
+    use rio_vt::crosswords::{Crosswords, CrosswordsSize};
+    use rio_vt::event::WindowId;
+    use rio_vt::performer::handler::Processor;
+
+    use crate::vt::TerminalEventSink;
+
+    /// Renders `input` through [`TerminalWidget`] and returns row 0's cells.
+    fn render_cells(rows: u16, cols: u16, input: &[u8]) -> Vec<Cell> {
+        let mut term = Crosswords::new(
+            CrosswordsSize::new(usize::from(cols), usize::from(rows)),
+            CursorShape::Block,
+            TerminalEventSink::default(),
+            WindowId::from(0),
+            0,
+            1000,
+        );
+        Processor::default().advance(&mut term, input);
+
+        let area = Rect::new(0, 0, cols, rows);
+        let mut buffer = Buffer::empty(area);
+        TerminalWidget {
+            term: &term,
+            selection: &TerminalSelection::default(),
+            theme: &ThemeConfig::default(),
+            font_style: FontStyleConfig::Regular,
+        }
+        .render(area, &mut buffer);
+
+        (0..cols).map(|col| buffer[(col, 0)].clone()).collect()
+    }
+
+    /// Renders `input` through [`TerminalWidget`] and returns the drawn rows.
+    fn render_rows(rows: u16, cols: u16, input: &[u8]) -> Vec<String> {
+        let mut term = Crosswords::new(
+            CrosswordsSize::new(usize::from(cols), usize::from(rows)),
+            CursorShape::Block,
+            TerminalEventSink::default(),
+            WindowId::from(0),
+            0,
+            1000,
+        );
+        Processor::default().advance(&mut term, input);
+
+        let area = Rect::new(0, 0, cols, rows);
+        let mut buffer = Buffer::empty(area);
+        TerminalWidget {
+            term: &term,
+            selection: &TerminalSelection::default(),
+            theme: &ThemeConfig::default(),
+            font_style: FontStyleConfig::Regular,
+        }
+        .render(area, &mut buffer);
+
+        (0..rows)
+            .map(|row| {
+                (0..cols)
+                    .map(|col| buffer[(col, row)].symbol())
+                    .collect::<String>()
+                    .trim_end()
+                    .to_string()
+            })
+            .collect()
+    }
+
+    /// End-to-end guard for the defect that motivated this engine port: rio-vt's
+    /// `visible_rows` is bound to the DECSTBM scroll region, so a widget built on
+    /// it draws the grid shifted up with blank rows at the bottom the moment an
+    /// application narrows the region — which vim, less, htop and tmux all do.
+    #[test]
+    fn widget_draws_every_row_with_a_scroll_region_set() {
+        let mut input = Vec::new();
+        for line in 0..8 {
+            input.extend_from_slice(format!("\x1b[{};1Hline{line}", line + 1).as_bytes());
+        }
+        let without_region = render_rows(8, 20, &input);
+
+        input.extend_from_slice(b"\x1b[2;6r");
+        let with_region = render_rows(8, 20, &input);
+
+        let expected: Vec<String> = (0..8).map(|line| format!("line{line}")).collect();
+        assert_eq!(without_region, expected);
+        assert_eq!(
+            with_region, expected,
+            "a narrowed scroll region must not shift or blank the drawn grid"
+        );
+    }
+
+    /// When a wide glyph does not fit, rio-vt pads end-of-line with a space
+    /// carrying the active SGR style. Drawing that pad paints a styled block at
+    /// the line end and breaks the renderer's wide-cell heuristic, which only
+    /// treats a trailing space as a continuation when it has no background.
+    /// vt100 had no equivalent cell, so this guards buffer parity with it.
+    #[test]
+    fn wrapped_wide_characters_leave_an_unstyled_pad() {
+        // Green background, then text that pushes a wide glyph past the edge.
+        let rendered = render_cells(2, 14, b"\x1b[42mabcdefghijkl\xe4\xbd\xa0\x1b[0m");
+
+        let pad = &rendered[13];
+        assert_eq!(pad.symbol(), " ", "the pad cell must stay blank");
+        assert_eq!(
+            pad.bg,
+            TuiColor::Reset,
+            "the pad cell must not carry the active background"
+        );
+    }
+
+    /// Earlier rio-vt releases aborted placing a double-width glyph in a
+    /// single-column grid, which is why the grid floor used to be two columns.
+    /// Window managers and drag-resize routinely produce very narrow grids, so
+    /// keep a guard on the sizes that used to panic.
+    #[test]
+    fn degenerate_grids_render_without_panicking() {
+        for (rows, cols) in [(1_u16, 1_u16), (1, 40), (40, 1), (2, 2)] {
+            let rendered = render_rows(rows, cols, "\u{4f60}\u{597d}ab".as_bytes());
+            assert_eq!(rendered.len(), usize::from(rows));
+        }
+    }
+
+    #[test]
+    fn widget_draws_wide_characters_and_combining_marks() {
+        let rendered = render_rows(2, 10, "你好e\u{0301}z".as_bytes());
+
+        // The spacer cell after a wide glyph stays blank rather than repeating it.
+        assert_eq!(rendered[0], "你 好 e\u{0301}z");
+    }
 
     /// Regression test for vertical-only zoom steps (#97): with fractional
     /// cell quantization, every font-size step must grow both axes.

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -572,10 +572,10 @@ mod tests {
             .collect()
     }
 
-    /// End-to-end guard for the defect that motivated this engine port: rio-vt's
-    /// `visible_rows` is bound to the DECSTBM scroll region, so a widget built on
-    /// it draws the grid shifted up with blank rows at the bottom the moment an
-    /// application narrows the region — which vim, less, htop and tmux all do.
+    /// End-to-end guard for the defect that motivated this engine port: older
+    /// rio-vt releases bound `visible_rows` to the DECSTBM scroll region, so a
+    /// widget built on it drew the grid shifted up with blank rows at the bottom
+    /// the moment an application narrowed the region.
     #[test]
     fn widget_draws_every_row_with_a_scroll_region_set() {
         let mut input = Vec::new();

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -1,8 +1,10 @@
 //! Terminal surface rendering and Ratatui integration.
 
+use std::num::NonZeroU16;
+
 use bevy::prelude::*;
 use parley_ratatui::ratatui::Terminal;
-use parley_ratatui::ratatui::buffer::Buffer;
+use parley_ratatui::ratatui::buffer::{Buffer, CellDiffOption};
 use parley_ratatui::ratatui::layout::Rect;
 use parley_ratatui::ratatui::style::{Color as TuiColor, Modifier, Style};
 use parley_ratatui::ratatui::widgets::Widget;
@@ -400,15 +402,32 @@ impl Widget for TerminalWidget<'_> {
             };
             for col in 0..draw_cols {
                 let square = grid_row[Column(usize::from(col))];
-                // Both spacer kinds are padding rather than content and must be
-                // left at the buffer's blank default. `Spacer` is the second
-                // half of a wide glyph; `LeadingSpacer` is the pad rio-vt writes
-                // at end-of-line when a wide glyph wraps — it holds a space
-                // carrying the active SGR style, so drawing it would paint a
-                // styled block there and defeat the renderer's wide-cell
-                // heuristic, which only treats a trailing space as a
-                // continuation when it has no background.
-                if matches!(square.wide(), Wide::Spacer | Wide::LeadingSpacer) {
+                let cell = &mut buf[(area.x + col, area.y + row)];
+
+                // Ratatui normally skips the trailing buffer cell when diffing
+                // a width-2 symbol. That is correct for a real terminal, where
+                // printing the glyph updates both columns, but ParleyBackend is
+                // an in-memory cell buffer: skipping the update leaves whatever
+                // symbol occupied the continuation cell in an earlier frame.
+                // Keep the owner visually wide for Parley while forcing Ratatui
+                // to diff it as one cell, which lets its spacer participate in
+                // the normal diff instead of being skipped.
+                if matches!(square.wide(), Wide::Spacer) {
+                    let mut style =
+                        square_style(styles, square, &theme_palette, theme_fg, self.font_style);
+                    if selection.is_some_and(|bounds| bounds.contains(row, col)) {
+                        style = style.add_modifier(Modifier::REVERSED);
+                    }
+                    cell.set_symbol(" ").set_style(style);
+                    continue;
+                }
+
+                // A leading spacer is the end-of-line pad Rio writes before a
+                // wide glyph wraps. It is not part of the glyph and must remain
+                // an unstyled blank so the normal diff clears content left by
+                // a previous frame.
+                if matches!(square.wide(), Wide::LeadingSpacer) {
+                    cell.set_symbol(" ");
                     continue;
                 }
 
@@ -425,9 +444,11 @@ impl Widget for TerminalWidget<'_> {
                     style = style.add_modifier(Modifier::REVERSED);
                 }
 
-                buf[(area.x + col, area.y + row)]
-                    .set_symbol(if symbol.is_empty() { " " } else { &symbol })
+                cell.set_symbol(if symbol.is_empty() { " " } else { &symbol })
                     .set_style(style);
+                if matches!(square.wide(), Wide::Wide) {
+                    cell.set_diff_option(CellDiffOption::ForcedWidth(NonZeroU16::MIN));
+                }
             }
         }
     }
@@ -572,6 +593,37 @@ mod tests {
             .collect()
     }
 
+    /// Draws a terminal state through Ratatui's differential update path into
+    /// the persistent Parley backend buffer.
+    fn draw_term(tui: &mut Terminal<ParleyBackend>, term: &Crosswords<TerminalEventSink>) {
+        tui.draw(|frame| {
+            frame.render_widget(
+                TerminalWidget {
+                    term,
+                    selection: &TerminalSelection::default(),
+                    theme: &ThemeConfig::default(),
+                    font_style: FontStyleConfig::Regular,
+                },
+                frame.area(),
+            );
+        })
+        .expect("draw terminal frame");
+    }
+
+    /// Builds and draws a fresh terminal state through [`draw_term`].
+    fn draw_input(tui: &mut Terminal<ParleyBackend>, rows: u16, cols: u16, input: &[u8]) {
+        let mut term = Crosswords::new(
+            CrosswordsSize::new(usize::from(cols), usize::from(rows)),
+            CursorShape::Block,
+            TerminalEventSink::default(),
+            WindowId::from(0),
+            0,
+            1000,
+        );
+        Processor::default().advance(&mut term, input);
+        draw_term(tui, &term);
+    }
+
     /// End-to-end guard for the defect that motivated this engine port: older
     /// rio-vt releases bound `visible_rows` to the DECSTBM scroll region, so a
     /// widget built on it drew the grid shifted up with blank rows at the bottom
@@ -602,8 +654,9 @@ mod tests {
     /// vt100 had no equivalent cell, so this guards buffer parity with it.
     #[test]
     fn wrapped_wide_characters_leave_an_unstyled_pad() {
-        // Green background, then text that pushes a wide glyph past the edge.
-        let rendered = render_cells(2, 14, b"\x1b[42mabcdefghijkl\xe4\xbd\xa0\x1b[0m");
+        // Green background, then thirteen narrow cells so the wide glyph cannot
+        // fit in the one remaining column and Rio writes a LeadingSpacer there.
+        let rendered = render_cells(2, 14, b"\x1b[42mabcdefghijklm\xe4\xbd\xa0\x1b[0m");
 
         let pad = &rendered[13];
         assert_eq!(pad.symbol(), " ", "the pad cell must stay blank");
@@ -612,6 +665,82 @@ mod tests {
             TuiColor::Reset,
             "the pad cell must not carry the active background"
         );
+    }
+
+    /// Ratatui skips a wide glyph's second cell when sending a diff to a real
+    /// terminal. ParleyBackend stores those diffs as cells, so the skipped
+    /// update used to retain the old symbol and background. Scrolling then
+    /// repeated those stale cells anywhere a CJK glyph or emoji moved.
+    #[test]
+    fn successive_draws_replace_wide_continuation_cells() {
+        let (rows, cols) = (2, 8);
+        let mut tui = Terminal::new(ParleyBackend::new(cols, rows)).expect("terminal");
+
+        draw_input(&mut tui, rows, cols, b"abcdefgh");
+        draw_input(
+            &mut tui,
+            rows,
+            cols,
+            "\x1b[42m\u{4f60}\u{1f600}\x1b[0m".as_bytes(),
+        );
+
+        let buffer = tui.backend().buffer();
+        assert_eq!(buffer[(0, 0)].symbol(), "\u{4f60}");
+        assert_eq!(buffer[(1, 0)].symbol(), " ");
+        assert_eq!(buffer[(2, 0)].symbol(), "\u{1f600}");
+        assert_eq!(buffer[(3, 0)].symbol(), " ");
+        assert_eq!(buffer[(1, 0)].bg, buffer[(0, 0)].bg);
+        assert_eq!(buffer[(3, 0)].bg, buffer[(2, 0)].bg);
+        assert_ne!(buffer[(0, 0)].bg, TuiColor::Reset);
+        for col in 4..cols {
+            assert_eq!(
+                buffer[(col, 0)].symbol(),
+                " ",
+                "old content survived at column {col}"
+            );
+        }
+    }
+
+    /// Repeatedly moving wide graphemes into and out of the viewport must not
+    /// leave their owners or continuation cells behind on unrelated rows.
+    #[test]
+    fn scrollback_redraws_wide_graphemes_without_artifacts() {
+        let (rows, cols) = (2, 8);
+        let mut tui = Terminal::new(ParleyBackend::new(cols, rows)).expect("terminal");
+        let mut term = Crosswords::new(
+            CrosswordsSize::new(usize::from(cols), usize::from(rows)),
+            CursorShape::Block,
+            TerminalEventSink::default(),
+            WindowId::from(0),
+            0,
+            1000,
+        );
+        Processor::default().advance(
+            &mut term,
+            "\x1b[42m\u{4f60}\u{1f600}\x1b[0m\r\nsecond\r\nthird\r\nfourth".as_bytes(),
+        );
+
+        for offset in [1, 2, 0, 2, 1, 2] {
+            crate::vt::set_scrollback(&mut term, offset);
+            draw_term(&mut tui, &term);
+
+            let buffer = tui.backend().buffer();
+            if offset == 2 {
+                assert_eq!(buffer[(0, 0)].symbol(), "\u{4f60}");
+                assert_eq!(buffer[(1, 0)].symbol(), " ");
+                assert_eq!(buffer[(2, 0)].symbol(), "\u{1f600}");
+                assert_eq!(buffer[(3, 0)].symbol(), " ");
+                assert_eq!(buffer[(1, 0)].bg, buffer[(0, 0)].bg);
+                assert_eq!(buffer[(3, 0)].bg, buffer[(2, 0)].bg);
+            } else {
+                assert!(
+                    buffer
+                        .content()
+                        .iter()
+                        .all(|cell| !matches!(cell.symbol(), "\u{4f60}" | "\u{1f600}"))
+                );
+            }
+        }
     }
 
     /// Earlier rio-vt releases aborted placing a double-width glyph in a

--- a/src/vt.rs
+++ b/src/vt.rs
@@ -1,0 +1,952 @@
+//! rio-vt integration.
+//!
+//! Holds the [`EventListener`] ratty drives rio-vt with, the screen-reading
+//! helpers its renderers share, and the small amount of terminal state rio-vt
+//! does not model itself.
+//!
+//! Screen reads go through [`visible_row`] rather than rio-vt's `visible_rows`.
+//! That function deep-copies every visible row on each call, and ratty reads the
+//! screen several times per frame and per PTY chunk, so indexing the grid and
+//! borrowing avoids the copy entirely.
+
+use std::sync::{Arc, Mutex, PoisonError};
+
+use rio_vt::ansi::CursorShape;
+use rio_vt::config::colors::{AnsiColor, NamedColor};
+use rio_vt::crosswords::grid::row::Row;
+use rio_vt::crosswords::grid::{Grid, Scroll};
+use rio_vt::crosswords::pos::{Column, Line, Pos};
+use rio_vt::crosswords::square::{ContentTag, Square, Wide};
+use rio_vt::crosswords::style::{Style, StyleFlags};
+use rio_vt::crosswords::{Crosswords, Mode};
+use rio_vt::event::{EventListener, RioEvent, WindowId};
+
+/// The rio-vt state machine ratty drives.
+pub type VtTerminal = Crosswords<TerminalEventSink>;
+
+/// Sink for the events rio-vt raises while parsing.
+///
+/// The only variant ratty acts on today is [`RioEvent::PtyWrite`] — the
+/// engine's DA, DSR, CPR, XTVERSION, and kitty-keyboard replies, which have to
+/// be written back to the PTY.
+///
+/// `send_event` takes `&self`, so the queue needs interior mutability, and
+/// `TerminalRuntime` is a Bevy resource that has to stay `Send + Sync`, which
+/// rules out `RefCell`.
+#[derive(Clone, Default)]
+pub struct TerminalEventSink {
+    replies: Arc<Mutex<Vec<Vec<u8>>>>,
+}
+
+impl TerminalEventSink {
+    /// Drains the bytes rio-vt has queued for write-back to the PTY.
+    pub fn take_replies(&self) -> Vec<Vec<u8>> {
+        let mut replies = self.replies.lock().unwrap_or_else(PoisonError::into_inner);
+        std::mem::take(&mut *replies)
+    }
+}
+
+impl EventListener for TerminalEventSink {
+    fn send_event(&self, event: RioEvent, _window: WindowId) {
+        match event {
+            // Engine-generated replies: primary and secondary device
+            // attributes, DSR, CPR, XTVERSION, kitty keyboard mode reports,
+            // and XTSMGRAPHICS. Recover from a poisoned lock rather than
+            // dropping these — an application that queried is waiting on them.
+            RioEvent::PtyWrite(_route, text) => {
+                let reply = rewrite_reply(&text).unwrap_or(text);
+                let mut replies = self.replies.lock().unwrap_or_else(PoisonError::into_inner);
+                replies.push(reply.into_bytes());
+            }
+
+            // Requests carrying a reply callback rio-vt expects the embedder to
+            // invoke and write back. Ratty answers none of them yet, so an
+            // application that queries with a timeout waits it out:
+            //   ColorRequest        OSC 4/10/11/12 palette queries
+            //   TextAreaSizeRequest CSI 14t/16t/18t pixel-geometry queries
+            //   ClipboardLoad       OSC 52 clipboard read
+            // Answering them needs, respectively, ratty's theme, its cell
+            // metrics, and a clipboard-read policy.
+            RioEvent::ColorRequest(..)
+            | RioEvent::TextAreaSizeRequest(..)
+            | RioEvent::ClipboardLoad(..) => {}
+
+            // Features ratty does not implement yet, listed so that adding one
+            // means filling in an arm rather than discovering the event exists.
+            RioEvent::ClipboardStore(..)
+            | RioEvent::Title(..)
+            | RioEvent::TitleWithSubtitle(..)
+            | RioEvent::ResetTitle
+            | RioEvent::Bell
+            | RioEvent::DesktopNotification { .. }
+            | RioEvent::ProgressReport(..)
+            | RioEvent::ColorChange(..) => {}
+
+            // The rest is Rio's own window, tab, and config plumbing, plus
+            // redraw bookkeeping ratty drives from Bevy instead. `RioEvent` is
+            // not `#[non_exhaustive]` and gains variants across minor releases,
+            // so this stays a catch-all rather than an exhaustive match that
+            // would break the build on every upgrade.
+            _ => {}
+        }
+    }
+}
+
+/// DA1 capability parameters ratty must not advertise.
+///
+/// rio-vt answers primary device attributes with a fixed list describing what
+/// the *engine* can parse, not what the embedder renders. `4` is sixel
+/// graphics — rio-vt's `graphics` feature is off here, so nothing decodes it —
+/// and `52` is OSC 52 clipboard access, whose events [`TerminalEventSink`]
+/// drops. Leaving either in makes applications feature-detect support that does
+/// not exist and emit payloads ratty silently swallows.
+const UNSUPPORTED_DA1_CAPABILITIES: &[&str] = &["4", "52"];
+
+/// Rewrites an engine reply that would misreport ratty's capabilities or
+/// identity, or returns `None` to send it through untouched.
+///
+/// rio-vt answers device-attribute and version queries on ratty's behalf, which
+/// is the right split — it owns the protocol framing. But it answers them as
+/// Rio: the DA1 capability list is hardcoded, and both the XTVERSION string and
+/// the DA2 firmware field carry rio-vt's own name and crate version. Patching
+/// the payloads on the way out keeps the engine's framing while reporting what
+/// ratty actually is and does.
+///
+/// Parsing structurally rather than matching the exact strings means a rio-vt
+/// release that changes its capability list still gets filtered.
+fn rewrite_reply(text: &str) -> Option<String> {
+    // Primary device attributes: `CSI ? <capabilities> c`.
+    if let Some(params) = text
+        .strip_prefix("\x1b[?")
+        .and_then(|rest| rest.strip_suffix('c'))
+    {
+        let kept = params
+            .split(';')
+            .filter(|param| !UNSUPPORTED_DA1_CAPABILITIES.contains(param))
+            .collect::<Vec<_>>();
+        // Nothing to do when the engine already reported only what ratty
+        // supports, and never answer with an empty capability list.
+        if kept.is_empty() || kept.len() == params.split(';').count() {
+            return None;
+        }
+        return Some(format!("\x1b[?{}c", kept.join(";")));
+    }
+
+    // Secondary device attributes: `CSI > <type> ; <firmware> ; <cartridge> c`,
+    // where the firmware field carries rio-vt's crate version.
+    if let Some(params) = text
+        .strip_prefix("\x1b[>")
+        .and_then(|rest| rest.strip_suffix('c'))
+    {
+        let mut fields = params.split(';').map(str::to_owned).collect::<Vec<_>>();
+        if fields.len() != 3 {
+            return None;
+        }
+        fields[1] = encoded_version().to_string();
+        return Some(format!("\x1b[>{}c", fields.join(";")));
+    }
+
+    // XTVERSION: `DCS > | <name and version> ST`.
+    if text.starts_with("\x1bP>|") && text.ends_with("\x1b\\") {
+        return Some(format!("\x1bP>|ratty {}\x1b\\", env!("CARGO_PKG_VERSION")));
+    }
+
+    None
+}
+
+/// Encodes ratty's version the way the DA2 firmware field expects.
+///
+/// Mirrors rio-vt's own encoding — pre-release suffix dropped, then each semver
+/// component weighted by a power of 100 — so the field keeps its established
+/// shape and only the value changes.
+fn encoded_version() -> usize {
+    let version = env!("CARGO_PKG_VERSION");
+    let version = version
+        .rsplit_once('-')
+        .map_or(version, |(release, _prerelease)| release);
+
+    version
+        .split('.')
+        .rev()
+        .enumerate()
+        .map(|(index, component)| {
+            let scale = u32::try_from(index)
+                .ok()
+                .and_then(|index| 100_usize.checked_pow(index))
+                .unwrap_or(0);
+            scale.saturating_mul(component.parse::<usize>().unwrap_or(0))
+        })
+        .sum()
+}
+
+/// Returns the visible row at `row`, or `None` when it is outside the grid.
+///
+/// Mirrors rio-vt's own `visible_line_bounds` offset math, but borrows instead
+/// of copying. See the module docs.
+pub fn visible_row(term: &VtTerminal, row: u16) -> Option<&Row<Square>> {
+    if usize::from(row) >= term.screen_lines() {
+        return None;
+    }
+    let offset = i32::try_from(term.display_offset()).unwrap_or(i32::MAX);
+    Some(&term.grid[Line(i32::from(row) - offset)])
+}
+
+/// Appends a cell's full grapheme cluster to `out`.
+///
+/// Wide-character continuation cells contribute nothing: their codepoint is a
+/// space, and emitting it would overwrite the left half of the glyph.
+pub fn push_cell_text(out: &mut String, grid: &Grid<Square>, pos: Pos) {
+    if matches!(grid[pos].wide(), Wide::Spacer) {
+        return;
+    }
+    // `cell_text` yields the base codepoint followed by any zero-width marks,
+    // so combining marks and ZWJ sequences survive.
+    for character in grid.cell_text(pos) {
+        if character != '\0' {
+            out.push(character);
+        }
+    }
+}
+
+/// Returns whether the cell is the second half of a wide glyph.
+///
+/// Callers that substitute a space for blank cells must skip these outright:
+/// a spacer is padding, not an empty cell, and emitting a space for it inserts
+/// a gap after every wide character.
+pub fn is_wide_spacer(grid: &Grid<Square>, pos: Pos) -> bool {
+    matches!(grid[pos].wide(), Wide::Spacer)
+}
+
+/// Returns the grid position of a visible `(row, col)`.
+pub fn visible_pos(term: &VtTerminal, row: u16, col: u16) -> Pos {
+    let offset = i32::try_from(term.display_offset()).unwrap_or(i32::MAX);
+    Pos::new(Line(i32::from(row) - offset), Column(usize::from(col)))
+}
+
+/// Returns each visible row as a trailing-trimmed string.
+///
+/// Allocates, so it is only worth calling when something actually diffs rows —
+/// today that is inline-object scroll tracking.
+pub fn visible_row_texts(term: &VtTerminal) -> Vec<String> {
+    let columns = term.columns();
+    (0..term.screen_lines())
+        .map(|row| {
+            let Some(row) = u16::try_from(row)
+                .ok()
+                .filter(|row| visible_row(term, *row).is_some())
+            else {
+                return String::new();
+            };
+            let mut out = String::with_capacity(columns);
+            for col in 0..columns {
+                let Ok(col) = u16::try_from(col) else {
+                    break;
+                };
+                let pos = visible_pos(term, row, col);
+                if is_wide_spacer(&term.grid, pos) {
+                    continue;
+                }
+                let before = out.len();
+                push_cell_text(&mut out, &term.grid, pos);
+                if out.len() == before {
+                    // Blank cells are stored as NUL rather than a space.
+                    out.push(' ');
+                }
+            }
+            let trimmed = out.trim_end();
+            out.truncate(trimmed.len());
+            out
+        })
+        .collect()
+}
+
+/// Returns whether the alternate screen is active.
+pub fn alternate_screen(term: &VtTerminal) -> bool {
+    term.mode().contains(Mode::ALT_SCREEN)
+}
+
+/// Returns whether bracketed paste mode is active.
+pub fn bracketed_paste(term: &VtTerminal) -> bool {
+    term.mode().contains(Mode::BRACKETED_PASTE)
+}
+
+/// Returns whether application cursor keys mode is active.
+pub fn application_cursor(term: &VtTerminal) -> bool {
+    term.mode().contains(Mode::APP_CURSOR)
+}
+
+/// A cell colour resolved to what a renderer has to draw.
+///
+/// rio-vt's [`AnsiColor::Named`] covers more than the sixteen ANSI slots: the
+/// terminal's own default foreground and background, the cursor colour, and a
+/// dim variant of each base colour. Resolving them once here keeps the ratatui
+/// widget and the debug-image renderer from drifting apart.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CellColor {
+    /// Fall back to the theme's default foreground or background.
+    Default,
+    /// Palette index, 0-255.
+    Indexed(u8),
+    /// Direct 24-bit colour.
+    Rgb(u8, u8, u8),
+}
+
+/// Resolves a rio-vt colour into a [`CellColor`].
+pub fn resolve_color(color: AnsiColor) -> CellColor {
+    match color {
+        AnsiColor::Indexed(index) => CellColor::Indexed(index),
+        AnsiColor::Spec(rgb) => CellColor::Rgb(rgb.r, rgb.g, rgb.b),
+        AnsiColor::Named(named) => match named {
+            // The terminal's own defaults. `Cursor` lands here because ratty
+            // draws its own cursor rather than recolouring the cell.
+            NamedColor::Foreground
+            | NamedColor::Background
+            | NamedColor::Cursor
+            | NamedColor::LightForeground
+            | NamedColor::DimForeground => CellColor::Default,
+            // Dim variants resolve to their base slot: the DIM style flag
+            // already carries the dimming, so folding it into the colour too
+            // would double up.
+            NamedColor::DimBlack
+            | NamedColor::DimRed
+            | NamedColor::DimGreen
+            | NamedColor::DimYellow
+            | NamedColor::DimBlue
+            | NamedColor::DimMagenta
+            | NamedColor::DimCyan
+            | NamedColor::DimWhite => {
+                let base = named as u32 - NamedColor::DimBlack as u32;
+                u8::try_from(base).map_or(CellColor::Default, CellColor::Indexed)
+            }
+            // Everything left is one of the sixteen ANSI slots.
+            named => {
+                let index = named as u32;
+                debug_assert!(index < 16, "unhandled NamedColor variant: {named:?}");
+                u8::try_from(index).map_or(CellColor::Default, CellColor::Indexed)
+            }
+        },
+    }
+}
+
+/// Foreground colour, background colour, and attribute flags for a cell.
+pub fn cell_attributes(styles: &[Style], square: Square) -> (CellColor, CellColor, StyleFlags) {
+    match square.content_tag() {
+        ContentTag::Codepoint => {
+            let style = styles
+                .get(usize::from(square.style_id()))
+                .copied()
+                .unwrap_or_default();
+            (
+                resolve_color(style.fg),
+                resolve_color(style.bg),
+                style.flags,
+            )
+        }
+        ContentTag::BgPalette => (
+            CellColor::Default,
+            CellColor::Indexed(square.bg_palette_index()),
+            StyleFlags::empty(),
+        ),
+        ContentTag::BgRgb => {
+            let (r, g, b) = square.bg_rgb();
+            (
+                CellColor::Default,
+                CellColor::Rgb(r, g, b),
+                StyleFlags::empty(),
+            )
+        }
+    }
+}
+
+/// Returns the grid's interned style table, indexed by `Square::style_id`.
+pub fn styles(term: &VtTerminal) -> &[Style] {
+    term.grid.style_set.styles()
+}
+
+/// The xterm mouse reporting mode an application has requested.
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Default)]
+pub enum MouseProtocolMode {
+    /// Mouse reporting is off.
+    #[default]
+    None,
+    /// Report press only (X10, `CSI ? 9 h`).
+    Press,
+    /// Report press and release (1000).
+    PressRelease,
+    /// Report press, release, and motion while a button is held (1002).
+    ButtonMotion,
+    /// Report press, release, and all motion (1003).
+    AnyMotion,
+}
+
+/// The encoding used for mouse reports.
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Default)]
+pub enum MouseProtocolEncoding {
+    /// Single-printable-byte encoding.
+    #[default]
+    Default,
+    /// UTF-8 encoding (1005).
+    Utf8,
+    /// SGR encoding (1006).
+    Sgr,
+}
+
+/// Returns the active mouse reporting mode.
+///
+/// Checked most-permissive first: 1003 supersedes 1002, which supersedes 1000.
+pub fn mouse_protocol_mode(term: &VtTerminal) -> MouseProtocolMode {
+    let mode = term.mode();
+    if mode.contains(Mode::MOUSE_MOTION) {
+        MouseProtocolMode::AnyMotion
+    } else if mode.contains(Mode::MOUSE_DRAG) {
+        MouseProtocolMode::ButtonMotion
+    } else if mode.contains(Mode::MOUSE_REPORT_CLICK) {
+        MouseProtocolMode::PressRelease
+    } else if mode.contains(Mode::MOUSE_REPORT_X10) {
+        MouseProtocolMode::Press
+    } else {
+        MouseProtocolMode::None
+    }
+}
+
+/// Returns the active mouse report encoding.
+pub fn mouse_protocol_encoding(term: &VtTerminal) -> MouseProtocolEncoding {
+    let mode = term.mode();
+    if mode.contains(Mode::SGR_MOUSE) {
+        MouseProtocolEncoding::Sgr
+    } else if mode.contains(Mode::UTF8_MOUSE) {
+        MouseProtocolEncoding::Utf8
+    } else {
+        MouseProtocolEncoding::Default
+    }
+}
+
+/// Returns the active kitty keyboard enhancement flags.
+pub fn kitty_keyboard_flags(term: &VtTerminal) -> u8 {
+    term.keyboard_mode().bits()
+}
+
+/// Returns the cursor position as `(row, col)` in grid coordinates.
+///
+/// Unaffected by the scrollback offset, which is what the inline-object anchors
+/// and mouse-wheel encoding want.
+pub fn cursor_position(term: &VtTerminal) -> (u16, u16) {
+    let pos = term.cursor().pos;
+    (
+        u16::try_from(pos.row.0.max(0)).unwrap_or(u16::MAX),
+        u16::try_from(pos.col.0).unwrap_or(u16::MAX),
+    )
+}
+
+/// Returns whether the cursor should be drawn.
+///
+/// Uses rio-vt's resolved cursor state, which folds in DECTCEM, the scrollback
+/// offset (the cursor hides while scrolled into history), and the wide-cell
+/// column snap. The raw `Mode::SHOW_CURSOR` bit carries none of that.
+pub fn cursor_hidden(term: &VtTerminal) -> bool {
+    term.cursor().content == CursorShape::Hidden
+}
+
+/// Returns how many rows the view is scrolled into history.
+pub fn scrollback(term: &VtTerminal) -> usize {
+    term.display_offset()
+}
+
+/// Scrolls the view `rows` rows into history, clamped to the available history.
+pub fn set_scrollback(term: &mut VtTerminal, rows: usize) {
+    let current = term.display_offset();
+    if rows == current {
+        return;
+    }
+    let delta = rows as i64 - current as i64;
+    let delta = delta.clamp(i64::from(i32::MIN), i64::from(i32::MAX)) as i32;
+    term.scroll_display(Scroll::Delta(delta));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use rio_vt::crosswords::CrosswordsSize;
+    use rio_vt::event::WindowId;
+    use rio_vt::performer::handler::Processor;
+
+    struct Harness {
+        term: VtTerminal,
+        processor: Processor,
+        sink: TerminalEventSink,
+    }
+
+    impl Harness {
+        fn new(rows: u16, cols: u16) -> Self {
+            let sink = TerminalEventSink::default();
+            let term = Crosswords::new(
+                CrosswordsSize::new(usize::from(cols), usize::from(rows)),
+                CursorShape::Block,
+                sink.clone(),
+                WindowId::from(0),
+                0,
+                1000,
+            );
+            Self {
+                term,
+                processor: Processor::default(),
+                sink,
+            }
+        }
+
+        fn feed(&mut self, bytes: &[u8]) {
+            self.processor.advance(&mut self.term, bytes);
+        }
+
+        fn row_text(&self, row: u16) -> String {
+            let Some(grid_row) = visible_row(&self.term, row) else {
+                return String::new();
+            };
+            let _ = grid_row;
+            let mut out = String::new();
+            for col in 0..u16::try_from(self.term.columns()).unwrap_or(u16::MAX) {
+                push_cell_text(&mut out, &self.term.grid, visible_pos(&self.term, row, col));
+            }
+            out.trim_end().to_string()
+        }
+    }
+
+    /// rio-vt's `visible_rows` iterates the DECSTBM scroll region, so a widget
+    /// built on it renders the grid shifted up and truncates the bottom rows as
+    /// soon as an application narrows the region. Every row the terminal
+    /// reports must stay reachable and correctly indexed.
+    #[test]
+    fn every_row_stays_reachable_with_a_scroll_region_set() {
+        let mut harness = Harness::new(10, 20);
+        for line in 0..10 {
+            harness.feed(format!("\x1b[{};1Hline{line}", line + 1).as_bytes());
+        }
+
+        harness.feed(b"\x1b[2;8r");
+
+        assert_eq!(harness.term.screen_lines(), 10);
+        for line in 0..10_u16 {
+            assert!(
+                visible_row(&harness.term, line).is_some(),
+                "row {line} unreachable with a scroll region set"
+            );
+            assert_eq!(
+                harness.row_text(line),
+                format!("line{line}"),
+                "row {line} holds the wrong grid line"
+            );
+        }
+        assert!(visible_row(&harness.term, 10).is_none());
+    }
+
+    #[test]
+    fn combining_marks_survive_in_cell_text() {
+        let mut harness = Harness::new(3, 20);
+        harness.feed("e\u{0301}X".as_bytes());
+
+        let mut first = String::new();
+        push_cell_text(
+            &mut first,
+            &harness.term.grid,
+            visible_pos(&harness.term, 0, 0),
+        );
+
+        assert_eq!(first, "e\u{0301}");
+        assert_eq!(first.chars().count(), 2);
+        assert_eq!(harness.row_text(0), "e\u{0301}X");
+    }
+
+    #[test]
+    fn wide_characters_skip_their_spacer_cells() {
+        let mut harness = Harness::new(3, 10);
+        harness.feed("你好ab".as_bytes());
+
+        let row = visible_row(&harness.term, 0).expect("row 0");
+        assert_eq!(row[Column(0)].c(), '你');
+        assert!(matches!(row[Column(1)].wide(), Wide::Spacer));
+
+        let mut spacer = String::new();
+        push_cell_text(
+            &mut spacer,
+            &harness.term.grid,
+            visible_pos(&harness.term, 0, 1),
+        );
+        assert!(spacer.is_empty(), "spacer cells must contribute no text");
+
+        assert_eq!(harness.row_text(0), "你好ab");
+    }
+
+    #[test]
+    fn cursor_hides_while_scrolled_into_history() {
+        let mut harness = Harness::new(3, 20);
+        for line in 0..10 {
+            harness.feed(format!("row{line}\r\n").as_bytes());
+        }
+        assert!(!cursor_hidden(&harness.term));
+
+        set_scrollback(&mut harness.term, 3);
+        assert_eq!(scrollback(&harness.term), 3);
+        assert!(
+            cursor_hidden(&harness.term),
+            "cursor must not be drawn over scrollback"
+        );
+
+        set_scrollback(&mut harness.term, 0);
+        assert_eq!(scrollback(&harness.term), 0);
+        assert!(!cursor_hidden(&harness.term));
+    }
+
+    #[test]
+    fn cursor_hides_under_dectcem() {
+        let mut harness = Harness::new(3, 20);
+        harness.feed(b"\x1b[?25l");
+        assert!(cursor_hidden(&harness.term));
+        harness.feed(b"\x1b[?25h");
+        assert!(!cursor_hidden(&harness.term));
+    }
+
+    #[test]
+    fn scrollback_clamps_to_available_history() {
+        let mut harness = Harness::new(3, 20);
+        for line in 0..10 {
+            harness.feed(format!("row{line}\r\n").as_bytes());
+        }
+        let history = harness.term.history_size();
+
+        set_scrollback(&mut harness.term, history + 100);
+        assert_eq!(scrollback(&harness.term), history);
+    }
+
+    #[test]
+    fn resize_reflows_and_keeps_scrollback() {
+        let mut harness = Harness::new(4, 20);
+        for line in 0..12 {
+            harness.feed(format!("row{line}\r\n").as_bytes());
+        }
+        assert!(harness.term.history_size() > 0);
+
+        harness.term.resize(CrosswordsSize::new(40, 6));
+
+        assert_eq!(harness.term.screen_lines(), 6);
+        assert_eq!(harness.term.columns(), 40);
+        assert!(harness.term.history_size() > 0);
+        for line in 0..6_u16 {
+            assert!(visible_row(&harness.term, line).is_some());
+        }
+    }
+
+    /// [`visible_row`] indexes the grid at `row - display_offset`, which is only
+    /// in range while the offset stays within the available history. A resize
+    /// that shrinks history must not leave a stale offset behind and push the
+    /// index past the ring.
+    #[test]
+    fn rows_stay_readable_after_resizing_while_scrolled_back() {
+        for (cols, rows) in [(40, 3), (10, 12), (80, 24), (20, 4)] {
+            let mut harness = Harness::new(6, 40);
+            for line in 0..60 {
+                harness.feed(format!("row{line}\r\n").as_bytes());
+            }
+            let history = harness.term.history_size();
+            set_scrollback(&mut harness.term, history);
+
+            harness.term.resize(CrosswordsSize::new(cols, rows));
+
+            let screen_lines = u16::try_from(harness.term.screen_lines()).expect("screen lines");
+            for line in 0..screen_lines {
+                assert!(
+                    visible_row(&harness.term, line).is_some(),
+                    "row {line} unreadable after resizing to {cols}x{rows} while scrolled back"
+                );
+            }
+            // And reading every cell must not index out of the ring.
+            let _ = visible_row_texts(&harness.term);
+        }
+    }
+
+    #[test]
+    fn resize_resets_a_narrowed_scroll_region() {
+        let mut harness = Harness::new(10, 20);
+        harness.feed(b"\x1b[2;5r");
+        harness.term.resize(CrosswordsSize::new(21, 10));
+
+        for line in 0..10_u16 {
+            assert!(visible_row(&harness.term, line).is_some());
+        }
+    }
+
+    #[test]
+    fn engine_replies_are_queued_for_write_back() {
+        let mut harness = Harness::new(5, 20);
+        harness.feed(b"\x1b[0c");
+        harness.feed(b"\x1b[5n");
+        harness.feed(b"\x1b[3;7H\x1b[6n");
+
+        let replies = harness.sink.take_replies();
+        assert_eq!(replies.len(), 3, "expected DA, DSR, and CPR replies");
+        assert_eq!(replies[1], b"\x1b[0n");
+        assert_eq!(replies[2], b"\x1b[3;7R");
+        assert!(harness.sink.take_replies().is_empty(), "replies must drain");
+    }
+
+    /// rio-vt reports the engine's capabilities, not ratty's. Sixel and OSC 52
+    /// must not survive to the PTY, or applications will emit payloads that
+    /// silently go nowhere.
+    #[test]
+    fn primary_device_attributes_drop_unimplemented_capabilities() {
+        let mut harness = Harness::new(5, 20);
+        harness.feed(b"\x1b[0c");
+
+        let replies = harness.sink.take_replies();
+        assert_eq!(replies.len(), 1);
+        let reply = String::from_utf8(replies[0].clone()).expect("utf-8 DA1 reply");
+
+        let params = reply
+            .strip_prefix("\x1b[?")
+            .and_then(|rest| rest.strip_suffix('c'))
+            .expect("DA1 shape preserved")
+            .split(';')
+            .collect::<Vec<_>>();
+
+        assert!(!params.contains(&"4"), "sixel must not be advertised");
+        assert!(!params.contains(&"52"), "OSC 52 must not be advertised");
+        assert!(
+            params.contains(&"62"),
+            "the VT220 terminal class must survive"
+        );
+        assert!(params.contains(&"22"), "ANSI colour must survive");
+    }
+
+    #[test]
+    fn secondary_device_attributes_report_rattys_version() {
+        let mut harness = Harness::new(5, 20);
+        harness.feed(b"\x1b[>0c");
+
+        let replies = harness.sink.take_replies();
+        assert_eq!(replies.len(), 1);
+        assert_eq!(
+            replies[0],
+            format!("\x1b[>0;{};1c", encoded_version()).into_bytes()
+        );
+    }
+
+    #[test]
+    fn xtversion_reports_ratty_rather_than_rio() {
+        let mut harness = Harness::new(5, 20);
+        harness.feed(b"\x1b[>0q");
+
+        let replies = harness.sink.take_replies();
+        assert_eq!(replies.len(), 1);
+        let reply = String::from_utf8(replies[0].clone()).expect("utf-8 XTVERSION reply");
+
+        assert_eq!(
+            reply,
+            format!("\x1bP>|ratty {}\x1b\\", env!("CARGO_PKG_VERSION"))
+        );
+        assert!(!reply.contains("Rio"));
+    }
+
+    #[test]
+    fn unrelated_replies_pass_through_untouched() {
+        for reply in [
+            "\x1b[0n",        // DSR
+            "\x1b[3;7R",      // CPR
+            "\x1b[?1u",       // kitty keyboard mode report
+            "\x1b[?62;22c",   // DA1 with nothing to strip
+            "\x1b[>0;1;2;3c", // DA2 with an unexpected field count
+        ] {
+            assert_eq!(rewrite_reply(reply), None, "{reply:?} should be untouched");
+        }
+    }
+
+    #[test]
+    fn encoded_version_matches_the_da2_weighting() {
+        // Mirrors rio-vt's scheme: patch + minor*100 + major*10000.
+        let expected = env!("CARGO_PKG_VERSION")
+            .split('.')
+            .rev()
+            .enumerate()
+            .map(|(index, part)| 100_usize.pow(index as u32) * part.parse::<usize>().unwrap_or(0))
+            .sum::<usize>();
+        assert_eq!(encoded_version(), expected);
+    }
+
+    #[test]
+    fn mouse_protocol_mode_prefers_the_most_permissive() {
+        let mut harness = Harness::new(5, 20);
+        assert_eq!(mouse_protocol_mode(&harness.term), MouseProtocolMode::None);
+
+        harness.feed(b"\x1b[?1000h");
+        assert_eq!(
+            mouse_protocol_mode(&harness.term),
+            MouseProtocolMode::PressRelease
+        );
+        harness.feed(b"\x1b[?1002h");
+        assert_eq!(
+            mouse_protocol_mode(&harness.term),
+            MouseProtocolMode::ButtonMotion
+        );
+        harness.feed(b"\x1b[?1003h");
+        assert_eq!(
+            mouse_protocol_mode(&harness.term),
+            MouseProtocolMode::AnyMotion
+        );
+
+        harness.feed(b"\x1b[?1003l\x1b[?1002l\x1b[?1000l");
+        assert_eq!(mouse_protocol_mode(&harness.term), MouseProtocolMode::None);
+    }
+
+    #[test]
+    fn mouse_protocol_encoding_prefers_sgr() {
+        let mut harness = Harness::new(5, 20);
+        assert_eq!(
+            mouse_protocol_encoding(&harness.term),
+            MouseProtocolEncoding::Default
+        );
+
+        harness.feed(b"\x1b[?1005h");
+        assert_eq!(
+            mouse_protocol_encoding(&harness.term),
+            MouseProtocolEncoding::Utf8
+        );
+        harness.feed(b"\x1b[?1006h");
+        assert_eq!(
+            mouse_protocol_encoding(&harness.term),
+            MouseProtocolEncoding::Sgr
+        );
+    }
+
+    #[test]
+    fn kitty_keyboard_flags_map_each_mode_bit() {
+        let mut harness = Harness::new(5, 20);
+        assert_eq!(kitty_keyboard_flags(&harness.term), 0);
+
+        for (requested, expected) in [(1_u8, 1_u8), (3, 3), (31, 31)] {
+            harness.feed(format!("\x1b[>{requested}u").as_bytes());
+            assert_eq!(
+                kitty_keyboard_flags(&harness.term),
+                expected,
+                "flags {requested} did not round-trip"
+            );
+            harness.feed(b"\x1b[<1u");
+        }
+    }
+
+    #[test]
+    fn default_style_resolves_to_theme_defaults() {
+        assert_eq!(
+            resolve_color(AnsiColor::Named(NamedColor::Foreground)),
+            CellColor::Default
+        );
+        assert_eq!(
+            resolve_color(AnsiColor::Named(NamedColor::Background)),
+            CellColor::Default
+        );
+        assert_eq!(
+            resolve_color(AnsiColor::Named(NamedColor::Cursor)),
+            CellColor::Default
+        );
+    }
+
+    #[test]
+    fn named_colors_resolve_to_their_palette_slots() {
+        assert_eq!(
+            resolve_color(AnsiColor::Named(NamedColor::Black)),
+            CellColor::Indexed(0)
+        );
+        assert_eq!(
+            resolve_color(AnsiColor::Named(NamedColor::LightWhite)),
+            CellColor::Indexed(15)
+        );
+        // Dim variants fall back to their base slot; the DIM flag does the rest.
+        assert_eq!(
+            resolve_color(AnsiColor::Named(NamedColor::DimBlack)),
+            CellColor::Indexed(0)
+        );
+        assert_eq!(
+            resolve_color(AnsiColor::Named(NamedColor::DimWhite)),
+            CellColor::Indexed(7)
+        );
+    }
+
+    #[test]
+    fn indexed_and_rgb_colors_pass_through() {
+        assert_eq!(
+            resolve_color(AnsiColor::Indexed(200)),
+            CellColor::Indexed(200)
+        );
+        assert_eq!(
+            resolve_color(AnsiColor::Spec(rio_vt::config::colors::ColorRgb {
+                r: 1,
+                g: 2,
+                b: 3
+            })),
+            CellColor::Rgb(1, 2, 3)
+        );
+    }
+
+    #[test]
+    fn cell_attributes_read_truecolor_and_flags() {
+        let mut harness = Harness::new(3, 20);
+        harness.feed(b"\x1b[1;3;4;7;38;2;10;20;30;48;5;99mX");
+
+        let row = visible_row(&harness.term, 0).expect("row 0");
+        let (fg, bg, flags) = cell_attributes(styles(&harness.term), row[Column(0)]);
+
+        assert_eq!(fg, CellColor::Rgb(10, 20, 30));
+        assert_eq!(bg, CellColor::Indexed(99));
+        assert!(flags.contains(StyleFlags::BOLD));
+        assert!(flags.contains(StyleFlags::ITALIC));
+        assert!(flags.intersects(StyleFlags::ALL_UNDERLINES));
+        assert!(flags.contains(StyleFlags::INVERSE));
+    }
+
+    /// rio-vt models `modifyOtherKeys` itself now, so ratty reads it from the
+    /// engine instead of sniffing PTY bytes. Level 0 means disabled and must
+    /// report `None`, since the key encoder treats any `Some` as enabled.
+    #[test]
+    fn modify_other_keys_comes_from_the_engine() {
+        let mut harness = Harness::new(5, 20);
+        assert_eq!(harness.term.modify_other_keys(), None);
+
+        harness.feed(b"\x1b[>4;2m");
+        assert_eq!(harness.term.modify_other_keys(), Some(2));
+
+        harness.feed(b"\x1b[>4;0m");
+        assert_eq!(
+            harness.term.modify_other_keys(),
+            None,
+            "level 0 disables the mode"
+        );
+
+        harness.feed(b"\x1b[>4;1m");
+        assert_eq!(harness.term.modify_other_keys(), Some(1));
+        harness.feed(b"\x1b[>4m");
+        assert_eq!(harness.term.modify_other_keys(), None);
+    }
+
+    /// Split across PTY reads, which the old byte sniffer could not handle.
+    #[test]
+    fn modify_other_keys_survives_a_split_sequence() {
+        let sequence = b"\x1b[>4;2m";
+        for split in 1..sequence.len() {
+            let mut harness = Harness::new(5, 20);
+            harness.feed(&sequence[..split]);
+            harness.feed(&sequence[split..]);
+            assert_eq!(
+                harness.term.modify_other_keys(),
+                Some(2),
+                "split at {split} was missed"
+            );
+        }
+    }
+
+    #[test]
+    fn x10_mouse_reporting_is_recognized() {
+        let mut harness = Harness::new(5, 20);
+        harness.feed(b"\x1b[?9h");
+        assert_eq!(mouse_protocol_mode(&harness.term), MouseProtocolMode::Press);
+        harness.feed(b"\x1b[?9l");
+        assert_eq!(mouse_protocol_mode(&harness.term), MouseProtocolMode::None);
+    }
+}

--- a/src/vt.rs
+++ b/src/vt.rs
@@ -512,10 +512,10 @@ mod tests {
         }
     }
 
-    /// rio-vt's `visible_rows` iterates the DECSTBM scroll region, so a widget
-    /// built on it renders the grid shifted up and truncates the bottom rows as
-    /// soon as an application narrows the region. Every row the terminal
-    /// reports must stay reachable and correctly indexed.
+    /// Older rio-vt releases made `visible_rows` iterate the DECSTBM scroll
+    /// region, so a widget built on it rendered the grid shifted up and
+    /// truncated the bottom rows as soon as an application narrowed the region.
+    /// Keep every reported row reachable so that bug cannot return here.
     #[test]
     fn every_row_stays_reachable_with_a_scroll_region_set() {
         let mut harness = Harness::new(10, 20);


### PR DESCRIPTION
Replaces [`vt100`](https://crates.io/crates/vt100) with [`rio-vt`](https://crates.io/crates/rio-vt) as Ratty's VT state machine. The integration uses Rio's native grid and protocol APIs rather than reproducing vt100's interface behind a shim. `portable-pty` remains Ratty's PTY layer.

This is an alternative implementation of #138. Full credit to @raphamorim for the engine work and for identifying the Rio integration gaps; the main difference here is the adapter strategy.

## Why a native adapter

`src/vt.rs` centralizes the Rio event listener, borrowed screen/grid helpers, terminal capability replies, and state not modeled by the engine. `TerminalRuntime` owns a `Crosswords` and `Processor`, while both renderers borrow the grid directly.

This avoids three mismatches that were easy to hide behind a vt100-shaped shim:

- older Rio releases tied `visible_rows()` to the DECSTBM scroll region;
- `visible_rows()` deep-copies rows, while Ratty reads the screen several times per frame;
- a single `Square::c()` is not the full grapheme cluster.

Rio now exposes the APIs needed to handle these natively (`visible_line_bounds`, `Grid::cell_text`, keyboard mode, `modifyOtherKeys`, and X10 mouse state).

## Correctness improvements

- Native resize/reflow preserves scrollback instead of rebuilding the parser from only visible rows.
- Rendering preserves combining marks and other full grapheme content.
- Cursor visibility and position come from Rio's resolved cursor state, including scrollback and wide-cell behavior.
- Wide-character owner and continuation cells are diffed independently in the in-memory Parley backend, so CJK/emoji backgrounds remain complete and scrolling cannot retain stale symbols; wrapped leading spacers stay unstyled.
- Kitty placeholder discovery uses Rio's per-row marker instead of scanning every cell.
- Kitty keyboard, `modifyOtherKeys`, mouse protocol precedence, X10 mouse mode, colors, and scrollback behavior come from engine state and are covered by tests.
- DA1, DA2, and XTVERSION replies are structurally rewritten so Ratty does not advertise unsupported capabilities or identify itself as Rio.

## Rio 0.5.19 update

This PR now uses `rio-vt 0.5.19` with `default-features = false`. Rio added a `pty` feature after the original PR was opened, so embedders such as Ratty can omit Rio's unused PTY implementation while continuing to use `portable-pty`.

That reduces the root lockfile from the original PR's 695 packages to 676 (main has 658): +18 rather than +37. The unused `teletypewriter`/`corcovado` chain and its old platform dependencies are gone.

Rio 0.5.19 still hardcodes Rio's device capabilities/identity, so the local reply rewriting remains necessary.

## Verification

Local verification on the final diff:

- `cargo fmt --all -- --check`
- `cargo fmt --all --manifest-path widget/Cargo.toml -- --check`
- `cargo test --lib --locked` — 103 passed, 0 failed
- `cargo check --all-targets --locked`
- `cargo check --all-targets --locked --manifest-path widget/Cargo.toml`
- `cargo clippy --all-targets --locked -- -D warnings`
- `cargo clippy --all-targets --locked --manifest-path widget/Cargo.toml -- -D warnings`

The workflow matrix was also corrected so all five targets run against both manifests (10 check jobs), with native ARM64 Linux on `ubuntu-24.04-arm`. A Linux library-test job now runs the full 103-test suite in CI.

## Manual visual pass still recommended

The remaining high-value manual pass is GPU-backed behavior: vim/less/htop/tmux bottom-row alignment, resize and scrollback, truecolor/attributes, Unicode and CJK text, mouse reporting, Kitty images, and RGP inline objects in both 2D and 3D.