### PR TITLE
Support the kitty image protocol natively through rio-vt

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1818,6 +1818,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ec7c5eb7a16992b1904d76c517d170ab353b0e0b3d5a0c81a8a0cd1037893cf"
 
 [[package]]
+name = "color_quant"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2485,6 +2491,15 @@ checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "font-types"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39a654f404bbcbd48ea58c617c2993ee91d1cb63727a37bf2323a4edeed1b8c5"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
+name = "font-types"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b38ad915f6dadd993ced50848a8291a543bd41ca62bc10740d5e64e2ab4cfd7"
@@ -2506,7 +2521,7 @@ dependencies = [
  "objc2-core-text",
  "objc2-foundation 0.3.2",
  "parlance",
- "read-fonts",
+ "read-fonts 0.39.2",
  "roxmltree",
  "smallvec",
  "windows",
@@ -2673,6 +2688,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "gif"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee8cfcc411d9adbbaba82fb72661cc1bcca13e8bba98b364e62b2dba8f960159"
+dependencies = [
+ "color_quant",
+ "weezl",
+]
+
+[[package]]
 name = "gl_generator"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2828,7 +2853,7 @@ checksum = "d12c7c642d4ce8c2e784b4751a6634bd89583912265add4a679a8882d123fbcd"
 dependencies = [
  "bitflags 2.13.0",
  "bytemuck",
- "read-fonts",
+ "read-fonts 0.39.2",
  "smallvec",
 ]
 
@@ -3067,10 +3092,25 @@ checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
 dependencies = [
  "bytemuck",
  "byteorder-lite",
+ "color_quant",
+ "gif",
+ "image-webp",
  "moxcms",
  "num-traits",
  "png",
  "tiff",
+ "zune-core",
+ "zune-jpeg",
+]
+
+[[package]]
+name = "image-webp"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "525e9ff3e1a4be2fbea1fdf0e98686a6d98b4d8f937e1bf7402245af1909e8c3"
+dependencies = [
+ "byteorder-lite",
+ "quick-error",
 ]
 
 [[package]]
@@ -4142,7 +4182,7 @@ dependencies = [
  "linebender_resource_handle",
  "parlance",
  "parley_data",
- "skrifa",
+ "skrifa 0.42.1",
 ]
 
 [[package]]
@@ -4716,6 +4756,7 @@ dependencies = [
  "parley_ratatui",
  "portable-pty",
  "ratatui",
+ "rio-graphics",
  "rio-vt",
  "rust-embed",
  "serde",
@@ -4747,12 +4788,22 @@ dependencies = [
 
 [[package]]
 name = "read-fonts"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6717cf23b488adf64b9d711329542ba34de147df262370221940dfabc2c91358"
+dependencies = [
+ "bytemuck",
+ "font-types 0.10.1",
+]
+
+[[package]]
+name = "read-fonts"
 version = "0.39.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4ed38b89c2c77ff968c524145ad65fb010f38af5c7a224b53b81d47ac2daa81"
 dependencies = [
  "bytemuck",
- "font-types",
+ "font-types 0.11.3",
 ]
 
 [[package]]
@@ -4850,7 +4901,10 @@ version = "0.5.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "150067cf37f1468cffffae9cbfd40e106adc5f8451239b5b0a7fa660b6a5a91c"
 dependencies = [
+ "image",
+ "parking_lot",
  "rustc-hash 2.1.3",
+ "skrifa 0.37.0",
  "tracing",
 ]
 
@@ -4864,6 +4918,7 @@ dependencies = [
  "bitflags 2.13.0",
  "cursor-icon",
  "flate2",
+ "image",
  "libc",
  "memchr",
  "parking_lot",
@@ -5276,12 +5331,22 @@ checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
 
 [[package]]
 name = "skrifa"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c31071dedf532758ecf3fed987cdb4bd9509f900e026ab684b4ecb81ea49841"
+dependencies = [
+ "bytemuck",
+ "read-fonts 0.35.0",
+]
+
+[[package]]
+name = "skrifa"
 version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c34617370ae968efb7161bb2beb517d9084659aae19e24b89e3db25b46e4564"
 dependencies = [
  "bytemuck",
- "read-fonts",
+ "read-fonts 0.39.2",
 ]
 
 [[package]]
@@ -5429,7 +5494,7 @@ version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0811b01ca2c4e8718760713911feaf4675c24f94e50530a015ec646cfb622f7c"
 dependencies = [
- "skrifa",
+ "skrifa 0.42.1",
  "yazi",
  "zeno",
 ]
@@ -6033,7 +6098,7 @@ dependencies = [
  "log",
  "peniko",
  "png",
- "skrifa",
+ "skrifa 0.42.1",
  "static_assertions",
  "thiserror 2.0.18",
  "vello_encoding",
@@ -6050,7 +6115,7 @@ dependencies = [
  "bytemuck",
  "guillotiere 0.7.0",
  "peniko",
- "skrifa",
+ "skrifa 0.42.1",
  "smallvec",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4887,9 +4887,9 @@ checksum = "19b30a45b0cd0bcca8037f3d0dc3421eaf95327a17cad11964fb8179b4fc4832"
 
 [[package]]
 name = "rio-grapheme-width"
-version = "0.5.19"
+version = "0.5.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8748a230342b653830718978aa78fc7e4887bcf2d1292228ea1e033dd0207151"
+checksum = "7d2ab35243df24e70e8d914655c94ad0088b47c4b17dc336c06dbfe42a1981dd"
 dependencies = [
  "phf 0.13.1",
  "ucd-trie",
@@ -4897,22 +4897,29 @@ dependencies = [
 
 [[package]]
 name = "rio-graphics"
-version = "0.5.19"
+version = "0.5.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "150067cf37f1468cffffae9cbfd40e106adc5f8451239b5b0a7fa660b6a5a91c"
+checksum = "762096f1b6b89a381bfff10243141bb77c2e950636699122dbb06045e9cccd22"
 dependencies = [
  "image",
  "parking_lot",
  "rustc-hash 2.1.3",
  "skrifa 0.37.0",
  "tracing",
+ "web-time",
 ]
 
 [[package]]
-name = "rio-vt"
-version = "0.5.19"
+name = "rio-unicode"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82bb771ed37480c3bec80684513a5d136a7cd5a32a86c0bf13a6d7cb0239b600"
+checksum = "0fd27f13eb08b6f41bb344e0c09052c25dd10f506e860e641c6bc292517f1fe6"
+
+[[package]]
+name = "rio-vt"
+version = "0.5.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e009948a9828a6149640e18adbdd9ca5c78d9e4b02843dd41a54d8eeb4c7635"
 dependencies = [
  "base64 0.23.0",
  "bitflags 2.13.0",
@@ -4926,12 +4933,13 @@ dependencies = [
  "regex-automata",
  "rio-grapheme-width",
  "rio-graphics",
+ "rio-unicode",
  "rustc-hash 2.1.3",
  "serde",
  "simdutf",
  "smallvec",
  "tracing",
- "unicode-width-16",
+ "web-time",
  "windows-sys 0.61.2",
 ]
 
@@ -6032,12 +6040,6 @@ name = "unicode-width"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
-
-[[package]]
-name = "unicode-width-16"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9eba15036aa0f5bf8ed6cd12a624ddb61fd50b0779b1c05d89b663bcaed7b5c2"
 
 [[package]]
 name = "unicode-xid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,8 +45,8 @@ image = { version = "0.25", default-features = false, features = ["png", "ico"] 
 parley_ratatui = "0.3.4"
 portable-pty = "0.8"
 ratatui = "0.30"
-rio-graphics = { version = "0.5.19", default-features = false }
-rio-vt = { version = "0.5.19", default-features = false, features = ["graphics"] }
+rio-graphics = { version = "0.5.20", default-features = false }
+rio-vt = { version = "0.5.20", default-features = false, features = ["graphics"] }
 rust-embed = "8.5"
 serde = { version = "1.0", features = ["derive"] }
 shellexpand = "3.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,8 @@ image = { version = "0.25", default-features = false, features = ["png", "ico"] 
 parley_ratatui = "0.3.4"
 portable-pty = "0.8"
 ratatui = "0.30"
-rio-vt = { version = "0.5.19", default-features = false }
+rio-graphics = { version = "0.5.19", default-features = false }
+rio-vt = { version = "0.5.19", default-features = false, features = ["graphics"] }
 rust-embed = "8.5"
 serde = { version = "1.0", features = ["derive"] }
 shellexpand = "3.1"

--- a/src/inline.rs
+++ b/src/inline.rs
@@ -11,14 +11,18 @@ use crate::model::{
     ObjectLoadOptions, load_object_source_from_bytes_with_options, load_object_source_with_options,
 };
 use crate::rgp::{
-    RgpOperation, RgpPlacementStyle, RgpPlacementUpdate, RgpRegisterSource,
+    RGP_APC_START, RgpOperation, RgpPlacementStyle, RgpPlacementUpdate, RgpRegisterSource,
     consume_sequence as consume_rgp_sequence, support_reply,
 };
 use crate::runtime::TerminalRuntime;
 
-const APC_START: &[u8] = b"\x1b_";
 const ST: &[u8] = b"\x1b\\";
 const C1_ST: u8 = 0x9c;
+
+/// Longest unterminated RGP sequence held back from the engine. Past this,
+/// the bytes are almost certainly not a real RGP message (chunked payloads
+/// stay far smaller), so they flow through rather than freezing the screen.
+const RGP_MAX_PENDING: usize = 8 * 1024 * 1024;
 
 /// Marker for 2D inline object sprites.
 #[derive(Component)]
@@ -86,7 +90,16 @@ pub struct TerminalInlineObjects {
 }
 
 impl TerminalInlineObjects {
-    /// Consumes PTY output and extracts inline object control sequences.
+    /// Consumes PTY output, extracting RGP control sequences and streaming
+    /// everything else — kitty graphics APCs included — straight through to
+    /// the engine, which parses APC statefully itself.
+    ///
+    /// Only bytes that could still become an RGP sequence are withheld: a
+    /// partial `ESC _ratty;g;` prefix at the tail of a chunk, or a matched
+    /// prefix whose terminator has not arrived yet (capped, so a runaway
+    /// stream cannot freeze the display). Everything else flows to the
+    /// engine immediately, so a multi-megabyte kitty transfer is never
+    /// buffered or rescanned here.
     pub fn consume_pty_output(
         &mut self,
         chunk: &[u8],
@@ -99,44 +112,53 @@ impl TerminalInlineObjects {
 
         let mut cursor = 0;
         loop {
-            let Some(start_offset) = self.pending_bytes[cursor..]
-                .windows(APC_START.len())
-                .position(|window| window == APC_START)
-            else {
-                let pending_len = self.pending_bytes.len();
-                let keep_from = pending_apc_prefix_start(&self.pending_bytes, cursor);
-                if cursor < keep_from {
-                    *terminal_output = true;
-                    runtime.process(&self.pending_bytes[cursor..keep_from]);
-                }
-                if keep_from < pending_len {
-                    self.pending_bytes.drain(..keep_from);
-                } else {
+            match next_rgp_candidate(&self.pending_bytes, cursor) {
+                RgpScan::None => {
+                    if cursor < self.pending_bytes.len() {
+                        *terminal_output = true;
+                        runtime.process(&self.pending_bytes[cursor..]);
+                    }
                     self.pending_bytes.clear();
+                    return replies;
                 }
-                return replies;
-            };
-            let start = cursor + start_offset;
-            if cursor < start {
-                *terminal_output = true;
-                runtime.process(&self.pending_bytes[cursor..start]);
+                RgpScan::Partial(start) => {
+                    if cursor < start {
+                        *terminal_output = true;
+                        runtime.process(&self.pending_bytes[cursor..start]);
+                    }
+                    self.pending_bytes.drain(..start);
+                    return replies;
+                }
+                RgpScan::Complete(start) => {
+                    if cursor < start {
+                        *terminal_output = true;
+                        runtime.process(&self.pending_bytes[cursor..start]);
+                    }
+                    let Some(end) = apc_end(&self.pending_bytes, start + RGP_APC_START.len())
+                    else {
+                        if self.pending_bytes.len() - start > RGP_MAX_PENDING {
+                            // Runaway unterminated sequence: stop withholding
+                            // and let the engine's APC parser deal with it.
+                            *terminal_output = true;
+                            runtime.process(&self.pending_bytes[start..]);
+                            self.pending_bytes.clear();
+                            return replies;
+                        }
+                        self.pending_bytes.drain(..start);
+                        return replies;
+                    };
+                    let sequence = self.pending_bytes[start..end].to_vec();
+                    let (handled, reply) = self.handle_rgp_apc(&sequence, camera_updates);
+                    if let Some(reply) = reply {
+                        replies.push(reply);
+                    }
+                    if !handled {
+                        *terminal_output = true;
+                        runtime.process(&sequence);
+                    }
+                    cursor = end;
+                }
             }
-
-            let payload_start = start + APC_START.len();
-            let Some(end) = apc_end(&self.pending_bytes, payload_start) else {
-                self.pending_bytes.drain(..start);
-                return replies;
-            };
-            let sequence = self.pending_bytes[start..end].to_vec();
-            let (handled, reply) = self.handle_apc_sequence(&sequence, camera_updates);
-            if let Some(reply) = reply {
-                replies.push(reply);
-            }
-            if !handled {
-                *terminal_output = true;
-                runtime.process(&sequence);
-            }
-            cursor = end;
         }
     }
 
@@ -180,12 +202,13 @@ impl TerminalInlineObjects {
 
     /// Synchronizes kitty graphics with the engine's state.
     ///
-    /// Drains the pixel data rio-vt queued for GPU upload and re-derives
-    /// the visible placements. Cheap when nothing changed, so it runs every
-    /// frame — placements move with scrollback without any PTY traffic.
-    pub fn refresh_kitty(&mut self, runtime: &mut TerminalRuntime) {
-        let updates = runtime.take_graphics_updates();
-        if self.kitty.refresh(&runtime.term, updates) {
+    /// Re-derives the visible placements and keeps textures aligned with
+    /// the engine's image store. Runs every frame — placements move with
+    /// scrollback without any PTY traffic — but the refresh gates itself
+    /// on the engine's dirty flag, `terminal_changed`, and the scroll
+    /// state, so quiet frames cost a few comparisons.
+    pub fn refresh_kitty(&mut self, runtime: &mut TerminalRuntime, terminal_changed: bool) {
+        if self.kitty.refresh(&mut runtime.term, terminal_changed) {
             self.dirty = true;
         }
     }
@@ -209,13 +232,15 @@ impl TerminalInlineObjects {
         self.dirty = true;
     }
 
-    fn handle_apc_sequence(
+    fn handle_rgp_apc(
         &mut self,
         sequence: &[u8],
         camera_updates: &mut Vec<TerminalCameraUpdate>,
     ) -> (bool, Option<Vec<u8>>) {
         // Only RGP is ratty's to parse. Kitty graphics APCs flow through to
-        // rio-vt, which owns that protocol end to end.
+        // rio-vt, which owns that protocol end to end. A sequence that
+        // matched the RGP prefix but fails to parse also flows through, so
+        // no bytes are ever swallowed silently.
         if let Some(reply) = self.handle_rgp_sequence(sequence, camera_updates) {
             return (true, reply);
         }
@@ -407,13 +432,34 @@ struct PendingRgpPayload {
     options: ObjectLoadOptions,
 }
 
-fn pending_apc_prefix_start(bytes: &[u8], cursor: usize) -> usize {
-    let start = cursor.min(bytes.len());
-    if bytes[start..].ends_with(&APC_START[..1]) {
-        bytes.len() - 1
-    } else {
-        bytes.len()
+/// Where the next possible RGP sequence starts, relative to `bytes`.
+enum RgpScan {
+    /// No RGP prefix anywhere after `from` — everything can flow through.
+    None,
+    /// The buffer ends mid-prefix; bytes from here must wait for more input.
+    Partial(usize),
+    /// A full `ESC _ratty;g;` prefix starts here.
+    Complete(usize),
+}
+
+/// Scans for the next byte position that matches the RGP APC prefix as far
+/// as the buffer reaches. APC payloads cannot contain `ESC` (it terminates
+/// them), so a match inside another sequence's payload is impossible.
+fn next_rgp_candidate(bytes: &[u8], from: usize) -> RgpScan {
+    let mut index = from;
+    while let Some(offset) = bytes[index..].iter().position(|byte| *byte == 0x1b) {
+        let start = index + offset;
+        let available = bytes.len() - start;
+        let compare = available.min(RGP_APC_START.len());
+        if bytes[start..start + compare] == RGP_APC_START[..compare] {
+            if compare < RGP_APC_START.len() {
+                return RgpScan::Partial(start);
+            }
+            return RgpScan::Complete(start);
+        }
+        index = start + 1;
     }
+    RgpScan::None
 }
 
 fn apc_end(bytes: &[u8], payload_start: usize) -> Option<usize> {

--- a/src/inline.rs
+++ b/src/inline.rs
@@ -6,7 +6,7 @@ use std::path::Path;
 use bevy::prelude::*;
 
 use crate::camera::{OptionalVec3, TerminalCameraUpdate};
-use crate::kitty::{KittyOperation, KittyParserState, refresh_kitty_placeholder_anchors};
+use crate::kitty::{KittyGraphics, PlacementKey};
 use crate::model::{
     ObjectLoadOptions, load_object_source_from_bytes_with_options, load_object_source_with_options,
 };
@@ -15,7 +15,6 @@ use crate::rgp::{
     consume_sequence as consume_rgp_sequence, support_reply,
 };
 use crate::runtime::TerminalRuntime;
-use crate::vt::{self, VtTerminal};
 
 const APC_START: &[u8] = b"\x1b_";
 const ST: &[u8] = b"\x1b\\";
@@ -44,6 +43,8 @@ pub(crate) struct InlineKittyPlaneLayout {
     pub x_segments: u32,
     /// Vertical mesh subdivision count.
     pub y_segments: u32,
+    /// Normalized source crop mapped onto the mesh UVs.
+    pub source_rect: [f32; 4],
 }
 
 /// Cached GPU assets for a Kitty image plane attached to the terminal surface.
@@ -52,6 +53,8 @@ pub(crate) struct KittyPlaneCache {
     pub x_segments: u32,
     /// Cached vertical mesh subdivision count.
     pub y_segments: u32,
+    /// Cached normalized source crop baked into the mesh UVs.
+    pub source_rect: [f32; 4],
     /// Cached plane mesh handle.
     pub mesh: Handle<Mesh>,
     /// Cached plane material handle.
@@ -70,13 +73,16 @@ pub struct TerminalRgpObject {
 pub struct TerminalInlineObjects {
     pending_bytes: Vec<u8>,
     pending_rgp_payloads: HashMap<u32, PendingRgpPayload>,
-    kitty: KittyParserState,
     dirty: bool,
     last_viewport_size: Vec2,
     last_cols: u16,
     last_rows: u16,
-    pub(crate) objects: HashMap<u32, InlineObject>,
+    pub(crate) objects: HashMap<u32, RgpInlineObject>,
     pub(crate) anchors: HashMap<u32, InlineAnchor>,
+    /// Kitty graphics derived from rio-vt's engine state.
+    pub(crate) kitty: KittyGraphics,
+    /// Cached plane assets per kitty placement (3D presentation).
+    pub(crate) kitty_planes: HashMap<PlacementKey, KittyPlaneCache>,
 }
 
 impl TerminalInlineObjects {
@@ -122,11 +128,7 @@ impl TerminalInlineObjects {
                 return replies;
             };
             let sequence = self.pending_bytes[start..end].to_vec();
-            let (handled, reply) = self.handle_apc_sequence(
-                &sequence,
-                vt::cursor_position(&runtime.term),
-                camera_updates,
-            );
+            let (handled, reply) = self.handle_apc_sequence(&sequence, camera_updates);
             if let Some(reply) = reply {
                 replies.push(reply);
             }
@@ -160,14 +162,7 @@ impl TerminalInlineObjects {
             return;
         }
 
-        self.anchors.retain(|object_id, anchor| {
-            if self
-                .objects
-                .get(object_id)
-                .is_some_and(|object| !object.scrolls_with_text())
-            {
-                return true;
-            }
+        self.anchors.retain(|_, anchor| {
             let new_row = anchor.row as i32 - rows_scrolled as i32;
             if new_row + anchor.rows as i32 <= 0 {
                 return false;
@@ -180,16 +175,17 @@ impl TerminalInlineObjects {
 
     /// Returns whether any anchors need scroll tracking.
     pub fn has_scroll_tracked_anchors(&self) -> bool {
-        self.anchors.keys().any(|object_id| {
-            self.objects
-                .get(object_id)
-                .is_some_and(InlineObject::scrolls_with_text)
-        })
+        !self.anchors.is_empty()
     }
 
-    /// Refreshes placeholder-derived Kitty anchors.
-    pub fn refresh_placeholder_anchors(&mut self, term: &VtTerminal) {
-        if refresh_kitty_placeholder_anchors(&self.objects, &mut self.anchors, term) {
+    /// Synchronizes kitty graphics with the engine's state.
+    ///
+    /// Drains the pixel data rio-vt queued for GPU upload and re-derives
+    /// the visible placements. Cheap when nothing changed, so it runs every
+    /// frame — placements move with scrollback without any PTY traffic.
+    pub fn refresh_kitty(&mut self, runtime: &mut TerminalRuntime) {
+        let updates = runtime.take_graphics_updates();
+        if self.kitty.refresh(&runtime.term, updates) {
             self.dirty = true;
         }
     }
@@ -216,75 +212,14 @@ impl TerminalInlineObjects {
     fn handle_apc_sequence(
         &mut self,
         sequence: &[u8],
-        cursor_position: (u16, u16),
         camera_updates: &mut Vec<TerminalCameraUpdate>,
     ) -> (bool, Option<Vec<u8>>) {
+        // Only RGP is ratty's to parse. Kitty graphics APCs flow through to
+        // rio-vt, which owns that protocol end to end.
         if let Some(reply) = self.handle_rgp_sequence(sequence, camera_updates) {
             return (true, reply);
         }
-
-        let Some(operation) = self.kitty.consume_sequence(sequence, cursor_position) else {
-            return (false, None);
-        };
-
-        match operation {
-            KittyOperation::Pending | KittyOperation::Ignored => (true, None),
-            KittyOperation::TransmitOnly { object_id, image } => {
-                self.objects
-                    .insert(object_id, InlineObject::KittyImage(image.rasterize()));
-                self.dirty = true;
-                (true, None)
-            }
-            KittyOperation::TransmitAndPlace {
-                object_id,
-                image,
-                anchor,
-            } => {
-                self.remove_objects_at(&InlineAnchor {
-                    row: anchor.row,
-                    col: anchor.col,
-                    columns: anchor.columns,
-                    rows: anchor.rows,
-                    style: InlineStyle::default(),
-                });
-                self.objects
-                    .insert(object_id, InlineObject::KittyImage(image.rasterize()));
-                self.set_anchor(
-                    object_id,
-                    InlineAnchor {
-                        row: anchor.row,
-                        col: anchor.col,
-                        columns: anchor.columns,
-                        rows: anchor.rows,
-                        style: InlineStyle::default(),
-                    },
-                );
-                (true, None)
-            }
-            KittyOperation::PlaceExisting { object_id, anchor } => {
-                if self.objects.contains_key(&object_id) {
-                    self.set_anchor(
-                        object_id,
-                        InlineAnchor {
-                            row: anchor.row,
-                            col: anchor.col,
-                            columns: anchor.columns,
-                            rows: anchor.rows,
-                            style: InlineStyle::default(),
-                        },
-                    );
-                }
-                (true, None)
-            }
-            KittyOperation::Delete { object_id } => {
-                if let Some(object_id) = object_id {
-                    self.remove_object(object_id);
-                } else {
-                    self.clear_objects();
-                }
-                (true, None)
-            }
-        }
+        (false, None)
     }
 
     fn handle_rgp_sequence(
@@ -397,35 +332,6 @@ impl TerminalInlineObjects {
         })
     }
 
-    fn remove_objects_at(&mut self, new_anchor: &InlineAnchor) {
-        let row_start = new_anchor.row as i32;
-        let row_end = row_start + new_anchor.rows as i32;
-        let col_start = new_anchor.col as i32;
-        let col_end = col_start + new_anchor.columns as i32;
-
-        let overlapping_ids = self
-            .anchors
-            .iter()
-            .filter_map(|(object_id, anchor)| {
-                let anchor_row_start = anchor.row as i32;
-                let anchor_row_end = anchor_row_start + anchor.rows as i32;
-                let anchor_col_start = anchor.col as i32;
-                let anchor_col_end = anchor_col_start + anchor.columns as i32;
-
-                (anchor_row_start < row_end
-                    && anchor_row_end > row_start
-                    && anchor_col_start < col_end
-                    && anchor_col_end > col_start)
-                    .then_some(*object_id)
-            })
-            .collect::<Vec<_>>();
-
-        for object_id in overlapping_ids {
-            self.objects.remove(&object_id);
-            self.anchors.remove(&object_id);
-        }
-    }
-
     // Buffers chunked payload registrations until the final chunk arrives, then loads and registers the object.
     fn handle_rgp_payload_chunk(
         &mut self,
@@ -526,14 +432,6 @@ fn apc_end(bytes: &[u8], payload_start: usize) -> Option<usize> {
     }
 }
 
-/// Registered inline object.
-pub enum InlineObject {
-    /// Kitty image object.
-    KittyImage(KittyInlineObject),
-    /// Ratty graphics object.
-    RgpObject(RgpInlineObject),
-}
-
 /// Raster image payload.
 pub struct RasterObject {
     /// Image width in pixels.
@@ -544,16 +442,6 @@ pub struct RasterObject {
     pub rgba: Vec<u8>,
     /// Uploaded image handle.
     pub handle: Option<Handle<Image>>,
-}
-
-/// Kitty-backed inline object.
-pub struct KittyInlineObject {
-    /// Raster image payload.
-    pub raster: RasterObject,
-    /// Indicates placeholder-driven placement.
-    pub uses_placeholders: bool,
-    /// Cached plane mesh and material for 3D presentation.
-    pub(crate) plane: Option<KittyPlaneCache>,
 }
 
 /// RGP-backed inline object.
@@ -579,15 +467,6 @@ pub enum RgpInlineObject {
         /// Cached scene handle.
         handle: Option<Handle<WorldAsset>>,
     },
-}
-
-impl InlineObject {
-    fn scrolls_with_text(&self) -> bool {
-        match self {
-            InlineObject::KittyImage(object) => !object.uses_placeholders,
-            InlineObject::RgpObject(_) => true,
-        }
-    }
 }
 
 /// Inline object anchor.

--- a/src/keyboard.rs
+++ b/src/keyboard.rs
@@ -564,11 +564,14 @@ pub fn handle_keyboard_input(
                             render_scale_for_window(window),
                         );
                         let pty_pixels = layout.pty_pixels();
+                        let cell_px = params.terminal.char_dimensions() * layout.render_scale;
                         params.runtime.resize(
                             layout.cols,
                             layout.rows,
                             pty_pixels.x as u16,
                             pty_pixels.y as u16,
+                            cell_px.x,
+                            cell_px.y,
                         );
                         sync_terminal_layout(
                             layout,

--- a/src/kitty.rs
+++ b/src/kitty.rs
@@ -795,6 +795,22 @@ mod tests {
         );
     }
 
+    /// rio-vt 0.5.20: placing an image the engine does not hold answers
+    /// ENOENT instead of OK, so clients retransmit evicted images.
+    #[test]
+    fn placements_of_unknown_images_reply_enoent() {
+        let mut harness = Harness::new(5, 20);
+        harness.feed(b"\x1b_Ga=p,i=404\x1b\\");
+
+        let replies = harness.reply_text();
+        assert!(
+            replies.contains("ENOENT") && !replies.contains(";OK"),
+            "expected an ENOENT reply, got {replies:?}"
+        );
+        harness.refresh();
+        assert!(harness.kitty.placements().is_empty());
+    }
+
     #[test]
     fn queries_answer_without_placing() {
         let mut harness = Harness::new(5, 20);

--- a/src/kitty.rs
+++ b/src/kitty.rs
@@ -378,3 +378,254 @@ fn virtual_placement_views(term: &VtTerminal) -> Vec<KittyPlacementView> {
         })
         .collect()
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use base64::Engine as _;
+    use rio_vt::ansi::CursorShape;
+    use rio_vt::crosswords::{Crosswords, CrosswordsSize};
+    use rio_vt::event::WindowId;
+    use rio_vt::performer::handler::Processor;
+
+    use crate::vt::TerminalEventSink;
+
+    const CELL_WIDTH: u32 = 10;
+    const CELL_HEIGHT: u32 = 20;
+
+    struct Harness {
+        term: VtTerminal,
+        processor: Processor,
+        sink: TerminalEventSink,
+        kitty: KittyGraphics,
+    }
+
+    impl Harness {
+        fn new(rows: u16, cols: u16) -> Self {
+            let sink = TerminalEventSink::default();
+            let term = Crosswords::new(
+                CrosswordsSize::new_with_dimensions(
+                    usize::from(cols),
+                    usize::from(rows),
+                    u32::from(cols) * CELL_WIDTH,
+                    u32::from(rows) * CELL_HEIGHT,
+                    CELL_WIDTH,
+                    CELL_HEIGHT,
+                ),
+                CursorShape::Block,
+                sink.clone(),
+                WindowId::from(0),
+                0,
+                1000,
+            );
+            Self {
+                term,
+                processor: Processor::default(),
+                sink,
+                kitty: KittyGraphics::default(),
+            }
+        }
+
+        fn feed(&mut self, bytes: &[u8]) {
+            self.processor.advance(&mut self.term, bytes);
+        }
+
+        fn refresh(&mut self) -> bool {
+            let updates = self.sink.take_graphics_updates();
+            self.kitty.refresh(&self.term, updates)
+        }
+
+        /// Transmits and places an opaque RGBA image at the cursor.
+        fn transmit_and_place(&mut self, image_id: u32, width: u32, height: u32, extra: &str) {
+            let pixels = vec![255_u8; (width * height * 4) as usize];
+            let payload = base64::engine::general_purpose::STANDARD.encode(&pixels);
+            self.feed(
+                format!("\x1b_Ga=T,f=32,s={width},v={height},i={image_id}{extra};{payload}\x1b\\")
+                    .as_bytes(),
+            );
+        }
+
+        fn reply_text(&mut self) -> String {
+            self.sink
+                .take_replies()
+                .into_iter()
+                .map(|reply| String::from_utf8_lossy(&reply).into_owned())
+                .collect()
+        }
+    }
+
+    #[test]
+    fn transmit_and_place_lands_at_the_cursor() {
+        let mut harness = Harness::new(5, 20);
+        harness.feed(b"\x1b[2;3H");
+        harness.transmit_and_place(7, 2 * CELL_WIDTH, 2 * CELL_HEIGHT, "");
+
+        assert!(harness.refresh(), "a new placement must report a change");
+        let views = harness.kitty.placements();
+        assert_eq!(views.len(), 1);
+        let view = &views[0];
+        assert_eq!(view.image_id, 7);
+        assert_eq!((view.row, view.col), (1.0, 2.0));
+        assert_eq!((view.columns, view.rows), (2.0, 2.0));
+        assert_eq!(view.source_rect, [0.0, 0.0, 1.0, 1.0]);
+
+        let image = harness.kitty.image_mut(7).expect("decoded image");
+        assert_eq!(image.raster.width, 2 * CELL_WIDTH);
+        assert_eq!(image.raster.height, 2 * CELL_HEIGHT);
+        assert_eq!(
+            image.raster.rgba.len(),
+            (2 * CELL_WIDTH * 2 * CELL_HEIGHT * 4) as usize
+        );
+
+        assert!(
+            harness.reply_text().contains("\x1b_Gi=7;OK\x1b\\"),
+            "the engine must acknowledge the transfer"
+        );
+
+        assert!(!harness.refresh(), "an unchanged frame must not re-sync");
+    }
+
+    #[test]
+    fn rgb_payloads_expand_to_rgba() {
+        let mut harness = Harness::new(5, 20);
+        let payload = base64::engine::general_purpose::STANDARD.encode([9_u8, 8, 7]);
+        harness.feed(format!("\x1b_Ga=T,f=24,s=1,v=1,i=3;{payload}\x1b\\").as_bytes());
+
+        harness.refresh();
+        let image = harness.kitty.image_mut(3).expect("decoded image");
+        assert_eq!(image.raster.rgba, vec![9, 8, 7, 255]);
+    }
+
+    #[test]
+    fn chunked_png_transfers_decode_once_complete() {
+        let mut harness = Harness::new(5, 20);
+        let png = {
+            let image = image::RgbaImage::from_pixel(4, 4, image::Rgba([1, 2, 3, 255]));
+            let mut bytes = Vec::new();
+            image::DynamicImage::ImageRgba8(image)
+                .write_to(
+                    &mut std::io::Cursor::new(&mut bytes),
+                    image::ImageFormat::Png,
+                )
+                .expect("png encode");
+            bytes
+        };
+        let payload = base64::engine::general_purpose::STANDARD.encode(&png);
+        // Chunk boundaries must fall on base64 quantum edges, as kitten
+        // icat's 4096-byte chunks do.
+        let (first, second) = payload.split_at((payload.len() / 2) & !3);
+
+        harness.feed(format!("\x1b_Ga=T,f=100,i=9,m=1;{first}\x1b\\").as_bytes());
+        harness.refresh();
+        assert!(
+            harness.kitty.placements().is_empty(),
+            "an incomplete transfer must not place anything"
+        );
+
+        harness.feed(format!("\x1b_Gm=0;{second}\x1b\\").as_bytes());
+        harness.refresh();
+        assert_eq!(harness.kitty.placements().len(), 1);
+        let image = harness.kitty.image_mut(9).expect("decoded image");
+        assert_eq!((image.raster.width, image.raster.height), (4, 4));
+        assert_eq!(&image.raster.rgba[..4], &[1, 2, 3, 255]);
+    }
+
+    #[test]
+    fn placements_scroll_with_content_and_history() {
+        let mut harness = Harness::new(3, 20);
+        harness.transmit_and_place(5, CELL_WIDTH, 2 * CELL_HEIGHT, "");
+        harness.refresh();
+        assert_eq!(harness.kitty.placements()[0].row, 0.0);
+
+        // Scroll the content up one row: the placement follows the text.
+        harness.feed(b"\x1b[3;1H\r\n");
+        harness.refresh();
+        assert_eq!(harness.kitty.placements()[0].row, -1.0);
+
+        // And another: fully above the viewport, so nothing to draw.
+        harness.feed(b"\r\n");
+        harness.refresh();
+        assert!(harness.kitty.placements().is_empty());
+
+        // Scrolling back into history brings it back.
+        vt::set_scrollback(&mut harness.term, 2);
+        harness.refresh();
+        assert_eq!(harness.kitty.placements()[0].row, 0.0);
+    }
+
+    #[test]
+    fn delete_all_drops_placements_and_image_data() {
+        let mut harness = Harness::new(5, 20);
+        harness.transmit_and_place(4, CELL_WIDTH, CELL_HEIGHT, "");
+        harness.refresh();
+        assert_eq!(harness.kitty.placements().len(), 1);
+
+        harness.feed(b"\x1b_Ga=d,d=A\x1b\\");
+        assert!(harness.refresh());
+        assert!(harness.kitty.placements().is_empty());
+        assert!(
+            harness.kitty.image_mut(4).is_none(),
+            "deleted image data must not keep a texture alive"
+        );
+    }
+
+    #[test]
+    fn source_crops_resolve_to_normalized_rects() {
+        let mut harness = Harness::new(5, 20);
+        // Show only the right half of a 2-cell-wide image.
+        harness.transmit_and_place(
+            11,
+            2 * CELL_WIDTH,
+            CELL_HEIGHT,
+            &format!(",x={CELL_WIDTH},w={CELL_WIDTH}"),
+        );
+
+        harness.refresh();
+        let view = &harness.kitty.placements()[0];
+        assert_eq!(view.source_rect, [0.5, 0.0, 1.0, 1.0]);
+        assert_eq!(view.columns, 1.0);
+    }
+
+    #[test]
+    fn virtual_placements_follow_their_placeholder_cells() {
+        let mut harness = Harness::new(5, 20);
+        harness.transmit_and_place(42, 2 * CELL_WIDTH, CELL_HEIGHT, ",U=1,c=2,r=1");
+        harness.refresh();
+        assert!(
+            harness.kitty.placements().is_empty(),
+            "a virtual placement must not draw before placeholders exist"
+        );
+
+        // The application prints the placeholder cells itself, image id in
+        // the foreground color and row/column in combining diacritics.
+        let encode = rio_vt::ansi::kitty_virtual::encode_placeholder;
+        harness.feed(b"\x1b[3;4H\x1b[38;2;0;0;42m");
+        harness.feed(encode(0, 0, None).as_bytes());
+        harness.feed(encode(0, 1, None).as_bytes());
+        harness.feed(b"\x1b[m");
+
+        assert!(harness.refresh());
+        let views = harness.kitty.placements();
+        assert_eq!(views.len(), 1);
+        let view = &views[0];
+        assert_eq!(view.image_id, 42);
+        assert_eq!((view.row, view.col), (2.0, 3.0));
+        assert_eq!((view.columns, view.rows), (2.0, 1.0));
+    }
+
+    #[test]
+    fn queries_answer_without_placing() {
+        let mut harness = Harness::new(5, 20);
+        let payload = base64::engine::general_purpose::STANDARD.encode([0_u8, 0, 0, 0]);
+        harness.feed(format!("\x1b_Ga=q,f=32,s=1,v=1,i=6;{payload}\x1b\\").as_bytes());
+
+        let replies = harness.reply_text();
+        assert!(
+            replies.contains("\x1b_Gi=6;OK\x1b\\"),
+            "queries must be acknowledged, got {replies:?}"
+        );
+        harness.refresh();
+        assert!(harness.kitty.placements().is_empty());
+    }
+}

--- a/src/kitty.rs
+++ b/src/kitty.rs
@@ -1,302 +1,307 @@
-//! Kitty graphics protocol parsing.
+//! Kitty graphics rendering state.
+//!
+//! rio-vt owns the kitty graphics *protocol*: it parses the APC stream,
+//! decodes PNG, RGB, and RGBA payloads (chunked or not), stores images and
+//! placements per screen, answers queries, applies deletes, and evicts
+//! images over the spec's memory budget. This module owns what is ratty's
+//! to draw: it drains the pixel data the engine queues for upload and turns
+//! the engine's placement state into the flat list of textured quads the
+//! Bevy scene renders each frame.
+//!
+//! Two placement kinds reach the screen:
+//!
+//! - *Direct* placements (`a=T`/`a=p`) live in the engine as absolute,
+//!   scrollback-aware grid positions. Their on-screen position is derived
+//!   per refresh from the terminal's history and display offset, so they
+//!   stay glued to the text they were placed next to — including while the
+//!   user scrolls into history.
+//! - *Virtual* placements (`U=1`, what `kitten icat --unicode-placeholder`
+//!   emits) are anchored by U+10EEEE placeholder cells the application
+//!   prints itself. The visible cells are scanned and the image is fitted
+//!   to their bounding box, so the image moves, clips, and disappears with
+//!   the text that carries it.
 
 use std::collections::HashMap;
 
-use base64::Engine as _;
+use rio_graphics::{ColorType, GraphicData};
+use rio_vt::ansi::graphics::{kitty_display_size, resolve_source_rect};
+use rio_vt::ansi::kitty_virtual::PLACEHOLDER;
 use rio_vt::crosswords::pos::Column;
 
-use crate::inline::{InlineAnchor, InlineObject, InlineStyle, KittyInlineObject, RasterObject};
+use crate::inline::RasterObject;
 use crate::vt::{self, CellColor, VtTerminal};
 
-/// Kitty graphics APC prefix.
-pub const KITTY_APC_START: &[u8] = b"\x1b_G";
-const ST: &[u8] = b"\x1b\\";
-const C1_ST: u8 = 0x9c;
+/// A kitty placement key: `(image_id, placement_id)`.
+pub type PlacementKey = (u32, u32);
 
-/// Parser state for Kitty graphics sequences.
+/// Kitty images and the placements to draw, derived from engine state.
 #[derive(Default)]
-pub struct KittyParserState {
-    transfer: Option<KittyTransfer>,
-    next_object_id: u32,
+pub struct KittyGraphics {
+    /// Decoded images by kitty image id. Pixels are held until the render
+    /// sync uploads them, then only the texture handle remains.
+    images: HashMap<u32, KittyImage>,
+    /// Placements to draw, sorted back-to-front.
+    placements: Vec<KittyPlacementView>,
 }
 
-impl KittyParserState {
-    /// Consumes a Kitty graphics APC sequence.
-    pub fn consume_sequence(
+/// A decoded kitty image and its GPU upload state.
+pub struct KittyImage {
+    /// Pixel payload and texture handle.
+    pub raster: RasterObject,
+    /// Engine transmission timestamp, used to skip redundant re-uploads
+    /// when the engine re-queues the same pixels for another placement.
+    transmit_time: std::time::Instant,
+}
+
+/// One kitty placement resolved to visible-grid coordinates.
+///
+/// Spans are fractional cells: a placement shown at native pixel size
+/// rarely lands on a cell boundary, and rounding it up would stretch the
+/// image. `row` is signed so a placement partially scrolled off the top
+/// keeps its true origin instead of clamping to the first row.
+#[derive(Clone, Debug, PartialEq)]
+pub struct KittyPlacementView {
+    /// Kitty image id (`i=`).
+    pub image_id: u32,
+    /// Kitty placement id (`p=`, or engine-allocated).
+    pub placement_id: u32,
+    /// Top-left corner in visible-grid cells.
+    pub row: f32,
+    /// Top-left corner in visible-grid cells.
+    pub col: f32,
+    /// Width in cells.
+    pub columns: f32,
+    /// Height in cells.
+    pub rows: f32,
+    /// Normalized source crop within the image, `[u0, v0, u1, v1]`.
+    pub source_rect: [f32; 4],
+    /// Kitty z-index, used for draw order among images.
+    pub z: i32,
+}
+
+impl KittyGraphics {
+    /// Returns the placements to draw, sorted back-to-front.
+    pub fn placements(&self) -> &[KittyPlacementView] {
+        &self.placements
+    }
+
+    /// Returns the image backing a placement.
+    pub fn image_mut(&mut self, image_id: u32) -> Option<&mut KittyImage> {
+        self.images.get_mut(&image_id)
+    }
+
+    /// Synchronizes with the engine: applies queued pixel uploads and
+    /// removals, then rebuilds the placement list from the terminal's
+    /// kitty state. Returns whether anything the renderer draws changed.
+    pub fn refresh(
         &mut self,
-        sequence: &[u8],
-        cursor_position: (u16, u16),
-    ) -> Option<KittyOperation> {
-        if !sequence.starts_with(KITTY_APC_START) {
-            return None;
+        term: &VtTerminal,
+        updates: Vec<rio_vt::ansi::graphics::UpdateQueues>,
+    ) -> bool {
+        let mut changed = false;
+        for queues in updates {
+            changed |= self.apply_queues(queues);
         }
 
-        let content_end = if sequence.ends_with(&[C1_ST]) {
-            sequence.len() - 1
-        } else if sequence.ends_with(ST) {
-            sequence.len() - 2
-        } else {
-            return None;
-        };
-        let content = &sequence[KITTY_APC_START.len()..content_end];
-        let separator = content.iter().position(|byte| *byte == b';')?;
-        let header = std::str::from_utf8(&content[..separator]).ok()?;
-        let payload = &content[separator + 1..];
+        // Deletes clear the engine's image store without queueing texture
+        // removals, so drop whatever the engine no longer holds. Images on
+        // the *inactive* screen stay: the engine does not re-send pixels
+        // when the terminal swaps back from the alternate screen.
+        let graphics = &term.graphics;
+        let before = self.images.len();
+        self.images.retain(|image_id, _| {
+            graphics.get_kitty_image(*image_id).is_some()
+                || graphics
+                    .kitty_inactive_screen
+                    .kitty_images
+                    .contains_key(image_id)
+        });
+        changed |= self.images.len() != before;
 
-        let mut params = HashMap::new();
-        for part in header.split(',').filter(|part| !part.is_empty()) {
-            let Some((key, value)) = part.split_once('=') else {
+        let mut views = direct_placement_views(term);
+        views.extend(virtual_placement_views(term));
+        // Back-to-front by kitty z-index, then by ids so equal layers keep
+        // a deterministic order across refreshes.
+        views.sort_by_key(|view| (view.z, view.image_id, view.placement_id));
+        if views != self.placements {
+            self.placements = views;
+            changed = true;
+        }
+        changed
+    }
+
+    /// Applies one engine update batch: new image pixels in, deleted or
+    /// evicted textures out. Atlas graphics (sixel/iTerm2) are dropped —
+    /// ratty renders kitty placements only and does not advertise sixel.
+    fn apply_queues(&mut self, queues: rio_vt::ansi::graphics::UpdateQueues) -> bool {
+        let mut changed = false;
+
+        for key in queues.remove_queue {
+            // Kitty texture keys are the protocol image id verbatim; atlas
+            // keys live above the u32 range (see rio-graphics).
+            if let Ok(image_id) = u32::try_from(key) {
+                changed |= self.images.remove(&image_id).is_some();
+            }
+        }
+
+        for (image_id, data) in queues.pending_images {
+            // The engine re-queues the stored pixels for every new
+            // placement of an already-transmitted image; only a genuine
+            // retransmission carries a new timestamp.
+            if self
+                .images
+                .get(&image_id)
+                .is_some_and(|image| image.transmit_time == data.transmit_time)
+            {
+                continue;
+            }
+            let transmit_time = data.transmit_time;
+            let Some(raster) = rasterize(data) else {
                 continue;
             };
-            params.insert(key, value);
+            self.images.insert(
+                image_id,
+                KittyImage {
+                    raster,
+                    transmit_time,
+                },
+            );
+            changed = true;
         }
 
-        let action = params.get("a").copied().unwrap_or("T");
-        match action {
-            "T" | "t" => {
-                let starts_new_transfer = self.transfer.is_none()
-                    || params.contains_key("a")
-                    || params.contains_key("f")
-                    || params.contains_key("s")
-                    || params.contains_key("v")
-                    || params.contains_key("i");
-                if starts_new_transfer {
-                    let object_id = params
-                        .get("i")
-                        .and_then(|value| value.parse().ok())
-                        .unwrap_or(self.next_object_id.max(1));
-                    self.next_object_id = self.next_object_id.max(object_id + 1);
-                    self.transfer = Some(KittyTransfer {
-                        action: action.to_owned(),
-                        object_id,
-                        format: params
-                            .get("f")
-                            .and_then(|value| value.parse().ok())
-                            .unwrap_or(100),
-                        width: params.get("s").and_then(|value| value.parse().ok()),
-                        height: params.get("v").and_then(|value| value.parse().ok()),
-                        columns: params.get("c").and_then(|value| value.parse().ok()),
-                        rows: params.get("r").and_then(|value| value.parse().ok()),
-                        uses_placeholders: params.get("U").copied() == Some("1"),
-                        anchor_row: cursor_position.0,
-                        anchor_col: cursor_position.1,
-                        bytes: Vec::new(),
-                    });
-                }
-
-                let transfer = self.transfer.as_mut()?;
-                let chunk = base64::engine::general_purpose::STANDARD
-                    .decode(payload)
-                    .ok()?;
-                transfer.bytes.extend_from_slice(&chunk);
-
-                if params.get("m").copied().unwrap_or("0") == "1" {
-                    return Some(KittyOperation::Pending);
-                }
-
-                let transfer = self.transfer.take()?;
-                let image = transfer.finalize()?;
-                if transfer.action == "T" {
-                    return Some(KittyOperation::TransmitAndPlace {
-                        object_id: transfer.object_id,
-                        image,
-                        anchor: KittyAnchor {
-                            row: transfer.anchor_row,
-                            col: transfer.anchor_col,
-                            columns: transfer.columns.unwrap_or(1),
-                            rows: transfer.rows.unwrap_or(1),
-                        },
-                    });
-                }
-                Some(KittyOperation::TransmitOnly {
-                    object_id: transfer.object_id,
-                    image,
-                })
-            }
-            "p" => Some(KittyOperation::PlaceExisting {
-                object_id: params.get("i")?.parse().ok()?,
-                anchor: KittyAnchor {
-                    row: cursor_position.0,
-                    col: cursor_position.1,
-                    columns: params
-                        .get("c")
-                        .and_then(|value| value.parse().ok())
-                        .unwrap_or(1),
-                    rows: params
-                        .get("r")
-                        .and_then(|value| value.parse().ok())
-                        .unwrap_or(1),
-                },
-            }),
-            "d" => Some(match params.get("i").and_then(|value| value.parse().ok()) {
-                Some(object_id) => KittyOperation::Delete {
-                    object_id: Some(object_id),
-                },
-                None => KittyOperation::Delete { object_id: None },
-            }),
-            _ => Some(KittyOperation::Ignored),
-        }
+        changed
     }
 }
 
-/// Decoded Kitty image payload.
-#[derive(Default)]
-pub struct KittyImage {
-    /// Image width in pixels.
-    pub width: u32,
-    /// Image height in pixels.
-    pub height: u32,
-    /// RGBA image bytes.
-    pub rgba: Vec<u8>,
-    /// Indicates placeholder mode.
-    pub uses_placeholders: bool,
-}
-
-impl KittyImage {
-    /// Converts the decoded image into an inline object.
-    pub fn rasterize(self) -> KittyInlineObject {
-        KittyInlineObject {
-            raster: RasterObject {
-                width: self.width,
-                height: self.height,
-                rgba: self.rgba,
-                handle: None,
-            },
-            uses_placeholders: self.uses_placeholders,
-            plane: None,
+/// Converts engine pixel data into ratty's RGBA raster form.
+fn rasterize(data: GraphicData) -> Option<RasterObject> {
+    let width = u32::try_from(data.width).ok()?;
+    let height = u32::try_from(data.height).ok()?;
+    let pixel_count = data.width.checked_mul(data.height)?;
+    let rgba = match data.color_type {
+        ColorType::Rgba => {
+            if data.pixels.len() != pixel_count.checked_mul(4)? {
+                return None;
+            }
+            data.pixels
         }
+        ColorType::Rgb => {
+            if data.pixels.len() != pixel_count.checked_mul(3)? {
+                return None;
+            }
+            let mut rgba = Vec::with_capacity(pixel_count * 4);
+            for rgb in data.pixels.chunks_exact(3) {
+                rgba.extend_from_slice(&[rgb[0], rgb[1], rgb[2], 255]);
+            }
+            rgba
+        }
+    };
+    Some(RasterObject {
+        width,
+        height,
+        rgba,
+        handle: None,
+    })
+}
+
+/// Resolves the engine's direct placements against the current viewport.
+fn direct_placement_views(term: &VtTerminal) -> Vec<KittyPlacementView> {
+    let graphics = &term.graphics;
+    let cell_width = graphics.cell_width;
+    let cell_height = graphics.cell_height;
+    if cell_width < 1.0 || cell_height < 1.0 {
+        return Vec::new();
     }
-}
 
-/// Kitty object anchor.
-#[derive(Clone, Copy)]
-pub struct KittyAnchor {
-    /// Anchor row.
-    pub row: u16,
-    /// Anchor column.
-    pub col: u16,
-    /// Object width in cells.
-    pub columns: u32,
-    /// Object height in cells.
-    pub rows: u32,
-}
+    // The visible viewport's top row in the engine's absolute row space.
+    let viewport_top = term.grid.lines_evicted() as i64 + term.history_size() as i64
+        - term.display_offset() as i64;
+    let screen_lines = term.screen_lines() as i64;
 
-/// Parsed Kitty graphics operation.
-pub enum KittyOperation {
-    /// Indicates a multipart transfer is still pending.
-    Pending,
-    /// Indicates the sequence was ignored.
-    Ignored,
-    /// Image registration without placement.
-    TransmitOnly {
-        /// Object identifier.
-        object_id: u32,
-        /// Decoded image.
-        image: KittyImage,
-    },
-    /// Image registration with placement.
-    TransmitAndPlace {
-        /// Object identifier.
-        object_id: u32,
-        /// Decoded image.
-        image: KittyImage,
-        /// Placement anchor.
-        anchor: KittyAnchor,
-    },
-    /// Placement of a previously registered image.
-    PlaceExisting {
-        /// Object identifier.
-        object_id: u32,
-        /// Placement anchor.
-        anchor: KittyAnchor,
-    },
-    /// Image deletion.
-    Delete {
-        /// Optional object identifier.
-        object_id: Option<u32>,
-    },
-}
-
-struct KittyTransfer {
-    action: String,
-    object_id: u32,
-    format: u32,
-    width: Option<u32>,
-    height: Option<u32>,
-    columns: Option<u32>,
-    rows: Option<u32>,
-    uses_placeholders: bool,
-    anchor_row: u16,
-    anchor_col: u16,
-    bytes: Vec<u8>,
-}
-
-impl KittyTransfer {
-    fn finalize(&self) -> Option<KittyImage> {
-        let (width, height, rgba) = match self.format {
-            100 => {
-                let image =
-                    image::load_from_memory_with_format(&self.bytes, image::ImageFormat::Png)
-                        .ok()?;
-                let rgba = image.to_rgba8();
-                (rgba.width(), rgba.height(), rgba.into_raw())
-            }
-            24 => {
-                let width = self.width?;
-                let height = self.height?;
-                let expected = width as usize * height as usize * 3;
-                if self.bytes.len() != expected {
-                    return None;
-                }
-                let mut rgba = Vec::with_capacity(width as usize * height as usize * 4);
-                for rgb in self.bytes.chunks_exact(3) {
-                    rgba.extend_from_slice(&[rgb[0], rgb[1], rgb[2], 255]);
-                }
-                (width, height, rgba)
-            }
-            32 => {
-                let width = self.width?;
-                let height = self.height?;
-                let expected = width as usize * height as usize * 4;
-                if self.bytes.len() != expected {
-                    return None;
-                }
-                (width, height, self.bytes.clone())
-            }
-            _ => return None,
+    let mut views = Vec::new();
+    for (&(image_id, placement_id), placement) in &graphics.kitty_placements {
+        let Some(stored) = graphics.get_kitty_image(image_id) else {
+            continue;
+        };
+        let image_width = stored.data.width;
+        let image_height = stored.data.height;
+        let Some((source_x, source_y, source_width, source_height)) = resolve_source_rect(
+            placement.source_x,
+            placement.source_y,
+            placement.source_width,
+            placement.source_height,
+            image_width,
+            image_height,
+        ) else {
+            continue;
         };
 
-        Some(KittyImage {
-            width,
-            height,
-            rgba,
-            uses_placeholders: self.uses_placeholders,
-        })
+        let (display_width, display_height) = kitty_display_size(
+            source_width,
+            source_height,
+            placement.requested_columns,
+            placement.requested_rows,
+            cell_width.round() as usize,
+            cell_height.round() as usize,
+        );
+        if display_width == 0 || display_height == 0 {
+            continue;
+        }
+
+        // Per the kitty spec the sub-cell offset stays inside the cell box;
+        // the engine stores the raw request, so clamp at read time.
+        let x_offset = (placement.cell_x_offset as f32).min(cell_width - 1.0) / cell_width;
+        let y_offset = (placement.cell_y_offset as f32).min(cell_height - 1.0) / cell_height;
+
+        let row = (placement.dest_row - viewport_top) as f32 + y_offset;
+        let col = placement.dest_col as f32 + x_offset;
+        let columns = display_width as f32 / cell_width;
+        let rows = display_height as f32 / cell_height;
+        if row + rows <= 0.0 || row >= screen_lines as f32 {
+            continue;
+        }
+
+        views.push(KittyPlacementView {
+            image_id,
+            placement_id,
+            row,
+            col,
+            columns,
+            rows,
+            source_rect: [
+                source_x as f32 / image_width as f32,
+                source_y as f32 / image_height as f32,
+                (source_x + source_width) as f32 / image_width as f32,
+                (source_y + source_height) as f32 / image_height as f32,
+            ],
+            z: placement.z_index,
+        });
     }
+    views
 }
 
-/// Refreshes placeholder-backed Kitty anchors from the terminal grid.
-pub fn refresh_kitty_placeholder_anchors(
-    objects: &HashMap<u32, InlineObject>,
-    anchors: &mut HashMap<u32, InlineAnchor>,
-    term: &VtTerminal,
-) -> bool {
-    let placeholder_ids = objects
-        .iter()
-        .filter_map(|(object_id, object)| match object {
-            InlineObject::KittyImage(object) => object.uses_placeholders.then_some(*object_id),
-            InlineObject::RgpObject(_) => None,
-        })
-        .collect::<Vec<_>>();
-    if placeholder_ids.is_empty() {
-        return false;
+/// Resolves virtual (`U=1`) placements from their placeholder cells.
+///
+/// The engine registers the placement metadata; the application prints the
+/// U+10EEEE cells whose foreground color carries the image id. The image is
+/// fitted to the visible placeholder bounding box, which keeps it welded to
+/// the text while scrolling, splitting, and erasing — kitty's reason for
+/// the placeholder mode to exist.
+fn virtual_placement_views(term: &VtTerminal) -> Vec<KittyPlacementView> {
+    let virtual_placements = &term.graphics.kitty_virtual_placements;
+    if virtual_placements.is_empty() {
+        return Vec::new();
     }
-    let placeholder_lookup = placeholder_ids
-        .iter()
-        .map(|object_id| (object_id & 0x00ff_ffff, *object_id))
-        .collect::<HashMap<_, _>>();
 
-    let mut bounds = HashMap::<u32, (u16, u16, u16, u16)>::new();
+    // Placeholder cells carry the image id's low 24 bits in the foreground
+    // color; the optional high byte lives in a third combining mark that
+    // real emitters (kitten icat) leave unused.
+    let lookup: HashMap<u32, PlacementKey> = virtual_placements
+        .keys()
+        .map(|&(image_id, placement_id)| (image_id & 0x00ff_ffff, (image_id, placement_id)))
+        .collect();
+
+    let mut bounds = HashMap::<PlacementKey, (u16, u16, u16, u16)>::new();
     let rows = u16::try_from(term.screen_lines()).unwrap_or(u16::MAX);
     let cols = u16::try_from(term.columns()).unwrap_or(u16::MAX);
     let styles = vt::styles(term);
@@ -304,26 +309,26 @@ pub fn refresh_kitty_placeholder_anchors(
         let Some(grid_row) = vt::visible_row(term, row) else {
             continue;
         };
-        // rio-vt flags rows holding a U+10EEEE placeholder, so rows without one
-        // skip the per-cell scan entirely.
+        // rio-vt flags rows holding a placeholder, so rows without one skip
+        // the per-cell scan entirely.
         if !grid_row.kitty_virtual_placeholder {
             continue;
         }
         for col in 0..cols {
             let square = grid_row[Column(usize::from(col))];
-            if square.c() != '\u{10EEEE}' {
+            if square.c() != PLACEHOLDER {
                 continue;
             }
             let (fg, _, _) = vt::cell_attributes(styles, square);
             let CellColor::Rgb(r, g, b) = fg else {
                 continue;
             };
-            let placeholder_id = ((r as u32) << 16) | ((g as u32) << 8) | (b as u32);
-            let Some(object_id) = placeholder_lookup.get(&placeholder_id).copied() else {
+            let encoded_id = (u32::from(r) << 16) | (u32::from(g) << 8) | u32::from(b);
+            let Some(&key) = lookup.get(&encoded_id) else {
                 continue;
             };
             bounds
-                .entry(object_id)
+                .entry(key)
                 .and_modify(|(top, left, bottom, right)| {
                     *top = (*top).min(row);
                     *left = (*left).min(col);
@@ -334,30 +339,42 @@ pub fn refresh_kitty_placeholder_anchors(
         }
     }
 
-    let mut changed = false;
-    for object_id in placeholder_ids {
-        if let Some((top, left, bottom, right)) = bounds.get(&object_id).copied() {
-            let columns = u32::from(right - left + 1);
-            let rows = u32::from(bottom - top + 1);
-            let new_anchor = InlineAnchor {
-                row: top,
-                col: left,
-                columns,
-                rows,
-                style: InlineStyle::default(),
-            };
-            changed |= anchors
-                .insert(object_id, new_anchor)
-                .is_none_or(|old_anchor| {
-                    old_anchor.row != top
-                        || old_anchor.col != left
-                        || old_anchor.columns != columns
-                        || old_anchor.rows != rows
-                });
-        } else {
-            changed |= anchors.remove(&object_id).is_some();
-        }
-    }
-
-    changed
+    bounds
+        .into_iter()
+        .map(|((image_id, placement_id), (top, left, bottom, right))| {
+            let placement = &virtual_placements[&(image_id, placement_id)];
+            let source_rect = term
+                .graphics
+                .get_kitty_image(image_id)
+                .and_then(|stored| {
+                    let width = stored.data.width;
+                    let height = stored.data.height;
+                    let (x, y, w, h) = resolve_source_rect(
+                        placement.x,
+                        placement.y,
+                        placement.width,
+                        placement.height,
+                        width,
+                        height,
+                    )?;
+                    Some([
+                        x as f32 / width as f32,
+                        y as f32 / height as f32,
+                        (x + w) as f32 / width as f32,
+                        (y + h) as f32 / height as f32,
+                    ])
+                })
+                .unwrap_or([0.0, 0.0, 1.0, 1.0]);
+            KittyPlacementView {
+                image_id,
+                placement_id,
+                row: f32::from(top),
+                col: f32::from(left),
+                columns: f32::from(right - left + 1),
+                rows: f32::from(bottom - top + 1),
+                source_rect,
+                z: 0,
+            }
+        })
+        .collect()
 }

--- a/src/kitty.rs
+++ b/src/kitty.rs
@@ -4,35 +4,46 @@
 //! decodes PNG, RGB, and RGBA payloads (chunked or not), stores images and
 //! placements per screen, answers queries, applies deletes, and evicts
 //! images over the spec's memory budget. This module owns what is ratty's
-//! to draw: it drains the pixel data the engine queues for upload and turns
-//! the engine's placement state into the flat list of textured quads the
-//! Bevy scene renders each frame.
+//! to draw: it turns the engine's placement state into the flat list of
+//! textured quads the Bevy scene renders each frame, converting pixels
+//! from the engine's image store into GPU textures on demand.
+//!
+//! The engine store is the single source of truth for pixels. Textures are
+//! cached per image id and validated against the store's transmission
+//! timestamp, so retransmissions, alternate-screen id collisions, and
+//! evictions all resolve to whatever the engine currently holds.
 //!
 //! Two placement kinds reach the screen:
 //!
 //! - *Direct* placements (`a=T`/`a=p`) live in the engine as absolute,
-//!   scrollback-aware grid positions. Their on-screen position is derived
-//!   per refresh from the terminal's history and display offset, so they
-//!   stay glued to the text they were placed next to — including while the
-//!   user scrolls into history.
+//!   scrollback-aware grid positions. Their on-screen quad comes from the
+//!   engine's own [`kitty_overlay_geometry`], clipped to the terminal
+//!   surface with a proportional source-rect shrink, so partially scrolled
+//!   images show the correct slice instead of overhanging the grid.
 //! - *Virtual* placements (`U=1`, what `kitten icat --unicode-placeholder`
 //!   emits) are anchored by U+10EEEE placeholder cells the application
-//!   prints itself. The visible cells are scanned and the image is fitted
-//!   to their bounding box, so the image moves, clips, and disappears with
-//!   the text that carries it.
+//!   prints itself. Each row-run of placeholder cells is decoded with the
+//!   engine's [`IncompletePlacement`] rules (image id in the foreground
+//!   color — RGB or indexed — placement id in the underline color, row,
+//!   column, and id high byte in combining diacritics) and rendered as its
+//!   own slice via [`compute_run_geometry`], so scrolled or split
+//!   placeholder regions show the right image tiles.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
-use rio_graphics::{ColorType, GraphicData};
-use rio_vt::ansi::graphics::{kitty_display_size, resolve_source_rect};
-use rio_vt::ansi::kitty_virtual::PLACEHOLDER;
+use rio_graphics::{ColorType, GraphicData, GraphicOverlay};
+use rio_vt::ansi::graphics::{OverlayViewport, clip_overlay_to_rect, kitty_overlay_geometry};
+use rio_vt::ansi::kitty_virtual::{IncompletePlacement, PLACEHOLDER, compute_run_geometry};
 use rio_vt::crosswords::pos::Column;
 
 use crate::inline::RasterObject;
-use crate::vt::{self, CellColor, VtTerminal};
+use crate::vt::{self, VtTerminal};
 
-/// A kitty placement key: `(image_id, placement_id)`.
-pub type PlacementKey = (u32, u32);
+/// A kitty placement view key: `(image_id, placement_id, run)`.
+///
+/// Direct placements use run `0`; virtual placements get one view per
+/// placeholder row-run, keyed by the run's screen position.
+pub type PlacementKey = (u32, u32, u32);
 
 /// Kitty images and the placements to draw, derived from engine state.
 #[derive(Default)]
@@ -42,29 +53,58 @@ pub struct KittyGraphics {
     images: HashMap<u32, KittyImage>,
     /// Placements to draw, sorted back-to-front.
     placements: Vec<KittyPlacementView>,
+    /// Scroll state the current placement views were derived from.
+    snapshot: Option<Snapshot>,
 }
 
 /// A decoded kitty image and its GPU upload state.
 pub struct KittyImage {
     /// Pixel payload and texture handle.
     pub raster: RasterObject,
-    /// Engine transmission timestamp, used to skip redundant re-uploads
-    /// when the engine re-queues the same pixels for another placement.
+    /// Engine transmission timestamp. A mismatch with the engine store
+    /// means the pixels changed under this id — a retransmission, or an
+    /// alternate-screen swap where both screens use the same id — and the
+    /// texture is rebuilt from the store.
     transmit_time: std::time::Instant,
+}
+
+/// The terminal state the placement views depend on besides the grid
+/// content and the engine's dirty flag: any change here moves placements
+/// without either of those signals firing.
+#[derive(Clone, Copy, PartialEq, Eq)]
+struct Snapshot {
+    display_offset: usize,
+    history_size: usize,
+    lines_evicted: u64,
+    direct: usize,
+    r#virtual: usize,
+}
+
+impl Snapshot {
+    fn of(term: &VtTerminal) -> Self {
+        Self {
+            display_offset: term.display_offset(),
+            history_size: term.history_size(),
+            lines_evicted: term.grid.lines_evicted(),
+            direct: term.graphics.kitty_placements.len(),
+            r#virtual: term.graphics.kitty_virtual_placements.len(),
+        }
+    }
 }
 
 /// One kitty placement resolved to visible-grid coordinates.
 ///
 /// Spans are fractional cells: a placement shown at native pixel size
 /// rarely lands on a cell boundary, and rounding it up would stretch the
-/// image. `row` is signed so a placement partially scrolled off the top
-/// keeps its true origin instead of clamping to the first row.
+/// image.
 #[derive(Clone, Debug, PartialEq)]
 pub struct KittyPlacementView {
     /// Kitty image id (`i=`).
     pub image_id: u32,
     /// Kitty placement id (`p=`, or engine-allocated).
     pub placement_id: u32,
+    /// Distinguishes the row-runs of a virtual placement; `0` for direct.
+    pub run: u32,
     /// Top-left corner in visible-grid cells.
     pub row: f32,
     /// Top-left corner in visible-grid cells.
@@ -75,8 +115,15 @@ pub struct KittyPlacementView {
     pub rows: f32,
     /// Normalized source crop within the image, `[u0, v0, u1, v1]`.
     pub source_rect: [f32; 4],
-    /// Kitty z-index, used for draw order among images.
+    /// Kitty z-index. Negative layers render behind the terminal surface.
     pub z: i32,
+}
+
+impl KittyPlacementView {
+    /// Returns the plane-cache key for this view.
+    pub fn key(&self) -> PlacementKey {
+        (self.image_id, self.placement_id, self.run)
+    }
 }
 
 impl KittyGraphics {
@@ -90,23 +137,75 @@ impl KittyGraphics {
         self.images.get_mut(&image_id)
     }
 
-    /// Synchronizes with the engine: applies queued pixel uploads and
-    /// removals, then rebuilds the placement list from the terminal's
-    /// kitty state. Returns whether anything the renderer draws changed.
-    pub fn refresh(
-        &mut self,
-        term: &VtTerminal,
-        updates: Vec<rio_vt::ansi::graphics::UpdateQueues>,
-    ) -> bool {
-        let mut changed = false;
-        for queues in updates {
-            changed |= self.apply_queues(queues);
+    /// Synchronizes with the engine: re-derives the placement views and
+    /// keeps the texture cache aligned with the engine's image store.
+    /// Returns whether anything the renderer draws changed.
+    ///
+    /// `terminal_changed` marks frames where grid content changed (PTY
+    /// output, resize); together with the engine's dirty flag and the
+    /// scroll-state snapshot it gates the rebuild, so idle frames — and
+    /// all frames on a terminal with no graphics — cost a few comparisons.
+    pub fn refresh(&mut self, term: &mut VtTerminal, terminal_changed: bool) -> bool {
+        let engine_dirty = std::mem::take(&mut term.graphics.kitty_graphics_dirty);
+        let snapshot = Snapshot::of(term);
+        if !engine_dirty && !terminal_changed && self.snapshot == Some(snapshot) {
+            return false;
         }
+        self.snapshot = Some(snapshot);
 
-        // Deletes clear the engine's image store without queueing texture
-        // removals, so drop whatever the engine no longer holds. Images on
-        // the *inactive* screen stay: the engine does not re-send pixels
-        // when the terminal swaps back from the alternate screen.
+        let mut views = direct_placement_views(term);
+        views.extend(virtual_placement_views(term));
+        // Back-to-front by kitty z-index, then by keys so equal layers
+        // keep a deterministic order across refreshes.
+        views.sort_by_key(|view| (view.z, view.key()));
+
+        let mut changed = self.ensure_textures(term, &views);
+        changed |= self.prune_textures(term);
+        if views != self.placements {
+            self.placements = views;
+            changed = true;
+        }
+        changed
+    }
+
+    /// Builds or refreshes textures for every image the views reference,
+    /// pulling pixels from the engine's store.
+    fn ensure_textures(&mut self, term: &VtTerminal, views: &[KittyPlacementView]) -> bool {
+        let mut changed = false;
+        let mut seen = HashSet::new();
+        for view in views {
+            if !seen.insert(view.image_id) {
+                continue;
+            }
+            let Some(stored) = term.graphics.get_kitty_image(view.image_id) else {
+                continue;
+            };
+            if self
+                .images
+                .get(&view.image_id)
+                .is_some_and(|image| image.transmit_time == stored.transmission_time)
+            {
+                continue;
+            }
+            let Some(raster) = rasterize(&stored.data) else {
+                continue;
+            };
+            self.images.insert(
+                view.image_id,
+                KittyImage {
+                    raster,
+                    transmit_time: stored.transmission_time,
+                },
+            );
+            changed = true;
+        }
+        changed
+    }
+
+    /// Drops textures for images the engine no longer holds. Images on
+    /// the *inactive* screen stay cached: the engine does not re-send
+    /// pixels when the terminal swaps back from the alternate screen.
+    fn prune_textures(&mut self, term: &VtTerminal) -> bool {
         let graphics = &term.graphics;
         let before = self.images.len();
         self.images.retain(|image_id, _| {
@@ -116,65 +215,12 @@ impl KittyGraphics {
                     .kitty_images
                     .contains_key(image_id)
         });
-        changed |= self.images.len() != before;
-
-        let mut views = direct_placement_views(term);
-        views.extend(virtual_placement_views(term));
-        // Back-to-front by kitty z-index, then by ids so equal layers keep
-        // a deterministic order across refreshes.
-        views.sort_by_key(|view| (view.z, view.image_id, view.placement_id));
-        if views != self.placements {
-            self.placements = views;
-            changed = true;
-        }
-        changed
-    }
-
-    /// Applies one engine update batch: new image pixels in, deleted or
-    /// evicted textures out. Atlas graphics (sixel/iTerm2) are dropped —
-    /// ratty renders kitty placements only and does not advertise sixel.
-    fn apply_queues(&mut self, queues: rio_vt::ansi::graphics::UpdateQueues) -> bool {
-        let mut changed = false;
-
-        for key in queues.remove_queue {
-            // Kitty texture keys are the protocol image id verbatim; atlas
-            // keys live above the u32 range (see rio-graphics).
-            if let Ok(image_id) = u32::try_from(key) {
-                changed |= self.images.remove(&image_id).is_some();
-            }
-        }
-
-        for (image_id, data) in queues.pending_images {
-            // The engine re-queues the stored pixels for every new
-            // placement of an already-transmitted image; only a genuine
-            // retransmission carries a new timestamp.
-            if self
-                .images
-                .get(&image_id)
-                .is_some_and(|image| image.transmit_time == data.transmit_time)
-            {
-                continue;
-            }
-            let transmit_time = data.transmit_time;
-            let Some(raster) = rasterize(data) else {
-                continue;
-            };
-            self.images.insert(
-                image_id,
-                KittyImage {
-                    raster,
-                    transmit_time,
-                },
-            );
-            changed = true;
-        }
-
-        changed
+        before != self.images.len()
     }
 }
 
 /// Converts engine pixel data into ratty's RGBA raster form.
-fn rasterize(data: GraphicData) -> Option<RasterObject> {
+fn rasterize(data: &GraphicData) -> Option<RasterObject> {
     let width = u32::try_from(data.width).ok()?;
     let height = u32::try_from(data.height).ok()?;
     let pixel_count = data.width.checked_mul(data.height)?;
@@ -183,7 +229,7 @@ fn rasterize(data: GraphicData) -> Option<RasterObject> {
             if data.pixels.len() != pixel_count.checked_mul(4)? {
                 return None;
             }
-            data.pixels
+            data.pixels.clone()
         }
         ColorType::Rgb => {
             if data.pixels.len() != pixel_count.checked_mul(3)? {
@@ -204,7 +250,9 @@ fn rasterize(data: GraphicData) -> Option<RasterObject> {
     })
 }
 
-/// Resolves the engine's direct placements against the current viewport.
+/// Resolves the engine's direct placements against the current viewport,
+/// using the engine's own geometry and clipping helpers so ratty draws
+/// exactly the slice rio's renderer would.
 fn direct_placement_views(term: &VtTerminal) -> Vec<KittyPlacementView> {
     let graphics = &term.graphics;
     let cell_width = graphics.cell_width;
@@ -213,67 +261,55 @@ fn direct_placement_views(term: &VtTerminal) -> Vec<KittyPlacementView> {
         return Vec::new();
     }
 
-    // The visible viewport's top row in the engine's absolute row space.
-    let viewport_top = term.grid.lines_evicted() as i64 + term.history_size() as i64
-        - term.display_offset() as i64;
-    let screen_lines = term.screen_lines() as i64;
+    let viewport = OverlayViewport {
+        cell_width,
+        cell_height,
+        origin_x: 0.0,
+        origin_y: 0.0,
+        // `dest_row` is anchored in the stable row space that includes
+        // rows evicted off the ring; fold them into the history so the
+        // viewport top lines up.
+        history_size: term.grid.lines_evicted() as i64 + term.history_size() as i64,
+        display_offset: term.display_offset() as i64,
+        screen_lines: term.screen_lines() as i64,
+    };
+    let surface_width = term.columns() as f32 * cell_width;
+    let surface_height = term.screen_lines() as f32 * cell_height;
 
     let mut views = Vec::new();
     for (&(image_id, placement_id), placement) in &graphics.kitty_placements {
         let Some(stored) = graphics.get_kitty_image(image_id) else {
             continue;
         };
-        let image_width = stored.data.width;
-        let image_height = stored.data.height;
-        let Some((source_x, source_y, source_width, source_height)) = resolve_source_rect(
-            placement.source_x,
-            placement.source_y,
-            placement.source_width,
-            placement.source_height,
-            image_width,
-            image_height,
-        ) else {
+        let Some(geometry) =
+            kitty_overlay_geometry(placement, stored.data.width, stored.data.height, &viewport)
+        else {
             continue;
         };
-
-        let (display_width, display_height) = kitty_display_size(
-            source_width,
-            source_height,
-            placement.requested_columns,
-            placement.requested_rows,
-            cell_width.round() as usize,
-            cell_height.round() as usize,
-        );
-        if display_width == 0 || display_height == 0 {
+        // Clip to the terminal surface: a partially scrolled placement
+        // keeps its position and shows the covered part of the image,
+        // instead of overhanging the grid.
+        let mut overlay = GraphicOverlay {
+            image_id: u64::from(image_id),
+            x: geometry.x,
+            y: geometry.y,
+            width: geometry.width,
+            height: geometry.height,
+            z_index: placement.z_index,
+            source_rect: geometry.source_rect,
+        };
+        if !clip_overlay_to_rect(&mut overlay, 0.0, 0.0, surface_width, surface_height) {
             continue;
         }
-
-        // Per the kitty spec the sub-cell offset stays inside the cell box;
-        // the engine stores the raw request, so clamp at read time.
-        let x_offset = (placement.cell_x_offset as f32).min(cell_width - 1.0) / cell_width;
-        let y_offset = (placement.cell_y_offset as f32).min(cell_height - 1.0) / cell_height;
-
-        let row = (placement.dest_row - viewport_top) as f32 + y_offset;
-        let col = placement.dest_col as f32 + x_offset;
-        let columns = display_width as f32 / cell_width;
-        let rows = display_height as f32 / cell_height;
-        if row + rows <= 0.0 || row >= screen_lines as f32 {
-            continue;
-        }
-
         views.push(KittyPlacementView {
             image_id,
             placement_id,
-            row,
-            col,
-            columns,
-            rows,
-            source_rect: [
-                source_x as f32 / image_width as f32,
-                source_y as f32 / image_height as f32,
-                (source_x + source_width) as f32 / image_width as f32,
-                (source_y + source_height) as f32 / image_height as f32,
-            ],
+            run: 0,
+            row: overlay.y / cell_height,
+            col: overlay.x / cell_width,
+            columns: overlay.width / cell_width,
+            rows: overlay.height / cell_height,
+            source_rect: overlay.source_rect,
             z: placement.z_index,
         });
     }
@@ -283,100 +319,115 @@ fn direct_placement_views(term: &VtTerminal) -> Vec<KittyPlacementView> {
 /// Resolves virtual (`U=1`) placements from their placeholder cells.
 ///
 /// The engine registers the placement metadata; the application prints the
-/// U+10EEEE cells whose foreground color carries the image id. The image is
-/// fitted to the visible placeholder bounding box, which keeps it welded to
-/// the text while scrolling, splitting, and erasing — kitty's reason for
-/// the placeholder mode to exist.
+/// U+10EEEE cells itself. Each row-run of consecutive placeholder cells is
+/// decoded with the engine's continuation rules and rendered as one slice,
+/// which keeps the image welded to the text while scrolling, splitting,
+/// and erasing — kitty's reason for the placeholder mode to exist.
 fn virtual_placement_views(term: &VtTerminal) -> Vec<KittyPlacementView> {
-    let virtual_placements = &term.graphics.kitty_virtual_placements;
-    if virtual_placements.is_empty() {
+    if term.graphics.kitty_virtual_placements.is_empty() {
+        return Vec::new();
+    }
+    let cell_width = term.graphics.cell_width;
+    let cell_height = term.graphics.cell_height;
+    if cell_width < 1.0 || cell_height < 1.0 {
         return Vec::new();
     }
 
-    // Placeholder cells carry the image id's low 24 bits in the foreground
-    // color; the optional high byte lives in a third combining mark that
-    // real emitters (kitten icat) leave unused.
-    let lookup: HashMap<u32, PlacementKey> = virtual_placements
-        .keys()
-        .map(|&(image_id, placement_id)| (image_id & 0x00ff_ffff, (image_id, placement_id)))
-        .collect();
-
-    let mut bounds = HashMap::<PlacementKey, (u16, u16, u16, u16)>::new();
     let rows = u16::try_from(term.screen_lines()).unwrap_or(u16::MAX);
     let cols = u16::try_from(term.columns()).unwrap_or(u16::MAX);
     let styles = vt::styles(term);
+    let mut views = Vec::new();
     for row in 0..rows {
         let Some(grid_row) = vt::visible_row(term, row) else {
             continue;
         };
-        // rio-vt flags rows holding a placeholder, so rows without one skip
-        // the per-cell scan entirely.
+        // rio-vt flags rows holding a placeholder, so rows without one
+        // skip the per-cell scan entirely.
         if !grid_row.kitty_virtual_placeholder {
             continue;
         }
+        let mut current: Option<(IncompletePlacement, u16)> = None;
         for col in 0..cols {
             let square = grid_row[Column(usize::from(col))];
-            if square.c() != PLACEHOLDER {
-                continue;
-            }
-            let (fg, _, _) = vt::cell_attributes(styles, square);
-            let CellColor::Rgb(r, g, b) = fg else {
-                continue;
+            let cell = (square.c() == PLACEHOLDER).then(|| {
+                let style = styles
+                    .get(usize::from(square.style_id()))
+                    .copied()
+                    .unwrap_or_default();
+                // Combining marks carry the row/column/id-high diacritics.
+                let combining = term
+                    .grid
+                    .cell_text(vt::visible_pos(term, row, col))
+                    .skip(1)
+                    .collect::<Vec<_>>();
+                IncompletePlacement::from_cell(style.fg, style.underline_color, &combining)
+            });
+            current = match (current.take(), cell) {
+                (Some((mut run, start)), Some(cell)) if run.can_append(&cell) => {
+                    run.append();
+                    Some((run, start))
+                }
+                (previous, cell) => {
+                    if let Some((run, start)) = previous {
+                        views.extend(run_view(term, &run, row, start, cell_width, cell_height));
+                    }
+                    cell.map(|cell| (cell, col))
+                }
             };
-            let encoded_id = (u32::from(r) << 16) | (u32::from(g) << 8) | u32::from(b);
-            let Some(&key) = lookup.get(&encoded_id) else {
-                continue;
-            };
-            bounds
-                .entry(key)
-                .and_modify(|(top, left, bottom, right)| {
-                    *top = (*top).min(row);
-                    *left = (*left).min(col);
-                    *bottom = (*bottom).max(row);
-                    *right = (*right).max(col);
-                })
-                .or_insert((row, col, row, col));
+        }
+        if let Some((run, start)) = current {
+            views.extend(run_view(term, &run, row, start, cell_width, cell_height));
         }
     }
+    views
+}
 
-    bounds
-        .into_iter()
-        .map(|((image_id, placement_id), (top, left, bottom, right))| {
-            let placement = &virtual_placements[&(image_id, placement_id)];
-            let source_rect = term
-                .graphics
-                .get_kitty_image(image_id)
-                .and_then(|stored| {
-                    let width = stored.data.width;
-                    let height = stored.data.height;
-                    let (x, y, w, h) = resolve_source_rect(
-                        placement.x,
-                        placement.y,
-                        placement.width,
-                        placement.height,
-                        width,
-                        height,
-                    )?;
-                    Some([
-                        x as f32 / width as f32,
-                        y as f32 / height as f32,
-                        (x + w) as f32 / width as f32,
-                        (y + h) as f32 / height as f32,
-                    ])
-                })
-                .unwrap_or([0.0, 0.0, 1.0, 1.0]);
-            KittyPlacementView {
-                image_id,
-                placement_id,
-                row: f32::from(top),
-                col: f32::from(left),
-                columns: f32::from(right - left + 1),
-                rows: f32::from(bottom - top + 1),
-                source_rect,
-                z: 0,
-            }
-        })
-        .collect()
+/// Resolves one placeholder row-run into a placement view.
+fn run_view(
+    term: &VtTerminal,
+    run: &IncompletePlacement,
+    screen_row: u16,
+    start_col: u16,
+    cell_width: f32,
+    cell_height: f32,
+) -> Option<KittyPlacementView> {
+    let run = run.complete();
+    let virtual_placements = &term.graphics.kitty_virtual_placements;
+    // Exact key first; placeholder streams that omit the underline color
+    // (placement id 0) fall back to any placement of the image.
+    let (&(image_id, placement_id), placement) = virtual_placements
+        .get_key_value(&(run.image_id, run.placement_id))
+        .or_else(|| {
+            virtual_placements
+                .iter()
+                .find(|((id, _), _)| *id == run.image_id)
+        })?;
+    let stored = term.graphics.get_kitty_image(image_id)?;
+    let geometry = compute_run_geometry(
+        &run,
+        placement.columns,
+        placement.rows,
+        u32::try_from(stored.data.width).ok()?,
+        u32::try_from(stored.data.height).ok()?,
+        (placement.x, placement.y, placement.width, placement.height),
+        cell_width,
+        cell_height,
+        0.0,
+        0.0,
+        usize::from(screen_row),
+        usize::from(start_col),
+    )?;
+    Some(KittyPlacementView {
+        image_id,
+        placement_id,
+        run: (u32::from(screen_row) << 16) | u32::from(start_col),
+        row: geometry.y / cell_height,
+        col: geometry.x / cell_width,
+        columns: geometry.width / cell_width,
+        rows: geometry.height / cell_height,
+        source_rect: geometry.source_rect,
+        z: 0,
+    })
 }
 
 #[cfg(test)]
@@ -385,6 +436,7 @@ mod tests {
 
     use base64::Engine as _;
     use rio_vt::ansi::CursorShape;
+    use rio_vt::ansi::kitty_virtual::encode_placeholder;
     use rio_vt::crosswords::{Crosswords, CrosswordsSize};
     use rio_vt::event::WindowId;
     use rio_vt::performer::handler::Processor;
@@ -393,6 +445,7 @@ mod tests {
 
     const CELL_WIDTH: u32 = 10;
     const CELL_HEIGHT: u32 = 20;
+    const FULL: [f32; 4] = [0.0, 0.0, 1.0, 1.0];
 
     struct Harness {
         term: VtTerminal,
@@ -431,14 +484,31 @@ mod tests {
             self.processor.advance(&mut self.term, bytes);
         }
 
+        /// Refreshes as a frame with terminal changes would.
         fn refresh(&mut self) -> bool {
-            let updates = self.sink.take_graphics_updates();
-            self.kitty.refresh(&self.term, updates)
+            self.kitty.refresh(&mut self.term, true)
         }
 
-        /// Transmits and places an opaque RGBA image at the cursor.
+        /// Refreshes as a quiet frame would: only the engine dirty flag
+        /// and the scroll snapshot can trigger a rebuild.
+        fn refresh_quiet(&mut self) -> bool {
+            self.kitty.refresh(&mut self.term, false)
+        }
+
+        /// Transmits and places a solid RGBA image at the cursor.
         fn transmit_and_place(&mut self, image_id: u32, width: u32, height: u32, extra: &str) {
-            let pixels = vec![255_u8; (width * height * 4) as usize];
+            self.transmit_pixels(image_id, width, height, [255, 255, 255, 255], extra);
+        }
+
+        fn transmit_pixels(
+            &mut self,
+            image_id: u32,
+            width: u32,
+            height: u32,
+            pixel: [u8; 4],
+            extra: &str,
+        ) {
+            let pixels = pixel.repeat((width * height) as usize);
             let payload = base64::engine::general_purpose::STANDARD.encode(&pixels);
             self.feed(
                 format!("\x1b_Ga=T,f=32,s={width},v={height},i={image_id}{extra};{payload}\x1b\\")
@@ -468,7 +538,7 @@ mod tests {
         assert_eq!(view.image_id, 7);
         assert_eq!((view.row, view.col), (1.0, 2.0));
         assert_eq!((view.columns, view.rows), (2.0, 2.0));
-        assert_eq!(view.source_rect, [0.0, 0.0, 1.0, 1.0]);
+        assert_eq!(view.source_rect, FULL);
 
         let image = harness.kitty.image_mut(7).expect("decoded image");
         assert_eq!(image.raster.width, 2 * CELL_WIDTH);
@@ -482,8 +552,27 @@ mod tests {
             harness.reply_text().contains("\x1b_Gi=7;OK\x1b\\"),
             "the engine must acknowledge the transfer"
         );
+    }
 
-        assert!(!harness.refresh(), "an unchanged frame must not re-sync");
+    #[test]
+    fn quiet_frames_skip_the_rebuild() {
+        let mut harness = Harness::new(5, 20);
+        for line in 0..10 {
+            harness.feed(format!("row{line}\r\n").as_bytes());
+        }
+        harness.transmit_and_place(3, CELL_WIDTH, CELL_HEIGHT, "");
+
+        assert!(
+            harness.refresh_quiet(),
+            "the engine dirty flag must trigger a rebuild without a grid-change hint"
+        );
+        assert!(!harness.refresh_quiet(), "an idle frame must be a no-op");
+
+        vt::set_scrollback(&mut harness.term, 2);
+        assert!(
+            harness.refresh_quiet(),
+            "a scrollback change must rebuild the views"
+        );
     }
 
     #[test]
@@ -532,26 +621,31 @@ mod tests {
     }
 
     #[test]
-    fn placements_scroll_with_content_and_history() {
+    fn scrolled_placements_clip_to_the_visible_slice() {
         let mut harness = Harness::new(3, 20);
         harness.transmit_and_place(5, CELL_WIDTH, 2 * CELL_HEIGHT, "");
         harness.refresh();
         assert_eq!(harness.kitty.placements()[0].row, 0.0);
 
-        // Scroll the content up one row: the placement follows the text.
+        // Scroll the content up one row: the top half leaves the screen,
+        // and the visible remainder shows the bottom half of the image.
         harness.feed(b"\x1b[3;1H\r\n");
         harness.refresh();
-        assert_eq!(harness.kitty.placements()[0].row, -1.0);
+        let view = &harness.kitty.placements()[0];
+        assert_eq!((view.row, view.rows), (0.0, 1.0));
+        assert_eq!(view.source_rect, [0.0, 0.5, 1.0, 1.0]);
 
         // And another: fully above the viewport, so nothing to draw.
         harness.feed(b"\r\n");
         harness.refresh();
         assert!(harness.kitty.placements().is_empty());
 
-        // Scrolling back into history brings it back.
+        // Scrolling back into history brings the whole image back.
         vt::set_scrollback(&mut harness.term, 2);
         harness.refresh();
-        assert_eq!(harness.kitty.placements()[0].row, 0.0);
+        let view = &harness.kitty.placements()[0];
+        assert_eq!((view.row, view.rows), (0.0, 2.0));
+        assert_eq!(view.source_rect, FULL);
     }
 
     #[test]
@@ -588,6 +682,20 @@ mod tests {
     }
 
     #[test]
+    fn negative_z_layers_sort_first_and_stay_negative() {
+        let mut harness = Harness::new(5, 20);
+        harness.transmit_and_place(1, CELL_WIDTH, CELL_HEIGHT, ",z=1");
+        harness.feed(b"\x1b[1;1H");
+        harness.transmit_and_place(2, CELL_WIDTH, CELL_HEIGHT, ",z=-1");
+
+        harness.refresh();
+        let views = harness.kitty.placements();
+        assert_eq!(views.len(), 2);
+        assert_eq!((views[0].image_id, views[0].z), (2, -1));
+        assert_eq!((views[1].image_id, views[1].z), (1, 1));
+    }
+
+    #[test]
     fn virtual_placements_follow_their_placeholder_cells() {
         let mut harness = Harness::new(5, 20);
         harness.transmit_and_place(42, 2 * CELL_WIDTH, CELL_HEIGHT, ",U=1,c=2,r=1");
@@ -599,10 +707,9 @@ mod tests {
 
         // The application prints the placeholder cells itself, image id in
         // the foreground color and row/column in combining diacritics.
-        let encode = rio_vt::ansi::kitty_virtual::encode_placeholder;
         harness.feed(b"\x1b[3;4H\x1b[38;2;0;0;42m");
-        harness.feed(encode(0, 0, None).as_bytes());
-        harness.feed(encode(0, 1, None).as_bytes());
+        harness.feed(encode_placeholder(0, 0, None).as_bytes());
+        harness.feed(encode_placeholder(0, 1, None).as_bytes());
         harness.feed(b"\x1b[m");
 
         assert!(harness.refresh());
@@ -612,6 +719,80 @@ mod tests {
         assert_eq!(view.image_id, 42);
         assert_eq!((view.row, view.col), (2.0, 3.0));
         assert_eq!((view.columns, view.rows), (2.0, 1.0));
+        assert_eq!(view.source_rect, FULL);
+    }
+
+    #[test]
+    fn indexed_color_placeholders_render() {
+        let mut harness = Harness::new(5, 20);
+        harness.transmit_and_place(42, 2 * CELL_WIDTH, CELL_HEIGHT, ",U=1,c=2,r=1");
+
+        // Ids up to 255 may arrive as an indexed foreground color.
+        harness.feed(b"\x1b[1;1H\x1b[38;5;42m");
+        harness.feed(encode_placeholder(0, 0, None).as_bytes());
+        harness.feed(encode_placeholder(0, 1, None).as_bytes());
+        harness.feed(b"\x1b[m");
+
+        harness.refresh();
+        let views = harness.kitty.placements();
+        assert_eq!(views.len(), 1);
+        assert_eq!(views[0].image_id, 42);
+    }
+
+    #[test]
+    fn partially_shown_virtual_placements_slice_by_diacritics() {
+        let mut harness = Harness::new(5, 20);
+        // A 2x2-cell virtual placement, but the application only shows the
+        // second image row: kitty semantics say those cells display the
+        // bottom slice, never a squashed whole image.
+        harness.transmit_and_place(9, 2 * CELL_WIDTH, 2 * CELL_HEIGHT, ",U=1,c=2,r=2");
+        harness.feed(b"\x1b[1;1H\x1b[38;2;0;0;9m");
+        harness.feed(encode_placeholder(1, 0, None).as_bytes());
+        harness.feed(encode_placeholder(1, 1, None).as_bytes());
+        harness.feed(b"\x1b[m");
+
+        harness.refresh();
+        let views = harness.kitty.placements();
+        assert_eq!(views.len(), 1);
+        let view = &views[0];
+        assert_eq!((view.row, view.col), (0.0, 0.0));
+        assert_eq!((view.columns, view.rows), (2.0, 1.0));
+        assert_eq!(
+            view.source_rect,
+            [0.0, 0.5, 1.0, 1.0],
+            "the run must show the image row its diacritics name"
+        );
+    }
+
+    #[test]
+    fn alt_screen_id_collisions_rebuild_from_the_engine_store() {
+        let mut harness = Harness::new(5, 20);
+        harness.transmit_pixels(1, 1, 1, [255, 0, 0, 255], "");
+        harness.refresh();
+        assert_eq!(
+            &harness.kitty.image_mut(1).expect("image 1").raster.rgba,
+            &[255, 0, 0, 255]
+        );
+
+        // An alt-screen app reuses id 1 for a different image.
+        harness.feed(b"\x1b[?1049h");
+        harness.transmit_pixels(1, 1, 1, [0, 0, 255, 255], "");
+        harness.refresh();
+        assert_eq!(
+            &harness.kitty.image_mut(1).expect("image 1").raster.rgba,
+            &[0, 0, 255, 255]
+        );
+
+        // Swapping back must restore the main screen's pixels even though
+        // the engine sends no new UpdateGraphics event for them.
+        harness.feed(b"\x1b[?1049l");
+        harness.refresh();
+        let views = harness.kitty.placements();
+        assert_eq!(views.len(), 1);
+        assert_eq!(
+            &harness.kitty.image_mut(1).expect("image 1").raster.rgba,
+            &[255, 0, 0, 255]
+        );
     }
 
     #[test]

--- a/src/model.rs
+++ b/src/model.rs
@@ -11,7 +11,7 @@ use bevy::prelude::*;
 use rust_embed::RustEmbed;
 
 use crate::config::{AppConfig, CURSOR_DEPTH};
-use crate::inline::{InlineObject, RgpInlineObject};
+use crate::inline::RgpInlineObject;
 use crate::paths::{expand_path, runtime_asset_root};
 
 #[derive(RustEmbed)]
@@ -32,9 +32,9 @@ pub enum ObjectSource {
     Stl(Mesh),
 }
 
-impl From<ObjectSource> for InlineObject {
+impl From<ObjectSource> for RgpInlineObject {
     fn from(val: ObjectSource) -> Self {
-        InlineObject::RgpObject(match val {
+        match val {
             ObjectSource::Stl(mesh) => RgpInlineObject::Stl { mesh, handle: None },
             ObjectSource::Obj(meshes) => RgpInlineObject::Obj {
                 meshes,
@@ -44,7 +44,7 @@ impl From<ObjectSource> for InlineObject {
                 asset_path,
                 handle: None,
             },
-        })
+        }
     }
 }
 

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -20,9 +20,10 @@ use crate::scene::{
 use crate::systems::{
     TerminalFrameDirty, TerminalRedrawSet, animate_inline_kitty_planes, animate_mobius_transition,
     animate_terminal_plane_warp, apply_inline_objects, apply_instance_brightness,
-    finish_terminal_model_load, handle_window_resize, pump_pty_output, render_terminal_widget,
-    request_exit_on_primary_window_close, shutdown_terminal_runtime_on_exit,
-    sync_asset_to_terminal_cursor, sync_inline_objects, sync_rgp_objects, sync_terminal_materials,
+    finish_terminal_model_load, handle_window_resize, pump_pty_output, refresh_kitty_graphics,
+    render_terminal_widget, request_exit_on_primary_window_close,
+    shutdown_terminal_runtime_on_exit, sync_asset_to_terminal_cursor, sync_inline_objects,
+    sync_rgp_objects, sync_terminal_materials,
 };
 use crate::terminal::TerminalRedrawState;
 
@@ -133,6 +134,15 @@ impl Plugin for TerminalPlugin {
                 )
                     .chain()
                     .in_set(TerminalRedrawSet),
+            )
+            .add_systems(
+                Update,
+                // After the mouse input set so scrollback changes land in the
+                // same frame's placement views.
+                refresh_kitty_graphics
+                    .after(pump_pty_output)
+                    .after(TerminalCameraSystemSet::MouseInput)
+                    .before(sync_inline_objects),
             )
             .add_systems(
                 Update,

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -137,11 +137,15 @@ impl Plugin for TerminalPlugin {
             )
             .add_systems(
                 Update,
-                // After the mouse input set so scrollback changes land in the
-                // same frame's placement views.
+                // After the mouse input set and the window resize so
+                // scrollback changes and post-reflow grids land in the same
+                // frame's placement views; before the redraw set because the
+                // refresh peeks the pending-redraw flag the redraw consumes.
                 refresh_kitty_graphics
                     .after(pump_pty_output)
+                    .after(handle_window_resize)
                     .after(TerminalCameraSystemSet::MouseInput)
+                    .before(TerminalRedrawSet)
                     .before(sync_inline_objects),
             )
             .add_systems(

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -242,11 +242,6 @@ impl TerminalRuntime {
         self.sink.take_replies()
     }
 
-    /// Drains the kitty graphics update queues rio-vt has emitted.
-    pub fn take_graphics_updates(&mut self) -> Vec<rio_vt::ansi::graphics::UpdateQueues> {
-        self.sink.take_graphics_updates()
-    }
-
     /// Receives pending PTY output without blocking.
     pub fn try_recv(&mut self) -> Result<Vec<u8>, TryRecvError> {
         self.rx.get().try_recv()
@@ -267,7 +262,22 @@ impl TerminalRuntime {
     }
 
     /// Resizes the PTY and parser screen.
-    pub fn resize(&mut self, cols: u16, rows: u16, pw: u16, ph: u16) {
+    ///
+    /// `cell_width`/`cell_height` are the renderer's physical cell metrics.
+    /// They arrive fractional (parley cells rarely land on whole pixels) and
+    /// are rounded for the engine, which sizes kitty graphics placements
+    /// against them and refuses placements while they are zero. Deriving
+    /// them from `pw / cols` instead would truncate — an 8.4px cell would
+    /// reach the engine as 8px and mis-scale every native-size image by 5%.
+    pub fn resize(
+        &mut self,
+        cols: u16,
+        rows: u16,
+        pw: u16,
+        ph: u16,
+        cell_width: f32,
+        cell_height: f32,
+    ) {
         if cols == 0 || rows == 0 {
             return;
         }
@@ -283,16 +293,13 @@ impl TerminalRuntime {
 
         // rio-vt reflows content and resets the scrolling region natively, so
         // the grid resize is the whole operation — no snapshot and replay.
-        // The pixel dimensions matter too: the engine sizes kitty graphics
-        // placements against the cell pixel size, and refuses placements
-        // while it is zero.
         self.term.resize(CrosswordsSize::new_with_dimensions(
             usize::from(cols),
             usize::from(rows),
             u32::from(pw),
             u32::from(ph),
-            u32::from(pw / cols),
-            u32::from(ph / rows),
+            cell_width.round().max(1.0) as u32,
+            cell_height.round().max(1.0) as u32,
         ));
     }
 

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -242,6 +242,11 @@ impl TerminalRuntime {
         self.sink.take_replies()
     }
 
+    /// Drains the kitty graphics update queues rio-vt has emitted.
+    pub fn take_graphics_updates(&mut self) -> Vec<rio_vt::ansi::graphics::UpdateQueues> {
+        self.sink.take_graphics_updates()
+    }
+
     /// Receives pending PTY output without blocking.
     pub fn try_recv(&mut self) -> Result<Vec<u8>, TryRecvError> {
         self.rx.get().try_recv()
@@ -278,8 +283,17 @@ impl TerminalRuntime {
 
         // rio-vt reflows content and resets the scrolling region natively, so
         // the grid resize is the whole operation — no snapshot and replay.
-        self.term
-            .resize(CrosswordsSize::new(usize::from(cols), usize::from(rows)));
+        // The pixel dimensions matter too: the engine sizes kitty graphics
+        // placements against the cell pixel size, and refuses placements
+        // while it is zero.
+        self.term.resize(CrosswordsSize::new_with_dimensions(
+            usize::from(cols),
+            usize::from(rows),
+            u32::from(pw),
+            u32::from(ph),
+            u32::from(pw / cols),
+            u32::from(ph / rows),
+        ));
     }
 
     /// Returns the active kitty keyboard enhancement flags.

--- a/src/scene/mod.rs
+++ b/src/scene/mod.rs
@@ -234,11 +234,14 @@ pub(crate) fn setup_scene(mut params: SetupSceneParams) {
     let render_scale = render_scale_for_window(window);
     let layout = terminal.resize_to_fit(window_size, render_scale);
     let pty_pixels = layout.pty_pixels();
+    let cell_px = terminal.char_dimensions() * layout.render_scale;
     runtime.resize(
         layout.cols,
         layout.rows,
         pty_pixels.x as u16,
         pty_pixels.y as u16,
+        cell_px.x,
+        cell_px.y,
     );
 
     commands.spawn((

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -28,9 +28,10 @@ use crate::camera::{
 use crate::config::{AppConfig, CURSOR_DEPTH};
 use crate::direct_render::DirectTerminalSceneExchange;
 use crate::inline::{
-    InlineKittyPlaneLayout, InlineObject, TerminalInlineObjectPlane, TerminalInlineObjectSprite,
+    InlineKittyPlaneLayout, KittyPlaneCache, TerminalInlineObjectPlane, TerminalInlineObjectSprite,
     TerminalInlineObjects, TerminalRgpObject,
 };
+use crate::kitty::{KittyPlacementView, PlacementKey};
 use crate::model::CursorModel;
 use crate::model::spawn_cursor_model;
 use crate::mouse::TerminalSelection;
@@ -60,8 +61,8 @@ use bevy::render::render_resource::{Extent3d, TextureDimension, TextureFormat};
 use bevy::window::{PrimaryWindow, Window, WindowCloseRequested, WindowResized};
 
 struct InlineLayout {
-    columns: u32,
-    rows: u32,
+    columns: f32,
+    rows: f32,
     center_x: f32,
     center_y: f32,
     local_x: f32,
@@ -189,7 +190,6 @@ pub fn pump_pty_output(
                     let scrolled = infer_upward_scroll(&prev_rows, &next_rows);
                     inline_objects.apply_scroll(scrolled);
                 }
-                inline_objects.refresh_placeholder_anchors(&runtime.term);
             }
             Err(TryRecvError::Empty) => break,
             Err(TryRecvError::Disconnected) => {
@@ -205,6 +205,19 @@ pub fn pump_pty_output(
     if processed_output {
         redraw.request();
     }
+}
+
+/// Synchronizes kitty graphics state with the rio-vt engine.
+///
+/// Runs every frame between [`pump_pty_output`] and [`sync_inline_objects`]:
+/// placements depend on the scrollback display offset, which mouse input
+/// changes without any PTY traffic, so PTY-driven refreshes are not enough.
+/// The refresh is a no-op diff when nothing changed.
+pub(crate) fn refresh_kitty_graphics(
+    mut runtime: ResMut<TerminalRuntime>,
+    mut inline_objects: ResMut<TerminalInlineObjects>,
+) {
+    inline_objects.refresh_kitty(&mut runtime);
 }
 
 fn infer_upward_scroll(prev_rows: &[String], next_rows: &[String]) -> u16 {
@@ -547,11 +560,11 @@ pub(crate) struct SyncInlineParams<'w, 's> {
     meshes: ResMut<'w, Assets<Mesh>>,
 }
 
-/// Synchronizes Kitty inline object entities.
+/// Synchronizes inline object entities.
 ///
-/// This runs after [`render_terminal_widget`]. It rebuilds the scene entities for registered
-/// [`InlineObject::KittyImage`] values and clears stale inline entities first so the scene matches
-/// the latest terminal anchors exactly.
+/// This runs after [`render_terminal_widget`]. It rebuilds the scene entities for kitty graphics
+/// placements and registered RGP objects, clearing stale inline entities first so the scene
+/// matches the latest terminal state exactly.
 ///
 /// In 2D mode it spawns [`TerminalInlineObjectSprite`] entities. In 3D mode it also generates
 /// plane-attached meshes under [`TerminalPlane`] so images follow the warped terminal surface.
@@ -607,46 +620,79 @@ pub(crate) fn sync_inline_objects(mut params: SyncInlineParams) {
         })
         .collect::<Vec<_>>();
 
-    let mut plane_children = Vec::new();
     for object_id in renderable_ids {
         let Some(anchor) = inline_objects.anchors.get(&object_id) else {
             continue;
         };
-        let layout = inline_layout(anchor, terminal, viewport, cell_width, cell_height);
         let style = anchor.style;
         let Some(object) = inline_objects.objects.get_mut(&object_id) else {
             continue;
         };
-        match object {
-            InlineObject::KittyImage(object) => {
-                let mut ctx = KittyRenderContext {
-                    mode: camera_slots.active().mode,
-                    mobius_progress: active_mobius_progress(
-                        camera_slots.active().mode,
-                        mobius_transition,
-                    ),
-                    warp_amount: plane_warp.amount,
-                    elapsed_secs,
-                    materials,
-                    images,
-                    meshes,
-                    plane_children: &mut plane_children,
-                };
-                sync_kitty_inline_image(commands, object, &layout, &mut ctx);
-            }
-            InlineObject::RgpObject(object) => {
-                spawn_rgp_object(
-                    commands,
-                    object_id,
-                    object,
-                    style,
-                    materials,
-                    meshes,
-                    asset_server,
-                );
-            }
-        }
+        spawn_rgp_object(
+            commands,
+            object_id,
+            object,
+            style,
+            materials,
+            meshes,
+            asset_server,
+        );
     }
+
+    // Kitty placements come resolved from the engine; the views are cloned
+    // out so the image store can be borrowed mutably for texture uploads.
+    let mut plane_children = Vec::new();
+    let views = inline_objects.kitty.placements().to_vec();
+    let inline: &mut TerminalInlineObjects = inline_objects;
+    for (draw_order, view) in views.iter().enumerate() {
+        let Some(image) = inline.kitty.image_mut(view.image_id) else {
+            continue;
+        };
+        let layout = inline_layout(
+            view.row,
+            view.col,
+            view.columns,
+            view.rows,
+            terminal,
+            viewport,
+            cell_width,
+            cell_height,
+        );
+        let mut ctx = KittyRenderContext {
+            mode: camera_slots.active().mode,
+            mobius_progress: active_mobius_progress(camera_slots.active().mode, mobius_transition),
+            warp_amount: plane_warp.amount,
+            elapsed_secs,
+            materials,
+            images,
+            meshes,
+            plane_children: &mut plane_children,
+        };
+        sync_kitty_placement(
+            commands,
+            view,
+            &mut image.raster,
+            &mut inline.kitty_planes,
+            &layout,
+            draw_order,
+            &mut ctx,
+        );
+    }
+
+    // Placements that disappeared leave their cached plane assets behind;
+    // free them so `Assets` does not accumulate dead meshes and materials.
+    let live_keys = views
+        .iter()
+        .map(|view| (view.image_id, view.placement_id))
+        .collect::<std::collections::HashSet<PlacementKey>>();
+    inline.kitty_planes.retain(|key, cache| {
+        if live_keys.contains(key) {
+            return true;
+        }
+        meshes.remove(&cache.mesh);
+        materials.remove(&cache.material);
+        false
+    });
 
     if !plane_children.is_empty() {
         commands.entity(plane_entity).add_children(&plane_children);
@@ -655,47 +701,53 @@ pub(crate) fn sync_inline_objects(mut params: SyncInlineParams) {
     inline_objects.finish_sync(viewport.size, terminal.cols, terminal.rows);
 }
 
+#[allow(clippy::too_many_arguments)]
 fn inline_layout(
-    anchor: &crate::inline::InlineAnchor,
+    row: f32,
+    col: f32,
+    columns: f32,
+    rows: f32,
     terminal: &TerminalSurface,
     viewport: &TerminalViewport,
     cell_width: f32,
     cell_height: f32,
 ) -> InlineLayout {
-    let cols = terminal.cols.max(1) as f32;
-    let rows = terminal.rows.max(1) as f32;
-    let center_x = viewport.center.x - viewport.size.x * 0.5
-        + (anchor.col as f32 + anchor.columns as f32 * 0.5) * cell_width;
-    let center_y = viewport.center.y + viewport.size.y * 0.5
-        - (anchor.row as f32 + anchor.rows as f32 * 0.5) * cell_height;
+    let grid_cols = terminal.cols.max(1) as f32;
+    let grid_rows = terminal.rows.max(1) as f32;
+    let center_x = viewport.center.x - viewport.size.x * 0.5 + (col + columns * 0.5) * cell_width;
+    let center_y = viewport.center.y + viewport.size.y * 0.5 - (row + rows * 0.5) * cell_height;
 
     InlineLayout {
-        columns: anchor.columns,
-        rows: anchor.rows,
+        columns,
+        rows,
         center_x,
         center_y,
-        local_x: (anchor.col as f32 + anchor.columns as f32 * 0.5) / cols - 0.5,
-        local_y: 0.5 - (anchor.row as f32 + anchor.rows as f32 * 0.5) / rows,
-        local_width: anchor.columns as f32 / cols,
-        local_height: anchor.rows as f32 / rows,
-        pixel_width: anchor.columns as f32 * cell_width,
-        pixel_height: anchor.rows as f32 * cell_height,
+        local_x: (col + columns * 0.5) / grid_cols - 0.5,
+        local_y: 0.5 - (row + rows * 0.5) / grid_rows,
+        local_width: columns / grid_cols,
+        local_height: rows / grid_rows,
+        pixel_width: columns * cell_width,
+        pixel_height: rows * cell_height,
     }
 }
 
-fn sync_kitty_inline_image(
+#[allow(clippy::too_many_arguments)]
+fn sync_kitty_placement(
     commands: &mut Commands,
-    object: &mut crate::inline::KittyInlineObject,
+    view: &KittyPlacementView,
+    raster: &mut crate::inline::RasterObject,
+    plane_caches: &mut HashMap<PlacementKey, KittyPlaneCache>,
     layout: &InlineLayout,
+    draw_order: usize,
     ctx: &mut KittyRenderContext<'_>,
 ) {
-    let image_handle = if let Some(handle) = object.raster.handle.as_ref() {
+    let image_handle = if let Some(handle) = raster.handle.as_ref() {
         handle.clone()
     } else {
         let mut image = Image::new_fill(
             Extent3d {
-                width: object.raster.width,
-                height: object.raster.height,
+                width: raster.width,
+                height: raster.height,
                 depth_or_array_layers: 1,
             },
             TextureDimension::D2,
@@ -704,18 +756,33 @@ fn sync_kitty_inline_image(
             bevy::asset::RenderAssetUsages::default(),
         );
         image.sampler = ImageSampler::nearest();
-        image.data = Some(std::mem::take(&mut object.raster.rgba));
+        image.data = Some(std::mem::take(&mut raster.rgba));
         let handle = ctx.images.add(image);
-        object.raster.handle = Some(handle.clone());
+        raster.handle = Some(handle.clone());
         handle
     };
 
     let mut sprite = Sprite::from_image(image_handle.clone());
     sprite.custom_size = Some(Vec2::new(layout.pixel_width, layout.pixel_height));
+    if view.source_rect != [0.0, 0.0, 1.0, 1.0] {
+        let [u0, v0, u1, v1] = view.source_rect;
+        sprite.rect = Some(Rect::new(
+            u0 * raster.width as f32,
+            v0 * raster.height as f32,
+            u1 * raster.width as f32,
+            v1 * raster.height as f32,
+        ));
+    }
     commands.spawn((
         TerminalInlineObjectSprite,
         sprite,
-        Transform::from_translation(Vec3::new(layout.center_x, layout.center_y, 5.0)),
+        // The kitty z-index ordering is baked into the placement order, so
+        // an epsilon per placement keeps sprites stacked back-to-front.
+        Transform::from_translation(Vec3::new(
+            layout.center_x,
+            layout.center_y,
+            5.0 + draw_order as f32 * 0.001,
+        )),
         if ctx.mode.is_3d() {
             Visibility::Hidden
         } else {
@@ -723,9 +790,10 @@ fn sync_kitty_inline_image(
         },
     ));
 
-    let plane_layout = inline_kitty_plane_layout(layout);
+    let plane_layout = inline_kitty_plane_layout(layout, view.source_rect);
+    let key = (view.image_id, view.placement_id);
     let (mesh_handle, material_handle) =
-        ensure_kitty_plane_assets(object, &plane_layout, &image_handle, ctx);
+        ensure_kitty_plane_assets(plane_caches, key, &plane_layout, &image_handle, ctx);
     ctx.plane_children.push(
         commands
             .spawn((
@@ -742,28 +810,35 @@ fn sync_kitty_inline_image(
     );
 }
 
-fn inline_kitty_plane_layout(layout: &InlineLayout) -> InlineKittyPlaneLayout {
+fn inline_kitty_plane_layout(
+    layout: &InlineLayout,
+    source_rect: [f32; 4],
+) -> InlineKittyPlaneLayout {
     InlineKittyPlaneLayout {
         local_x: layout.local_x,
         local_y: layout.local_y,
         local_width: layout.local_width,
         local_height: layout.local_height,
-        x_segments: layout.columns.clamp(2, 24),
-        y_segments: layout.rows.clamp(2, 24),
+        x_segments: (layout.columns.ceil() as u32).clamp(2, 24),
+        y_segments: (layout.rows.ceil() as u32).clamp(2, 24),
+        source_rect,
     }
 }
 
 fn ensure_kitty_plane_assets(
-    object: &mut crate::inline::KittyInlineObject,
+    plane_caches: &mut HashMap<PlacementKey, KittyPlaneCache>,
+    key: PlacementKey,
     layout: &InlineKittyPlaneLayout,
     image_handle: &Handle<Image>,
     ctx: &mut KittyRenderContext<'_>,
 ) -> (Handle<Mesh>, Handle<StandardMaterial>) {
-    let needs_rebuild = object.plane.as_ref().is_none_or(|cache| {
-        cache.x_segments != layout.x_segments || cache.y_segments != layout.y_segments
+    let needs_rebuild = plane_caches.get(&key).is_none_or(|cache| {
+        cache.x_segments != layout.x_segments
+            || cache.y_segments != layout.y_segments
+            || cache.source_rect != layout.source_rect
     });
     if needs_rebuild {
-        if let Some(cache) = object.plane.take() {
+        if let Some(cache) = plane_caches.remove(&key) {
             ctx.meshes.remove(&cache.mesh);
             ctx.materials.remove(&cache.material);
         }
@@ -776,16 +851,22 @@ fn ensure_kitty_plane_assets(
         );
         let mesh_handle = ctx.meshes.add(mesh);
         let material_handle = ctx.materials.add(kitty_plane_material(image_handle));
-        object.plane = Some(crate::inline::KittyPlaneCache {
-            x_segments: layout.x_segments,
-            y_segments: layout.y_segments,
-            mesh: mesh_handle.clone(),
-            material: material_handle.clone(),
-        });
+        plane_caches.insert(
+            key,
+            KittyPlaneCache {
+                x_segments: layout.x_segments,
+                y_segments: layout.y_segments,
+                source_rect: layout.source_rect,
+                mesh: mesh_handle.clone(),
+                material: material_handle.clone(),
+            },
+        );
         return (mesh_handle, material_handle);
     }
 
-    let cache = object.plane.as_mut().expect("plane cache should exist");
+    let cache = plane_caches
+        .get_mut(&key)
+        .expect("plane cache should exist");
     if let Some(mut mesh) = ctx.meshes.get_mut(&cache.mesh) {
         write_kitty_plane_positions(
             &mut mesh,
@@ -826,6 +907,7 @@ fn build_kitty_plane_mesh(
     let mut uvs = Vec::with_capacity(vertex_count);
     let mut indices = Vec::with_capacity((layout.x_segments * layout.y_segments * 6) as usize);
 
+    let [u0, v0, u1, v1] = layout.source_rect;
     for y in 0..=layout.y_segments {
         let v = y as f32 / layout.y_segments as f32;
         let py = layout.local_y + (0.5 - v) * layout.local_height;
@@ -833,7 +915,7 @@ fn build_kitty_plane_mesh(
             let u = x as f32 / layout.x_segments as f32;
             let px = layout.local_x + (u - 0.5) * layout.local_width;
             positions.push([px, py, 0.0]);
-            uvs.push([u, v]);
+            uvs.push([u0 + u * (u1 - u0), v0 + v * (v1 - v0)]);
         }
     }
 
@@ -1180,7 +1262,16 @@ pub(crate) fn sync_rgp_objects(mut params: RgpSyncParams) {
             *visibility = Visibility::Hidden;
             continue;
         };
-        let layout = inline_layout(anchor, terminal, viewport, cell_width, cell_height);
+        let layout = inline_layout(
+            f32::from(anchor.row),
+            f32::from(anchor.col),
+            anchor.columns as f32,
+            anchor.rows as f32,
+            terminal,
+            viewport,
+            cell_width,
+            cell_height,
+        );
         let base_scale = layout.pixel_width.max(layout.pixel_height).max(1.0) * 0.9;
         let scale = base_scale * anchor.style.scale.max(0.001);
         let scale3 = Vec3::new(
@@ -2048,6 +2139,7 @@ mod tests {
             local_height: 0.2,
             x_segments: 2,
             y_segments: 2,
+            source_rect: [0.0, 0.0, 1.0, 1.0],
         };
         let mesh =
             build_kitty_plane_mesh(&layout, TerminalPresentationMode::Mobius3d, 0.0, 0.0, 0.0);
@@ -2120,6 +2212,7 @@ mod tests {
             local_height: 0.2,
             x_segments: 2,
             y_segments: 2,
+            source_rect: [0.0, 0.0, 1.0, 1.0],
         };
         let mesh =
             build_kitty_plane_mesh(&layout, TerminalPresentationMode::Mobius3d, 0.0, 0.0, 1.0);

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -209,15 +209,19 @@ pub fn pump_pty_output(
 
 /// Synchronizes kitty graphics state with the rio-vt engine.
 ///
-/// Runs every frame between [`pump_pty_output`] and [`sync_inline_objects`]:
-/// placements depend on the scrollback display offset, which mouse input
-/// changes without any PTY traffic, so PTY-driven refreshes are not enough.
-/// The refresh is a no-op diff when nothing changed.
+/// Runs every frame after [`pump_pty_output`], [`handle_window_resize`],
+/// and the mouse input set, and before the redraw set: placements depend on
+/// the scrollback display offset, which mouse input changes without any PTY
+/// traffic, and on the post-resize grid. The pending-redraw flag is peeked
+/// (the redraw set consumes it later in the frame) as the grid-changed
+/// signal that gates the placeholder rescan.
 pub(crate) fn refresh_kitty_graphics(
     mut runtime: ResMut<TerminalRuntime>,
     mut inline_objects: ResMut<TerminalInlineObjects>,
+    redraw: Res<TerminalRedrawState>,
 ) {
-    inline_objects.refresh_kitty(&mut runtime);
+    let terminal_changed = redraw.pending();
+    inline_objects.refresh_kitty(&mut runtime, terminal_changed);
 }
 
 fn infer_upward_scroll(prev_rows: &[String], next_rows: &[String]) -> u16 {
@@ -292,11 +296,14 @@ pub(crate) fn handle_window_resize(
     let window_size = window_size.max(Vec2::ONE);
     let layout = terminal.resize_to_fit(window_size, render_scale_for_window(window));
     let pty_pixels = layout.pty_pixels();
+    let cell_px = terminal.char_dimensions() * layout.render_scale;
     runtime.resize(
         layout.cols,
         layout.rows,
         pty_pixels.x as u16,
         pty_pixels.y as u16,
+        cell_px.x,
+        cell_px.y,
     );
     sync_terminal_layout(layout, viewport, plane_query, plane_back_query);
     redraw.request();
@@ -683,7 +690,7 @@ pub(crate) fn sync_inline_objects(mut params: SyncInlineParams) {
     // free them so `Assets` does not accumulate dead meshes and materials.
     let live_keys = views
         .iter()
-        .map(|view| (view.image_id, view.placement_id))
+        .map(KittyPlacementView::key)
         .collect::<std::collections::HashSet<PlacementKey>>();
     inline.kitty_planes.retain(|key, cache| {
         if live_keys.contains(key) {
@@ -773,16 +780,21 @@ fn sync_kitty_placement(
             v1 * raster.height as f32,
         ));
     }
+    // Negative kitty z-indices render behind the terminal per the spec: the
+    // sprite goes under the text quad (z = 0), and the plane sinks behind
+    // the terminal surface. The epsilon per placement keeps overlapping
+    // images stacked back-to-front on both paths — the views arrive sorted
+    // by kitty z-index.
+    let layer = draw_order as f32 * 0.001;
+    let sprite_z = if view.z < 0 {
+        -5.0 + layer
+    } else {
+        5.0 + layer
+    };
     commands.spawn((
         TerminalInlineObjectSprite,
         sprite,
-        // The kitty z-index ordering is baked into the placement order, so
-        // an epsilon per placement keeps sprites stacked back-to-front.
-        Transform::from_translation(Vec3::new(
-            layout.center_x,
-            layout.center_y,
-            5.0 + draw_order as f32 * 0.001,
-        )),
+        Transform::from_translation(Vec3::new(layout.center_x, layout.center_y, sprite_z)),
         if ctx.mode.is_3d() {
             Visibility::Hidden
         } else {
@@ -791,9 +803,13 @@ fn sync_kitty_placement(
     ));
 
     let plane_layout = inline_kitty_plane_layout(layout, view.source_rect);
-    let key = (view.image_id, view.placement_id);
     let (mesh_handle, material_handle) =
-        ensure_kitty_plane_assets(plane_caches, key, &plane_layout, &image_handle, ctx);
+        ensure_kitty_plane_assets(plane_caches, view.key(), &plane_layout, &image_handle, ctx);
+    let plane_bias = if view.z < 0 {
+        -0.002 - draw_order as f32 * 0.0005
+    } else {
+        0.002 + draw_order as f32 * 0.0005
+    };
     ctx.plane_children.push(
         commands
             .spawn((
@@ -801,7 +817,7 @@ fn sync_kitty_placement(
                 plane_layout,
                 Mesh3d(mesh_handle),
                 MeshMaterial3d(material_handle),
-                Transform::default(),
+                Transform::from_xyz(0.0, 0.0, plane_bias),
                 // Warp and Mobius morphing move the vertices far outside the
                 // AABB cached at spawn, like the terminal planes.
                 NoFrustumCulling,

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -77,6 +77,11 @@ impl TerminalRedrawState {
     pub fn take(&mut self) -> bool {
         std::mem::take(&mut self.needs_redraw)
     }
+
+    /// Returns whether a redraw is pending, without consuming it.
+    pub fn pending(&self) -> bool {
+        self.needs_redraw
+    }
 }
 
 /// Terminal surface and render state.

--- a/src/vt.rs
+++ b/src/vt.rs
@@ -12,7 +12,6 @@
 use std::sync::{Arc, Mutex, PoisonError};
 
 use rio_vt::ansi::CursorShape;
-use rio_vt::ansi::graphics::UpdateQueues;
 use rio_vt::config::colors::{AnsiColor, NamedColor};
 use rio_vt::crosswords::grid::row::Row;
 use rio_vt::crosswords::grid::{Grid, Scroll};
@@ -27,18 +26,16 @@ pub type VtTerminal = Crosswords<TerminalEventSink>;
 
 /// Sink for the events rio-vt raises while parsing.
 ///
-/// Ratty acts on two variants: [`RioEvent::PtyWrite`] — the engine's DA, DSR,
-/// CPR, XTVERSION, kitty-keyboard, and kitty-graphics replies, which have to
-/// be written back to the PTY — and [`RioEvent::UpdateGraphics`], which
-/// carries decoded kitty image pixels for upload to the GPU.
+/// The only variant ratty acts on today is [`RioEvent::PtyWrite`] — the
+/// engine's DA, DSR, CPR, XTVERSION, kitty-keyboard, and kitty-graphics
+/// replies, which have to be written back to the PTY.
 ///
-/// `send_event` takes `&self`, so the queues need interior mutability, and
+/// `send_event` takes `&self`, so the queue needs interior mutability, and
 /// `TerminalRuntime` is a Bevy resource that has to stay `Send + Sync`, which
 /// rules out `RefCell`.
 #[derive(Clone, Default)]
 pub struct TerminalEventSink {
     replies: Arc<Mutex<Vec<Vec<u8>>>>,
-    graphics: Arc<Mutex<Vec<UpdateQueues>>>,
 }
 
 impl TerminalEventSink {
@@ -46,12 +43,6 @@ impl TerminalEventSink {
     pub fn take_replies(&self) -> Vec<Vec<u8>> {
         let mut replies = self.replies.lock().unwrap_or_else(PoisonError::into_inner);
         std::mem::take(&mut *replies)
-    }
-
-    /// Drains the graphics update queues rio-vt has emitted.
-    pub fn take_graphics_updates(&self) -> Vec<UpdateQueues> {
-        let mut updates = self.graphics.lock().unwrap_or_else(PoisonError::into_inner);
-        std::mem::take(&mut *updates)
     }
 }
 
@@ -68,13 +59,11 @@ impl EventListener for TerminalEventSink {
                 replies.push(reply.into_bytes());
             }
 
-            // Decoded image pixels the engine wants uploaded to the GPU, plus
-            // texture keys whose images were deleted or evicted. Ratty's
-            // kitty-graphics sync drains these each frame.
-            RioEvent::UpdateGraphics { queues, .. } => {
-                let mut updates = self.graphics.lock().unwrap_or_else(PoisonError::into_inner);
-                updates.push(queues);
-            }
+            // Decoded image pixels the engine queues for GPU upload. Ratty's
+            // kitty-graphics sync reads pixels from the engine's image store
+            // directly (the store, unlike this event, is per-screen and
+            // survives alternate-screen swaps), so the queue is dropped here.
+            RioEvent::UpdateGraphics { .. } => {}
 
             // Requests carrying a reply callback rio-vt expects the embedder to
             // invoke and write back. Ratty answers none of them yet, so an

--- a/src/vt.rs
+++ b/src/vt.rs
@@ -12,6 +12,7 @@
 use std::sync::{Arc, Mutex, PoisonError};
 
 use rio_vt::ansi::CursorShape;
+use rio_vt::ansi::graphics::UpdateQueues;
 use rio_vt::config::colors::{AnsiColor, NamedColor};
 use rio_vt::crosswords::grid::row::Row;
 use rio_vt::crosswords::grid::{Grid, Scroll};
@@ -26,16 +27,18 @@ pub type VtTerminal = Crosswords<TerminalEventSink>;
 
 /// Sink for the events rio-vt raises while parsing.
 ///
-/// The only variant ratty acts on today is [`RioEvent::PtyWrite`] — the
-/// engine's DA, DSR, CPR, XTVERSION, and kitty-keyboard replies, which have to
-/// be written back to the PTY.
+/// Ratty acts on two variants: [`RioEvent::PtyWrite`] — the engine's DA, DSR,
+/// CPR, XTVERSION, kitty-keyboard, and kitty-graphics replies, which have to
+/// be written back to the PTY — and [`RioEvent::UpdateGraphics`], which
+/// carries decoded kitty image pixels for upload to the GPU.
 ///
-/// `send_event` takes `&self`, so the queue needs interior mutability, and
+/// `send_event` takes `&self`, so the queues need interior mutability, and
 /// `TerminalRuntime` is a Bevy resource that has to stay `Send + Sync`, which
 /// rules out `RefCell`.
 #[derive(Clone, Default)]
 pub struct TerminalEventSink {
     replies: Arc<Mutex<Vec<Vec<u8>>>>,
+    graphics: Arc<Mutex<Vec<UpdateQueues>>>,
 }
 
 impl TerminalEventSink {
@@ -43,6 +46,12 @@ impl TerminalEventSink {
     pub fn take_replies(&self) -> Vec<Vec<u8>> {
         let mut replies = self.replies.lock().unwrap_or_else(PoisonError::into_inner);
         std::mem::take(&mut *replies)
+    }
+
+    /// Drains the graphics update queues rio-vt has emitted.
+    pub fn take_graphics_updates(&self) -> Vec<UpdateQueues> {
+        let mut updates = self.graphics.lock().unwrap_or_else(PoisonError::into_inner);
+        std::mem::take(&mut *updates)
     }
 }
 
@@ -57,6 +66,14 @@ impl EventListener for TerminalEventSink {
                 let reply = rewrite_reply(&text).unwrap_or(text);
                 let mut replies = self.replies.lock().unwrap_or_else(PoisonError::into_inner);
                 replies.push(reply.into_bytes());
+            }
+
+            // Decoded image pixels the engine wants uploaded to the GPU, plus
+            // texture keys whose images were deleted or evicted. Ratty's
+            // kitty-graphics sync drains these each frame.
+            RioEvent::UpdateGraphics { queues, .. } => {
+                let mut updates = self.graphics.lock().unwrap_or_else(PoisonError::into_inner);
+                updates.push(queues);
             }
 
             // Requests carrying a reply callback rio-vt expects the embedder to
@@ -96,10 +113,11 @@ impl EventListener for TerminalEventSink {
 ///
 /// rio-vt answers primary device attributes with a fixed list describing what
 /// the *engine* can parse, not what the embedder renders. `4` is sixel
-/// graphics — rio-vt's `graphics` feature is off here, so nothing decodes it —
-/// and `52` is OSC 52 clipboard access, whose events [`TerminalEventSink`]
-/// drops. Leaving either in makes applications feature-detect support that does
-/// not exist and emit payloads ratty silently swallows.
+/// graphics — the engine decodes it, but ratty only renders kitty-protocol
+/// placements — and `52` is OSC 52 clipboard access, whose events
+/// [`TerminalEventSink`] drops. Leaving either in makes applications
+/// feature-detect support that does not exist and emit payloads ratty
+/// silently swallows.
 const UNSUPPORTED_DA1_CAPABILITIES: &[&str] = &["4", "52"];
 
 /// Rewrites an engine reply that would misreport ratty's capabilities or


### PR DESCRIPTION
Now that the vt100 engine is gone (#140), we can lean on rio-vt for the kitty graphics protocol too. This deletes ratty's hand-rolled APC parser and enables rio-vt's `graphics` feature instead, so the whole protocol — chunked transmissions, PNG/RGB/RGBA payloads, placement ids, deletes, queries, quiet modes, the 320MB eviction budget, and per-screen state on alt-screen swaps — is handled by the engine, which already answers acks and queries through the same reply path we use for DA/DSR.

On ratty's side, kitty state is now derived from the engine each frame: decoded pixels arrive through `RioEvent::UpdateGraphics` and become Bevy textures, and placements are resolved from the engine's absolute, scrollback-aware positions. That fixes a few things the old parser couldn't do:

- images scroll with the content they were placed next to, including into and out of history (the old row-text diffing heuristic is gone)
- multiple placements of the same image share one texture instead of re-decoding
- source crops (`x=`/`y=`/`w=`/`h=`) and sub-cell offsets (`X=`/`Y=`) are honored, both for sprites and for the warped 3D planes
- kitty z-index ordering is respected between images
- `kitten icat --unicode-placeholder` style virtual placements are matched against the engine's placement registry rather than guessed from cell colors alone

The PTY grid resize now passes pixel dimensions through to the engine, since placements are sized against the cell pixel metrics. Sixel stays unadvertised in DA1: the engine can decode it now, but ratty only renders kitty placements.

Tests cover direct and chunked transfers, RGB expansion, crops, scrollback tracking, deletes dropping their textures, placeholder-driven placements, and queries being acked without placing anything.

<img width="2026" height="1420" alt="kitty-ratty" src="https://github.com/user-attachments/assets/1ee04b14-3e5c-4b4a-b970-24ce8150b0f2" />
