### PR TITLE
Fix crash caused by #135

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -2,8 +2,6 @@
 use anyhow::anyhow;
 use bevy::asset::AssetPlugin;
 use bevy::prelude::*;
-use bevy::render::RenderPlugin;
-use bevy::render::settings::{WgpuSettings, WgpuSettingsPriority};
 use bevy::window::{PrimaryWindow, WindowCreated, WindowResizeConstraints, WindowResolution};
 use bevy::winit::{UpdateMode, WINIT_WINDOWS, WinitSettings};
 use clap::Parser;
@@ -100,15 +98,6 @@ fn main() -> anyhow::Result<()> {
                 })
                 .set(AssetPlugin {
                     file_path: asset_root.to_string_lossy().into_owned(),
-                    ..default()
-                })
-                .set(RenderPlugin {
-                    render_creation: bevy::render::settings::RenderCreation::Automatic(Box::new(
-                        WgpuSettings {
-                            priority: WgpuSettingsPriority::WebGPU,
-                            ..default()
-                        },
-                    )),
                     ..default()
                 }),
         )


### PR DESCRIPTION
This is only a temporary fix, as discussed in the comments of #135

This code was causing the render plugin to crash if it would not find a WebGPU driver, or something to that effect (further investigation required):

```rs
...
.set(RenderPlugin {
    render_creation: bevy::render::settings::RenderCreation::Automatic(Box::new(
        WgpuSettings {
            priority: WgpuSettingsPriority::WebGPU,
            ..default()
        },
    )),
    ..default()
})
...
```

The error itself:
```
2026-08-29T19:00:04.762939Z ERROR bevy_render::error_handler: Caught rendering error: Validation Error

Caused by:
  In Device::create_texture
    Texture format Rgba16Unorm can't be used due to missing features
      Features Features { features_wgpu: FeaturesWGPU(TEXTURE_FORMAT_16BIT_NORM), features_webgpu: FeaturesWebGPU(0x0) } are required but not enabled on the device
```